### PR TITLE
Session snapshots + full docs refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 
 ## Tools
 
-- `execute` — run build123d Python code in a persistent session
-- `render_view` — render the current model from a given direction, returns a PNG image
-- `measure` — query bounding box dimensions on the current model
-- `export` — export the current model as STEP or STL
+- `execute` — run build123d Python code in a persistent session; use `show(name, shape)` to register named parts
+- `render_view` — render one or more shapes as PNG; supports assembly compositing, high-quality tessellation, and cross-section clip planes
+- `measure` — query bounding box, volume, surface area, minimum wall thickness, or clearance between two named bodies
+- `export` — export as STEP, STL, or both in one call; targets a named object or the current shape
+- `save_snapshot` / `restore_snapshot` — checkpoint and recover geometric state without re-running prior code
 - `reset` — clear the session back to empty state
 
 See [llms.md](llms.md) for full tool reference and usage patterns.
@@ -150,4 +151,4 @@ For best results, paste the contents of [default_prompt.md](default_prompt.md) a
 
 ## Status
 
-Early development (v0.1.0).
+Active development (v0.2.0).

--- a/default_prompt.md
+++ b/default_prompt.md
@@ -4,7 +4,7 @@ Use this as a system prompt when configuring an AI assistant to work with the bu
 
 ---
 
-You have access to a build123d CAD MCP server with five tools: `execute`, `render_view`, `measure`, `export`, and `reset`. Use them to build 3D geometry interactively rather than writing a complete script and hoping it is correct.
+You have access to a build123d CAD MCP server with seven tools: `execute`, `render_view`, `measure`, `export`, `save_snapshot`, `restore_snapshot`, and `reset`. Use them to build 3D geometry interactively rather than writing a complete script and hoping it is correct.
 
 ## How to work
 
@@ -14,12 +14,13 @@ You have access to a build123d CAD MCP server with five tools: `execute`, `rende
 1. Call `reset` before starting a new model.
 2. Call `execute` with `from build123d import *` and your first geometry.
 3. Call `render_view` (try `iso` first) to visually confirm the shape looks right.
-4. Call `measure` with `bounding_box` to verify dimensions are correct.
-5. Continue with further `execute` calls for additional features.
-6. Repeat render + measure after each significant step.
-7. Call `export` when the model is complete.
+4. Call `measure` to verify dimensions — use `bounding_box` for extents, `volume` to catch missing booleans, `clearance` to check fit between parts.
+5. Call `save_snapshot` before any complex or risky operation.
+6. Continue with further `execute` calls. If something breaks, call `restore_snapshot` to recover.
+7. Repeat render + measure after each significant step.
+8. Call `export` with `format="step,stl"` to write both formats in one call.
 
-**When something looks wrong:** call `reset`, diagnose the issue, and start the geometry fresh. Don't layer fixes on a broken state.
+**When something looks wrong:** restore the last good snapshot, or call `reset` to start fresh. Don't layer fixes on a broken state.
 
 ## Session model
 
@@ -40,12 +41,41 @@ with BuildPart() as bp:
 result = bp.part
 ```
 
+## Multi-object assemblies
+
+Use `show(name, shape)` inside `execute` to register named parts. This lets you render, measure, and export individual parts independently:
+
+```python
+frame = Box(60, 40, 8)
+show("frame", frame)
+
+axle = Cylinder(5, 50)
+show("axle", axle)
+```
+
+- `render_view()` — shows all registered objects together, each in a distinct colour
+- `render_view(objects="frame")` — shows only the named part
+- `measure(query="bounding_box", object_name="frame")` — measures a specific part
+- `measure(query="clearance", object_name="axle", object_name2="frame")` — checks fit
+- `export(filename="frame", format="step", object_name="frame")` — exports a specific part
+
+## Rendering tips
+
+- Use `quality="high"` when inspecting cylindrical surfaces or small features — it reduces tessellation artefacts.
+- Use `clip_plane="y"` (or `"x"` / `"z"`) to slice through the model and inspect internal geometry such as bores and wall thicknesses without exporting.
+
+## Snapshots
+
+- `save_snapshot("name")` saves the current geometric state (current shape + all `show()` objects). The Python namespace is NOT saved.
+- `restore_snapshot("name")` restores geometry to the checkpoint. Python variables created after the snapshot remain in scope — re-run relevant `execute()` calls if those variables need to match.
+- `reset` clears everything including snapshots.
+
 ## What to tell the user
 
 - Report dimensions from `measure` explicitly — don't guess.
 - When showing renders, describe what you see to confirm expectations.
 - If `execute` returns an error, show the user the error and explain what went wrong before retrying.
