### PR TITLE
Three-layer defence against code injection

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,102 @@
+# Security
+
+## Threat model
+
+build123-mcp executes AI-generated Python code via `exec()`. The primary threat is **prompt injection**: malicious content in a file or web page that the user asks an AI to analyse causes the AI to call `execute()` with a payload intended to read files, exfiltrate data, run shell commands, or open network connections.
+
+This is a local development tool. It is not designed for multi-tenant or production deployments.
+
+---
+
+## Defences
+
+Three layers are applied to every `execute()` call.
+
+### 1. AST inspection (pre-execution)
+
+Before `exec()` is called, the code is parsed and the AST is walked. The check rejects:
+
+- `import <module>` or `from <module> import ...` where the root module is not in the allowlist
+- Direct calls to `eval`, `exec`, `compile`, `open`, `__import__`, `breakpoint`, `input`
+
+**Import allowlist:** `build123d`, `math`, `numpy`, `typing`, `collections`, `itertools`, `functools`, `copy`
+
+This blocks common injection patterns before any code runs:
+- Shell access: `import os`, `import subprocess`
+- Filesystem: `import pathlib`, `import shutil`, `from os.path import ...`
+- Network: `import socket`, `import urllib`, `import requests`, `import http`
+- Code injection: `eval(...)`, `exec(...)`
+- File I/O: `open(...)`
+
+### 2. Restricted builtins (namespace-level)
+
+The exec namespace's `__builtins__` is replaced with a filtered copy:
+
+- `open`, `eval`, `exec`, `compile`, `breakpoint`, `input` are removed outright
+- `__import__` is replaced with an allowlisted wrapper that enforces the same import allowlist at the namespace level
+
+This provides a second layer independent of AST inspection. If the AST check were somehow bypassed (e.g. by a future code path that skips it), the namespace `__import__` restriction still fires at runtime.
+
+### 3. Execution timeout
+
+Each `execute()` call runs in a daemon thread with a configurable wall-clock limit (default: 30 seconds). If the limit is exceeded, `ExecutionTimeout` is raised and the error is returned to the caller.
+
+This prevents denial-of-service via infinite loops or expensive computations.
+
+---
+
+## Known limitations
+
+These are not fixed by the current implementation. They are documented so users can make an informed decision about deployment.
+
+### Python sandbox escapes
+
+Python's object model exposes powerful introspection APIs that can bypass namespace-level restrictions:
+
+```python
+# Access OS module via subclass traversal — not blocked
+[c for c in ().__class__.__bases__[0].__subclasses__()
+ if 'Popen' in c.__name__][0](['id'])
+
+# Access globals of an imported function
+list.__class__.__mro__[-1].__subclasses__()
+```
+
+These patterns are not blocked. Blocking them reliably requires a proper sandbox (see below).
+
+### Build123d internals
+
+Once `from build123d import *` runs, build123d symbols are in the exec namespace. If any build123d function internally wraps a file or subprocess operation, it could be called from user code without triggering the import check.
+
+### Memory exhaustion
+
+No memory limit is enforced. User code can allocate unbounded memory:
+
+```python
+x = [0] * 10**10  # not blocked
+```
+
+### Timeout thread continues
+
+The daemon thread running exec'd code continues after a timeout. The namespace may be in a partially modified state. Callers should treat the session as dirty after a timeout and call `reset()` or `restore_snapshot()`.
+
+### Windows
+
+`signal.SIGALRM` is not available on Windows. The timeout uses a thread join, which works cross-platform but cannot forcibly terminate the runaway thread.
+
+---
+
+## Recommendations for higher-security deployments
+
+If you are running this server in an environment where the input is not trusted (e.g. exposing it to external users, or in a shared environment), the namespace-level defences are not sufficient. Consider:
+
+1. **Run in a container** with no network access (`--network none`) and a read-only filesystem mount (except a controlled output directory).
+2. **Use seccomp/AppArmor** to restrict syscalls to those needed by build123d (file I/O within a temp dir, no fork, no network).
+3. **Use RestrictedPython** as an additional layer before exec, though it requires careful allowlisting to work with build123d.
+4. **Run each execute() call in a subprocess** and communicate results over a pipe; the subprocess can be killed hard on timeout.
+
+---
+
+## Reporting security issues
+
+Open an issue at https://github.com/pzfreo/build123-mcp/issues and label it `security`.

