### PR TITLE
render_view: quality and clip_plane params

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,9 +17,9 @@ def execute(code: str) -> str:
 
 
 @mcp.tool()
-def render_view(direction: str = "iso", objects: str = "") -> Image:
-    """Render model as PNG. direction: top, front, side, iso. objects: comma-separated names to show (default: all registered, or current shape)."""
-    png_bytes = render_view_fn(_session, direction, objects)
+def render_view(direction: str = "iso", objects: str = "", quality: str = "standard", clip_plane: str = "") -> Image:
+    """Render model as PNG. direction: top, front, side, iso. objects: comma-separated names (default: all). quality: standard, high. clip_plane: x, y, or z to slice at midpoint."""
+    png_bytes = render_view_fn(_session, direction, objects, quality, clip_plane)
     return Image(data=png_bytes, format="png")
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -78,6 +78,31 @@ def test_render_view_no_shape_raises(session):
         render_view(session, "iso")
 
 
+def test_render_view_high_quality_returns_png(session):
+    execute_code(session, "result = Cylinder(5, 20)")
+    png = render_view(session, "iso", quality="high")
+    assert png[:8] == PNG_MAGIC
+
+
+def test_render_view_invalid_quality_raises(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="Unknown quality"):
+        render_view(session, "iso", quality="ultra")
+
+
+def test_render_view_clip_plane_returns_png(session):
+    execute_code(session, "result = Cylinder(5, 20)")
+    for plane in ("x", "y", "z"):
+        png = render_view(session, "iso", clip_plane=plane)
+        assert png[:8] == PNG_MAGIC, f"clip_plane '{plane}' did not return valid PNG"
+
+
+def test_render_view_invalid_clip_plane_raises(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="Unknown clip_plane"):
+        render_view(session, "iso", clip_plane="w")
+
+
 # --- measure ---
 
 def test_measure_bounding_box(session):

--- a/tools/render.py
+++ b/tools/render.py
@@ -8,6 +8,11 @@ _PALETTE = [
     "lightyellow", "plum", "peachpuff", "lightcyan",
 ]
 
+_QUALITY = {
+    "standard": {"linear_deflection": 0.001, "angular_deflection": 0.1},
+    "high":     {"linear_deflection": 0.0005, "angular_deflection": 0.02},
+}
+
 
 def _init_display():
     global _display_initialized
@@ -36,12 +41,27 @@ def _resolve_shapes(session, objects: str):
     raise ValueError("No shape in session. Execute code to create geometry first.")
 
 
-def render_view(session, direction: str = "iso", objects: str = "") -> bytes:
+def render_view(
+    session,
+    direction: str = "iso",
+    objects: str = "",
+    quality: str = "standard",
+    clip_plane: str = "",
+) -> bytes:
     direction = direction.lower()
     if direction not in ("top", "front", "side", "iso"):
         raise ValueError(f"Unknown direction '{direction}'. Use: top, front, side, iso")
 
+    quality = quality.lower()
+    if quality not in _QUALITY:
+        raise ValueError(f"Unknown quality '{quality}'. Use: standard, high")
+
+    clip_plane = clip_plane.lower()
+    if clip_plane and clip_plane not in ("x", "y", "z"):
+        raise ValueError(f"Unknown clip_plane '{clip_plane}'. Use: x, y, z")
+
     shapes = _resolve_shapes(session, objects)
+    tess = _QUALITY[quality]
 
     _init_display()
     import pyvista as pv
@@ -54,9 +74,15 @@ def render_view(session, direction: str = "iso", objects: str = "") -> bytes:
         for i, (name, shape) in enumerate(shapes):
             stl_path = os.path.join(tmpdir, f"shape_{i}.stl")
             mesher = Mesher()
-            mesher.add_shape(shape)
+            mesher.add_shape(shape, **tess)
             mesher.write(stl_path)
             mesh = pv.read(stl_path)
+
+            if clip_plane:
+                center = mesh.center
+                origin = list(center)
+                mesh = mesh.clip(normal=clip_plane, origin=origin, invert=False)
+
             plotter.add_mesh(
                 mesh,
                 color=_PALETTE[i % len(_PALETTE)],


### PR DESCRIPTION
## Summary

- `quality="high"` tightens `angular_deflection` from 0.1 → 0.02 rad (~5× more facets on curved surfaces), eliminating the sunray/streaking artefacts on cylinders and circular faces
- `clip_plane="x"|"y"|"z"` clips each mesh at its bounding-box midpoint before rendering, exposing internal geometry (bores, wall thickness) without needing to export
- Both params are orthogonal to existing `direction` and `objects` params
- 4 new tests; all 43 tests pass

Closes #3 item 2 (rendering quality).

## Usage examples

```
render_view(direction="iso", quality="high")
render_view(direction="front", clip_plane="y")
render_view(direction="top", quality="high", clip_plane="z")
```

## Test plan
- [x] `test_render_view_high_quality_returns_png` — high quality renders valid PNG
- [x] `test_render_view_invalid_quality_raises` — clear error on bad value
- [x] `test_render_view_clip_plane_returns_png` — all three planes render valid PNG
- [x] `test_render_view_invalid_clip_plane_raises` — clear error on bad value
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)