-- When exporting, confirm the file path returned by the tool.
+- When exporting, confirm the file path(s) returned by the tool.
 
 ## Units
 

--- a/llms.md
+++ b/llms.md
@@ -1,10 +1,22 @@
 # build123-mcp — LLM Reference
 
-build123-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you five tools to build 3D geometry incrementally, render views, measure dimensions, export files, and reset state.
+build123-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you seven tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, and reset.
 
 ## Key concept: persistent session
 
 All tool calls share a single Python namespace. Variables and shapes you create with `execute` persist across subsequent calls. Use this to build geometry step by step, checking your work after each step.
+
+### Multi-object sessions
+
+Use `show(name, shape)` inside `execute` to register named objects. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.
+
+```python
+frame = Box(60, 40, 8)
+show("frame", frame)
+
+axle = Cylinder(5, 50)
+show("axle", axle)
+```
 
 ---
 
@@ -17,11 +29,10 @@ Run build123d Python code in the persistent session.
 
 **Returns:** captured stdout/stderr, or `"OK"` if silent, or an error message on exception.
 
-The server auto-detects the current shape. Prefer assigning your final shape to a variable named `result`:
+The server auto-detects the current shape. Prefer assigning your final shape to `result`, or use `show(name, shape)` for named objects:
 ```python
 result = Box(10, 20, 30)
 ```
-Or use the context manager pattern:
 ```python
 with BuildPart() as bp:
     Box(10, 20, 30)
@@ -34,22 +45,36 @@ result = bp.part
 ---
 
 ### `render_view`
-Render the current model and return a PNG image.
+Render one or more shapes and return a PNG image.
 
-**Input:** `direction` (string, default `"iso"`) — one of `top`, `front`, `side`, `iso`
+**Inputs:**
+- `direction` (string, default `"iso"`) — `top`, `front`, `side`, `iso`
+- `objects` (string, default `""`) — comma-separated names from `show()` to render; empty = all registered objects, or `current_shape` if none registered
+- `quality` (string, default `"standard"`) — `standard` or `high`; high uses finer tessellation to eliminate artefacts on curved surfaces
+- `clip_plane` (string, default `""`) — `x`, `y`, or `z`; clips each mesh at its bounding-box midpoint to expose internal geometry (bores, wall thickness)
 
 **Returns:** PNG image
 
-Call this after each significant change to verify geometry visually. Use all four directions when spatial orientation matters.
+Each named object is rendered in a distinct colour. Call this after each significant change to verify geometry visually.
 
 ---
 
 ### `measure`
-Query geometry of the current model.
+Query geometry of a shape.
 
-**Input:** `query` (string, default `"bounding_box"`)
+**Inputs:**
+- `query` (string, default `"bounding_box"`) — one of:
+  - `bounding_box` — extents, sizes, and centre
+  - `volume` — shape volume
+  - `area` — total surface area
+  - `min_wall_thickness` — shortest wall crossing via ray cast (accurate for prismatic parts)
+  - `clearance` — minimum distance between two named bodies (requires `object_name` and `object_name2`)
+- `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
+- `object_name2` (string, default `""`) — second named object; required for `clearance`
 
-**Returns:** JSON with bounding box extents and centre:
+**Returns:** JSON
+
+`bounding_box` example:
 ```json
 {
   "xmin": -5.0, "xmax": 5.0,
@@ -60,25 +85,54 @@ Query geometry of the current model.
 }
 ```
 
-Use this to verify dimensions are correct before exporting.
+`volume` example: `{"volume": 1000.0}`
+
+`clearance` example: `{"clearance": 1.0}`
 
 ---
 
 ### `export`
-Export the current model to a file.
+Export a shape to a file.
 
 **Inputs:**
 - `filename` (string) — target path; extension auto-appended if missing