--- a/security.py
+++ b/security.py
@@ -1,0 +1,154 @@
+"""
+Lightweight defence-in-depth for exec'd user code.
+
+Three layers:
+  1. AST inspection  — rejects dangerous imports and calls before exec runs.
+  2. Restricted builtins — namespace __builtins__ has open/eval/exec removed
+     and __import__ filtered to the allowlist.
+  3. Execution timeout — a background thread enforces a wall-clock limit.
+
+This is not a complete sandbox. Determined Python sandbox escapes
+(subclass traversal, ctypes, etc.) are not blocked. The goal is to raise
+the bar against realistic prompt-injection payloads: shell commands,
+filesystem reads, and network calls.
+"""
+
+import ast
+import threading
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+EXEC_TIMEOUT_SECONDS = 30
+
+# Modules user code may import. build123d's own internal imports are
+# unaffected — they run through the real import system, not this namespace.
+IMPORT_ALLOWLIST = frozenset({
+    "build123d",
+    "math",
+    "numpy",
+    "typing",
+    "collections",
+    "itertools",
+    "functools",
+    "copy",
+})
+
+# Builtins that are dangerous even without an import.
+_BLOCKED_BUILTINS = frozenset({
+    "eval", "exec", "compile", "open", "breakpoint", "input",
+})
+
+# Bare-name calls that are caught at the AST level (before exec runs).
+_BLOCKED_CALL_NAMES = frozenset({
+    "__import__", "eval", "exec", "compile", "open", "breakpoint", "input",
+})
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: AST inspection
+# ---------------------------------------------------------------------------
+
+def check_ast(code: str) -> None:
+    """Raise ValueError if code contains disallowed imports or dangerous calls.
+
+    Catches the most common injection patterns before exec() is ever called.
+    Syntax errors are left for exec() to report with better messages.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _check_module(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                _check_module(node.module)
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
+                raise ValueError(
+                    f"Call to '{node.func.id}' is not allowed."
+                )
+
+
+def _check_module(dotted_name: str) -> None:
+    root = dotted_name.split(".")[0]
+    if root not in IMPORT_ALLOWLIST:
+        raise ValueError(
+            f"Import of '{dotted_name}' is not allowed. "
+            f"This blocks filesystem (os, pathlib, shutil), network (socket, urllib, "
+            f"requests), and shell access (subprocess). "
+            f"Permitted: {sorted(IMPORT_ALLOWLIST)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: Restricted builtins
+# ---------------------------------------------------------------------------
+
+def make_restricted_builtins() -> dict:
+    """Return a __builtins__ dict with dangerous functions removed.
+
+    open / eval / exec / compile are removed outright.
+    __import__ is replaced with an allowlisted version so that
+    'from build123d import *' works but 'import os' is blocked at the
+    namespace level even if AST inspection is somehow bypassed.
+    """
+    import builtins
+    safe = vars(builtins).copy()
+
+    for name in _BLOCKED_BUILTINS:
+        safe.pop(name, None)
+
+    _original_import = safe["__import__"]
+
+    def _safe_import(name, *args, **kwargs):
+        root = name.split(".")[0]
+        if root not in IMPORT_ALLOWLIST:
+            raise ImportError(
+                f"Import of '{name}' is not allowed. "
+                f"Permitted: {sorted(IMPORT_ALLOWLIST)}"
+            )
+        return _original_import(name, *args, **kwargs)
+
+    safe["__import__"] = _safe_import
+    return safe
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: Execution timeout
+# ---------------------------------------------------------------------------
+
+class ExecutionTimeout(Exception):
+    pass
+
+
+def exec_with_timeout(compiled, namespace: dict, timeout_sec: int) -> None:
+    """Run exec(compiled, namespace) and raise ExecutionTimeout if it exceeds timeout_sec.
+
+    Uses a daemon thread so this works regardless of which thread the caller
+    is in (e.g. asyncio event loop). The background thread may outlive the
+    timeout — it is daemon so it will not prevent process exit, but it may
+    still modify namespace after the timeout. Callers should treat the
+    namespace as potentially dirty after a timeout.
+    """
+    exc_holder: list = [None]
+
+    def _run() -> None:
+        try:
+            exec(compiled, namespace)  # noqa: S102
+        except Exception as exc:
+            exc_holder[0] = exc
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_sec)
+
+    if t.is_alive():
+        raise ExecutionTimeout(f"Code exceeded the {timeout_sec}s execution time limit.")
+    if exc_holder[0] is not None:
+        raise exc_holder[0]

--- a/session.py
+++ b/session.py
@@ -1,16 +1,26 @@
 import io
 from contextlib import redirect_stdout, redirect_stderr
 
+from security import (
+    EXEC_TIMEOUT_SECONDS,
+    ExecutionTimeout,
+    check_ast,
+    exec_with_timeout,
+    make_restricted_builtins,
+)
+
 
 class Session:
-    def __init__(self):
+    def __init__(self, exec_timeout: int = EXEC_TIMEOUT_SECONDS):
+        self.exec_timeout = exec_timeout
         self.namespace = {}
         self.current_shape = None
         self.objects = {}
-        self.snapshots = {}  # name -> {"current_shape": ..., "objects": {...}}
+        self.snapshots = {}
         self._inject_builtins()
 
     def _inject_builtins(self):
+        self.namespace["__builtins__"] = make_restricted_builtins()
         objects = self.objects
 
         def show(name, shape):
@@ -19,13 +29,27 @@ class Session:
         self.namespace["show"] = show
 
     def execute(self, code: str) -> str:
+        # Layer 1: AST check before anything runs
+        try:
+            check_ast(code)
+        except ValueError as e:
+            return f"Error: SecurityError: {e}"
+
+        try:
+            compiled = compile(code, "<mcp>", "exec")
+        except SyntaxError as e:
+            return f"Error: SyntaxError: {e}"
+
         buf = io.StringIO()
         keys_before = set(self.namespace.keys())
         try:
             with redirect_stdout(buf), redirect_stderr(buf):
-                exec(compile(code, "<mcp>", "exec"), self.namespace)
+                # Layer 3: timeout wraps the actual exec
+                exec_with_timeout(compiled, self.namespace, self.exec_timeout)
             new_keys = set(self.namespace.keys()) - keys_before
             self._update_current_shape(new_keys)
+        except ExecutionTimeout as e:
+            return f"Error: ExecutionTimeout: {e}"
         except Exception as e:
             return f"Error: {type(e).__name__}: {e}"
         output = buf.getvalue()

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -118,6 +118,50 @@ def test_error_in_execute_preserves_current_shape(session):
 
 
 # ---------------------------------------------------------------------------
+# Security: injection resistance
+# ---------------------------------------------------------------------------
+
+def test_shell_injection_attempt_blocked(session):
+    """A prompt-injection payload trying to run a shell command is rejected."""
+    execute_code(session, "result = Box(10, 10, 10)")
+    shape_before = session.current_shape
+    result = execute_code(session, "import subprocess; subprocess.run(['id'])")
+    assert "not allowed" in result.lower() or "SecurityError" in result
+    # Geometry is intact
+    assert session.current_shape is shape_before
+
+
+def test_filesystem_read_attempt_blocked(session):
+    """Attempting to read a file via open() is rejected."""
+    result = execute_code(session, "data = open('/etc/passwd').read()")
+    assert "not allowed" in result.lower() or "Error" in result
+
+
+def test_network_access_attempt_blocked(session):
+    """Attempting to open a network socket is rejected."""
+    result = execute_code(session, "import socket; socket.create_connection(('1.1.1.1', 80))")
+    assert "not allowed" in result.lower() or "SecurityError" in result
+
+
+def test_normal_workflow_unaffected_by_security(session):
+    """Security hardening does not break a legitimate build123d session."""
+    execute_code(session, "import math\nresult = Cylinder(math.pi, 20)")
+    assert session.current_shape is not None
+    bb = json.loads(measure(session, "bounding_box"))
+    assert bb["zsize"] > 0
+
+
+def test_builtins_import_restriction_independent_of_ast(session):
+    """The builtins __import__ restriction provides a second layer: even if a
+    future change widened the AST allowlist, the namespace-level filter still
+    blocks non-allowlisted imports at runtime."""
+    # Bypass AST by calling __import__ through builtins dict directly
+    restricted_import = session.namespace["__builtins__"]["__import__"]
+    with pytest.raises(ImportError, match="not allowed"):
+        restricted_import("os")
+
+
+# ---------------------------------------------------------------------------
 # Session snapshots
 # ---------------------------------------------------------------------------
 
@@ -351,6 +395,20 @@ def test_mcp_reset_clears_state():
 
     text = asyncio.run(_mcp_session(run))
     assert "No shape" in text
+
+
+def test_mcp_injection_attempt_returns_error_not_executes():
+    """A shell-injection payload through the MCP wire returns an error and does
+    not produce side-effects (geometry is still None at the start of the session)."""
+    async def run(mcp):
+        result = await mcp.call_tool(
+            "execute",
+            {"code": "import subprocess; subprocess.run(['id'], capture_output=True)"},
+        )
+        return result.content[0].text
+
+    text = asyncio.run(_mcp_session(run))
+    assert "not allowed" in text.lower() or "SecurityError" in text
 
 
 def test_mcp_snapshot_save_and_restore():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,6 +20,14 @@ def session():
     return s
 
 
+@pytest.fixture
+def fast_session():
+    """Session with a 1-second exec timeout for testing timeout behaviour."""
+    s = Session(exec_timeout=1)
+    s.execute("from build123d import *")
+    return s
+
+
 # --- execute ---
 
 def test_execute_persists_state(session):
@@ -47,6 +55,75 @@ def test_execute_creates_shape(session):
 def test_execute_detects_buildpart(session):
     execute_code(session, "with BuildPart() as p:\n    Box(10, 10, 10)")
     assert session.current_shape is not None
+
+
+# --- security ---
+
+def test_import_os_blocked(session):
+    result = execute_code(session, "import os")
+    assert "SecurityError" in result or "not allowed" in result.lower()
+
+
+def test_import_subprocess_blocked(session):
+    result = execute_code(session, "import subprocess")
+    assert "not allowed" in result.lower()
+
+
+def test_from_os_import_blocked(session):
+    result = execute_code(session, "from os import getcwd")
+    assert "not allowed" in result.lower()
+
+
+def test_import_socket_blocked(session):
+    result = execute_code(session, "import socket")
+    assert "not allowed" in result.lower()
+
+
+def test_import_pathlib_blocked(session):
+    result = execute_code(session, "import pathlib")
+    assert "not allowed" in result.lower()
+
+
+def test_eval_call_blocked(session):
+    result = execute_code(session, "eval('1+1')")
+    assert "not allowed" in result.lower()
+
+
+def test_exec_call_blocked(session):
+    result = execute_code(session, "exec('x=1')")
+    assert "not allowed" in result.lower()
+
+
+def test_open_call_blocked(session):
+    result = execute_code(session, "open('/etc/passwd')")
+    assert "not allowed" in result.lower()
+
+
+def test_open_removed_from_builtins(session):
+    # open is blocked by builtins restriction even if AST check were bypassed
+    assert "open" not in session.namespace.get("__builtins__", {})
+
+
+def test_import_math_allowed(session):
+    result = execute_code(session, "import math\nx = math.pi")
+    assert "Error" not in result
+
+
+def test_import_build123d_allowed(session):
+    result = execute_code(session, "from build123d import *\nresult = Box(1, 1, 1)")
+    assert "Error" not in result
+
+
+def test_execution_timeout(fast_session):
+    result = execute_code(fast_session, "while True: pass")
+    assert "timeout" in result.lower() or "time limit" in result.lower()
+
+
+def test_blocked_import_does_not_corrupt_shape(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    shape_before = session.current_shape
+    execute_code(session, "import os")
+    assert session.current_shape is shape_before
 
 
 # --- render_view ---


### PR DESCRIPTION
## Summary

Adds `security.py` implementing three independent layers that apply to every `execute()` call:

**Layer 1 — AST inspection (pre-execution)**
Rejects code before `exec()` runs. Blocks:
- Imports outside an allowlist: `build123d`, `math`, `numpy`, `typing`, `collections`, `itertools`, `functools`, `copy` — covers `os`, `subprocess`, `socket`, `urllib`, `pathlib`, `shutil`, `requests`, etc.
- Direct calls to `eval`, `exec`, `compile`, `open`, `__import__`

**Layer 2 — Restricted builtins**
The exec namespace `__builtins__` has `open`/`eval`/`exec`/`compile`/`breakpoint`/`input` removed, and `__import__` replaced with an allowlisted wrapper. Fires at runtime independently of the AST check — a second line of defence if the AST path were bypassed.

**Layer 3 — Execution timeout**
`exec()` runs in a daemon thread. Default limit: 30s (configurable per-session for tests). Prevents infinite-loop DoS.

Security errors are returned as `"Error: SecurityError: ..."` so the calling AI can report them clearly without crashing.

**`security.md`** documents the threat model, what's covered, known limitations (Python sandbox escapes, memory exhaustion, timeout thread continuation), and recommendations for higher-security deployments.

Partially closes #1 (code execution sandbox + resource limits). Logging remains open.

## Test plan
- [x] `import os/subprocess/socket/pathlib` → blocked
- [x] `from os import getcwd` → blocked
- [x] `eval(...)` / `exec(...)` / `open(...)` calls → blocked
- [x] `open` not present in namespace builtins
- [x] Builtins `__import__` independently rejects non-allowlisted modules
- [x] `import math` / `from build123d import *` → allowed
- [x] Execution timeout fires for infinite loop
- [x] Blocked import does not corrupt `current_shape`
- [x] Normal build123d workflow unaffected
- [x] MCP wire: injection payload returns error, not side-effect
- [x] 94 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)