### PR TITLE
Security: fix path traversal in export and temp-file race in render_view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies for headless rendering
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y libgl1-mesa-glx libglu1-mesa xvfb libxrender1 libxi6
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install system dependencies for headless rendering
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y libgl1-mesa-glx libglu1-mesa xvfb libxrender1 libxi6
+          sudo apt-get install -y libgl1 libglu1-mesa xvfb libxrender1 libxi6
 
       - uses: astral-sh/setup-uv@v5
         with:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -128,6 +128,12 @@ def test_export_invalid_format(session):
         export_file(session, "out", "obj")
 
 
+def test_export_path_traversal_rejected(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="Path traversal"):
+        export_file(session, "../../etc/passwd", "step")
+
+
 # --- reset ---
 
 def test_reset_clears_shape(session):

--- a/tools/export.py
+++ b/tools/export.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import PurePosixPath, PureWindowsPath
 
 
 def export_file(session, filename: str, format: str = "step") -> str:
@@ -10,18 +11,24 @@ def export_file(session, filename: str, format: str = "step") -> str:
     if fmt not in ("step", "stl"):
         raise ValueError(f"Unknown format '{fmt}'. Use: step, stl")
 
+    # Reject path traversal attempts
+    if ".." in PurePosixPath(filename).parts or ".." in PureWindowsPath(filename).parts:
+        raise ValueError("Path traversal not allowed.")
+
     if fmt == "step" and not filename.lower().endswith((".step", ".stp")):
         filename += ".step"
     elif fmt == "stl" and not filename.lower().endswith(".stl"):
         filename += ".stl"
 
+    abs_path = os.path.realpath(filename)
+
     if fmt == "step":
         from build123d import export_step
-        export_step(shape, filename)
+        export_step(shape, abs_path)
     else:
         from build123d import Mesher
         mesher = Mesher()
         mesher.add_shape(shape)
-        mesher.write(filename)
+        mesher.write(abs_path)
 
-    return f"Exported to {os.path.abspath(filename)}"
+    return f"Exported to {abs_path}"

--- a/tools/render.py
+++ b/tools/render.py
@@ -29,12 +29,10 @@ def render_view(session, direction: str = "iso") -> bytes:
     import pyvista as pv
     from build123d import Mesher
 
-    stl_fd, stl_path = tempfile.mkstemp(suffix=".stl")
-    png_fd, png_path = tempfile.mkstemp(suffix=".png")
-    os.close(stl_fd)
-    os.close(png_fd)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stl_path = os.path.join(tmpdir, "shape.stl")
+        png_path = os.path.join(tmpdir, "render.png")
 
-    try:
         mesher = Mesher()
         mesher.add_shape(shape)
         mesher.write(stl_path)
@@ -65,9 +63,3 @@ def render_view(session, direction: str = "iso") -> bytes:
 
         with open(png_path, "rb") as f:
             return f.read()
-    finally:
-        for path in (stl_path, png_path):
-            try:
-                os.unlink(path)
-            except OSError:
-                pass


### PR DESCRIPTION
## Summary

- **`tools/export.py`**: Reject filenames containing `..` path components, blocking `../../etc/passwd`-style traversal. Absolute paths still work for legitimate use.
- **`tools/render.py`**: Replace `mkstemp` + immediate `os.close()` (TOCTOU race) with `tempfile.TemporaryDirectory()`, which keeps the temp dir alive for the render duration and cleans up atomically.
- **`tests/test_tools.py`**: Add `test_export_path_traversal_rejected` regression test.

Remaining security items (resource limits, namespace leakage, audit logging, error sanitisation) are tracked in #1.

## Test plan

- [x] All 18 existing tests pass
- [x] New `test_export_path_traversal_rejected` test passes
- [ ] Reviewer confirms path traversal fix covers the intended threat

🤖 Generated with [Claude Code](https://claude.com/claude-code)