-- `format` (string, default `"step"`) — `"step"` or `"stl"`
+- `format` (string, default `"step"`) — `"step"`, `"stl"`, or comma-separated `"step,stl"` to write both in one call
+- `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
 
-**Returns:** `"Exported to /path/to/file.step"`
+**Returns:** path(s) of exported file(s)
 
-STEP is preferred for most CAD uses (preserves exact geometry). STL is for mesh-based workflows (3D printing, etc.).
+STEP preserves exact geometry for downstream CAD tools. STL is for mesh-based workflows (3D printing, slicers, GitHub preview).
+
+---
+
+### `save_snapshot`
+Save a named checkpoint of the current geometric state.
+
+**Input:** `name` (string) — snapshot label
+
+**Returns:** confirmation listing what was captured
+
+**What is saved:** `current_shape` and the `show()` object registry.
+**What is NOT saved:** the Python variable namespace. After a restore, any intermediate Python variables (e.g. `box`, `cyl`) created after the snapshot are still in scope — but `current_shape` and all `show()` objects revert to the snapshot state.
+
+Call this before risky experiments so you can restore known-good geometry without re-running all prior `execute()` calls.
+
+---
+
+### `restore_snapshot`
+Restore geometric state from a previously saved snapshot.
+
+**Input:** `name` (string) — snapshot label
+
+**Returns:** confirmation listing restored geometry, or an error if the name does not exist.
+
+**What is restored:** `current_shape` and the `show()` object registry.
+**What is NOT restored:** the Python variable namespace remains as-is. If you need variables to match the snapshot, re-run the relevant `execute()` calls after restoring.
 
 ---
 
 ### `reset`
-Clear the session back to empty state.
+Clear the session back to empty state, including all snapshots.
 
 **No inputs.**
 
@@ -91,12 +145,13 @@ Call this before starting a new model to ensure a clean slate.
 ## Recommended workflow
 
 1. `reset` — start clean
-2. `execute` — create initial geometry
-3. `render_view` — visually verify
-4. `measure` — confirm dimensions
-5. `execute` — refine/add features
-6. Repeat 3–5 until satisfied
-7. `export` — write the file
+2. `execute` — imports and initial geometry; use `show()` for named parts
+3. `render_view` — visually verify (try `iso` first; use `quality="high"` for curved surfaces)
+4. `measure` — confirm dimensions (`bounding_box`, `volume`, `clearance`, etc.)
+5. `save_snapshot` — checkpoint before complex or risky operations
+6. `execute` — add features; if something breaks, `restore_snapshot`
+7. Repeat 3–6 until satisfied
+8. `export` — write STEP + STL in one call with `format="step,stl"`
 
 ---
 
@@ -116,8 +171,8 @@ Box(5, 5, 5, mode=Mode.SUBTRACT)   # subtract from current part
 Box(5, 5, 5, mode=Mode.INTERSECT)  # intersect with current part
 
 # Location / movement
-Pos(x, y, z)           # translate
-Rot(x_deg, y_deg, z_deg)   # rotate
+Pos(x, y, z)
+Rot(x_deg, y_deg, z_deg)
 
 # Context manager pattern (recommended)
 with BuildPart() as part:
@@ -126,9 +181,9 @@ with BuildPart() as part:
         Cylinder(radius=3, height=10, mode=Mode.SUBTRACT)
 result = part.part
 
-# Compound / boolean between separate shapes
-combined = part_a + part_b   # union
-cut = part_a - part_b        # difference
+# Boolean between separate shapes
+combined = part_a + part_b
+cut = part_a - part_b
 intersection = part_a & part_b
 ```
 
@@ -140,5 +195,7 @@ All units are millimetres by default.
 
 - **No shape yet:** `render_view`, `measure`, and `export` all fail if no shape exists. Always `execute` geometry first.
 - **Forgetting imports:** the namespace starts empty. Include `from build123d import *` in your first `execute` call.
-- **Shape not detected:** if the server doesn't pick up your shape, assign it explicitly to `result`.
-- **Dirty session:** unexpected results often mean leftover state from a previous run. Call `reset` first.
+- **Shape not detected:** if the server doesn't pick up your shape, assign it explicitly to `result` or use `show()`.
+- **Dirty session:** unexpected results often mean leftover state. Call `reset` first.
+- **`clearance` missing second object:** `clearance` requires both `object_name` and `object_name2`.
+- **Snapshot restores geometry only:** after `restore_snapshot`, Python variables are not rewound. Re-run `execute()` calls if variables need to match the snapshot.

--- a/server.py
+++ b/server.py
@@ -36,8 +36,32 @@ def export(filename: str, format: str = "step", object_name: str = "") -> str:
 
 
 @mcp.tool()
+def save_snapshot(name: str) -> str:
+    """Save a named checkpoint of the current geometric state (current_shape and the show() object registry).
+    The Python variable namespace is NOT saved — only geometry. Call this before risky experiments so you can
+    restore known-good geometry without re-running all prior execute() calls."""
+    _session.save_snapshot(name)
+    saved = ["current_shape"] + list(_session.snapshots[name]["objects"].keys())
+    return f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
+
+
+@mcp.tool()
+def restore_snapshot(name: str) -> str:
+    """Restore geometric state from a previously saved snapshot (current_shape and the show() registry).
+    The Python variable namespace is NOT restored — execute() calls made after the snapshot are still in scope,
+    but current_shape and all show() objects revert to what they were at snapshot time.
+    Raises an error if the snapshot name does not exist."""
+    try:
+        _session.restore_snapshot(name)
+    except KeyError as e:
+        return f"Error: {e}"
+    restored = ["current_shape"] + list(_session.objects.keys())
+    return f"Snapshot '{name}' restored. Active geometry: {', '.join(restored) if restored else 'none'}."
+
+
+@mcp.tool()
 def reset() -> str:
-    """Clear the current session back to empty state."""
+    """Clear the current session back to empty state, including all snapshots."""
     _session.reset()
     return "Session reset."
 

--- a/session.py
+++ b/session.py
@@ -7,6 +7,7 @@ class Session:
         self.namespace = {}
         self.current_shape = None
         self.objects = {}
+        self.snapshots = {}  # name -> {"current_shape": ..., "objects": {...}}
         self._inject_builtins()
 
     def _inject_builtins(self):
@@ -58,8 +59,23 @@ class Session:
                 self.current_shape = obj
                 return
 
+    def save_snapshot(self, name: str) -> None:
+        self.snapshots[name] = {
+            "current_shape": self.current_shape,
+            "objects": dict(self.objects),
+        }
+
+    def restore_snapshot(self, name: str) -> None:
+        if name not in self.snapshots:
+            raise KeyError(f"No snapshot named '{name}'. Available: {list(self.snapshots.keys())}")
+        snap = self.snapshots[name]
+        self.current_shape = snap["current_shape"]
+        self.objects.clear()
+        self.objects.update(snap["objects"])
+
     def reset(self):
         self.namespace.clear()
         self.current_shape = None
         self.objects.clear()
+        self.snapshots.clear()
         self._inject_builtins()

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -118,6 +118,50 @@ def test_error_in_execute_preserves_current_shape(session):
 
 
 # ---------------------------------------------------------------------------
+# Session snapshots
+# ---------------------------------------------------------------------------
+
+def test_snapshot_restores_geometry_after_bad_experiment(session):
+    """save_snapshot / restore_snapshot recovers known-good geometry."""
+    execute_code(session, "result = Box(10, 10, 10)")
+    session.save_snapshot("good")
+    good_vol = json.loads(measure(session, "volume"))["volume"]
+
+    # Simulate an experiment that produces wrong geometry
+    execute_code(session, "result = Box(1, 1, 1)")
+    assert json.loads(measure(session, "volume"))["volume"] < good_vol
+
+    session.restore_snapshot("good")
+    assert abs(json.loads(measure(session, "volume"))["volume"] - good_vol) < 0.1
+
+
+def test_snapshot_objects_registry_survives_round_trip(session):
+    """Named objects are captured in the snapshot and restored correctly."""
+    execute_code(session, "show('frame', Box(60, 40, 8))\nshow('axle', Cylinder(5, 50))")
+    session.save_snapshot("assembly_v1")
+
+    # Overwrite both objects
+    execute_code(session, "show('frame', Box(1, 1, 1))\nshow('axle', Box(1, 1, 1))")
+    session.restore_snapshot("assembly_v1")
+
+    frame_bb = json.loads(measure(session, "bounding_box", "frame"))
+    axle_bb = json.loads(measure(session, "bounding_box", "axle"))
+    assert abs(frame_bb["xsize"] - 60) < 0.1
+    assert abs(axle_bb["zsize"] - 50) < 0.1
+
+
+def test_namespace_not_restored_by_snapshot(session):
+    """Python variables set after a snapshot are still accessible after restore.
+    This confirms the documented behaviour: snapshot saves geometry only."""
+    execute_code(session, "result = Box(10, 10, 10)")
+    session.save_snapshot("s1")
+    execute_code(session, "extra_var = 123")
+    session.restore_snapshot("s1")
+    # extra_var is still in scope even though it was created after the snapshot
+    assert session.namespace.get("extra_var") == 123
+
+
+# ---------------------------------------------------------------------------
 # Multi-object session: show(), per-object measure/export/render
 # ---------------------------------------------------------------------------
 
@@ -253,13 +297,14 @@ async def _mcp_session(coro):
             return await coro(mcp)
 
 
-def test_mcp_lists_all_five_tools():
+def test_mcp_lists_all_tools():
     async def run(mcp):
         result = await mcp.list_tools()
         return {t.name for t in result.tools}
 
     names = asyncio.run(_mcp_session(run))
-    assert names == {"execute", "render_view", "measure", "export", "reset"}
+    assert names == {"execute", "render_view", "measure", "export", "reset",
+                     "save_snapshot", "restore_snapshot"}
 
 
 def test_mcp_execute_and_measure_round_trip():
@@ -306,6 +351,20 @@ def test_mcp_reset_clears_state():
 
     text = asyncio.run(_mcp_session(run))
     assert "No shape" in text
+
+
+def test_mcp_snapshot_save_and_restore():
+    """save_snapshot / restore_snapshot round-trip through the MCP wire restores geometry."""
+    async def run(mcp):
+        await mcp.call_tool("execute", {"code": "from build123d import *\nresult = Box(10, 10, 10)"})
+        await mcp.call_tool("save_snapshot", {"name": "v1"})
+        await mcp.call_tool("execute", {"code": "result = Box(99, 99, 99)"})
+        await mcp.call_tool("restore_snapshot", {"name": "v1"})
+        result = await mcp.call_tool("measure", {"query": "bounding_box"})
+        return result.content[0].text
+
+    data = json.loads(asyncio.run(_mcp_session(run)))
+    assert abs(data["xsize"] - 10) < 0.01
 
 
 def test_mcp_multi_format_export():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -290,3 +290,46 @@ def test_export_unknown_object_raises(session, tmp_path):
     execute_code(session, "show('a', Box(5, 5, 5))")
     with pytest.raises(ValueError, match="Unknown object"):
         export_file(session, str(tmp_path / "out"), "step", "missing")
+
+
+# --- snapshots ---
+
+def test_save_and_restore_snapshot(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    shape_before = session.current_shape
+    session.save_snapshot("v1")
+    execute_code(session, "result = Box(99, 99, 99)")
+    assert session.current_shape is not shape_before
+    session.restore_snapshot("v1")
+    assert session.current_shape is shape_before
+
+
+def test_snapshot_captures_objects_registry(session):
+    execute_code(session, "show('part', Box(10, 10, 10))")
+    session.save_snapshot("s1")
+    execute_code(session, "show('extra', Box(5, 5, 5))")
+    assert "extra" in session.objects
+    session.restore_snapshot("s1")
+    assert "extra" not in session.objects
+    assert "part" in session.objects
+
+
+def test_restore_unknown_snapshot_raises(session):
+    with pytest.raises(KeyError, match="no_such"):
+        session.restore_snapshot("no_such")
+
+
+def test_reset_clears_snapshots(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    session.save_snapshot("v1")
+    session.reset()
+    assert not session.snapshots
+
+
+def test_namespace_preserved_after_restore(session):
+    execute_code(session, "x = 42")
+    session.save_snapshot("s1")
+    execute_code(session, "x = 99")
+    session.restore_snapshot("s1")
+    # namespace is NOT restored — x stays at 99
+    assert session.namespace.get("x") == 99


### PR DESCRIPTION
## Summary

- `save_snapshot(name)` — captures `current_shape` and the `show()` object registry
- `restore_snapshot(name)` — reinstates that geometric state; returns a clear error if the name doesn't exist
- `reset()` now also clears all snapshots
- **Docs fully refreshed:** `llms.md`, `default_prompt.md`, and `README.md` now cover all features since v0.1.0 (show(), multi-object render, quality/clip_plane, richer measurements, multi-format export, snapshots)

Closes #3 item 4.

## What snapshots save and don't save

Documented explicitly everywhere the calling AI can see it — tool docstrings, llms.md, default_prompt.md:

> **What is saved:** `current_shape` and the `show()` object registry.
> **What is NOT saved:** the Python variable namespace. After a restore, Python variables created after the snapshot are still in scope — re-run relevant `execute()` calls if those variables need to match.

A dedicated unit test (`test_namespace_preserved_after_restore`) and outcome test (`test_namespace_not_restored_by_snapshot`) verify and demonstrate this behaviour explicitly.

## Test plan
- [x] `test_save_and_restore_snapshot` — shape reverts after restore
- [x] `test_snapshot_captures_objects_registry` — show() registry reverts
- [x] `test_restore_unknown_snapshot_raises`
- [x] `test_reset_clears_snapshots`
- [x] `test_namespace_preserved_after_restore` — confirms namespace NOT restored
- [x] `test_snapshot_restores_geometry_after_bad_experiment` — outcome test
- [x] `test_snapshot_objects_registry_survives_round_trip` — assembly outcome test
- [x] `test_namespace_not_restored_by_snapshot` — outcome test documents the caveat
- [x] `test_mcp_snapshot_save_and_restore` — MCP wire round-trip
- [x] `test_mcp_lists_all_tools` — updated for 7 tools
- [x] 75 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)