### PR TITLE
Rename package and project to build123d-mcp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "build123-mcp": {
+    "build123d-mcp": {
       "command": "uv",
       "args": ["run", "python", "server.py"],
       "cwd": "/app/workspaces/pzfreo/build123-mcp"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# build123-mcp
+# build123d-mcp
 
 ## Running tests
 

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,4 +1,4 @@
-# Session Prompt — build123-mcp
+# Session Prompt — build123d-mcp
 
 ## What we are building
 
@@ -9,7 +9,7 @@ files — rather than writing complete scripts blind.
 
 ## Repo
 
-https://github.com/pzfreo/build123-mcp
+https://github.com/pzfreo/build123d-mcp
 
 The repo already contains:
 - `README.md` — project overview

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# build123-mcp
+# build123d-mcp
 
 An MCP (Model Context Protocol) server that exposes build123d CAD operations as tools, enabling AI assistants to build, inspect, and iterate on 3D geometry interactively.
 
@@ -29,8 +29,8 @@ See [llms.md](llms.md) for full tool reference and usage patterns.
 Clone the repository:
 
 ```bash
-git clone https://github.com/pzfreo/build123-mcp
-cd build123-mcp
+git clone https://github.com/pzfreo/build123d-mcp
+cd build123d-mcp
 ```
 
 Install dependencies with uv:
@@ -55,7 +55,7 @@ The server runs over stdio — the client launches it as a subprocess. The comma
 uv run python server.py
 ```
 
-run from the `build123-mcp` directory.
+run from the `build123d-mcp` directory.
 
 ### Claude Code
 
@@ -64,10 +64,10 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
 ```json
 {
   "mcpServers": {
-    "build123-mcp": {
+    "build123d-mcp": {
       "command": "uv",
       "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123-mcp"
+      "cwd": "/path/to/build123d-mcp"
     }
   }
 }
@@ -82,10 +82,10 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
 ```json
 {
   "mcpServers": {
-    "build123-mcp": {
+    "build123d-mcp": {
       "command": "uv",
       "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123-mcp"
+      "cwd": "/path/to/build123d-mcp"
     }
   }
 }
@@ -100,10 +100,10 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
 ```json
 {
   "mcpServers": {
-    "build123-mcp": {
+    "build123d-mcp": {
       "command": "uv",
       "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123-mcp"
+      "cwd": "/path/to/build123d-mcp"
     }
   }
 }
@@ -117,10 +117,10 @@ For **Continue** extension, add to `.continue/config.json`:
 {
   "mcpServers": [
     {
-      "name": "build123-mcp",
+      "name": "build123d-mcp",
       "command": "uv",
       "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123-mcp"
+      "cwd": "/path/to/build123d-mcp"
     }
   ]
 }
@@ -131,11 +131,11 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
 ```json
 {
   "servers": {
-    "build123-mcp": {
+    "build123d-mcp": {
       "type": "stdio",
       "command": "uv",
       "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123-mcp"
+      "cwd": "/path/to/build123d-mcp"
     }
   }
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# build123-mcp — Specification
+# build123d-mcp — Specification
 
 ## Purpose
 
@@ -76,7 +76,7 @@ Start with SVG projection for v1 — simple and dependency-free. Upgrade to
 ## File Structure
 
 ```
-build123-mcp/
+build123d-mcp/
   server.py        # MCP server entry point
   session.py       # persistent build123d session management
   tools/

--- a/default_prompt.md
+++ b/default_prompt.md
@@ -1,6 +1,6 @@
-# Default system prompt for build123-mcp
+# Default system prompt for build123d-mcp
 
-Use this as a system prompt when configuring an AI assistant to work with the build123-mcp MCP server.
+Use this as a system prompt when configuring an AI assistant to work with the build123d-mcp MCP server.
 
 ---
 

--- a/llms.md
+++ b/llms.md
@@ -1,6 +1,6 @@
-# build123-mcp — LLM Reference
+# build123d-mcp — LLM Reference
 
-build123-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you seven tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, and reset.
+build123d-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you seven tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, and reset.
 
 ## Key concept: persistent session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "build123-mcp"
+name = "build123d-mcp"
 version = "0.1.0"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 requires-python = ">=3.10"
@@ -13,4 +13,4 @@ dependencies = [
 dev = ["pytest"]
 
 [project.scripts]
-build123-mcp = "server:main"
+build123d-mcp = "server:main"

--- a/security.md
+++ b/security.md
@@ -2,7 +2,7 @@
 
 ## Threat model
 
-build123-mcp executes AI-generated Python code via `exec()`. The primary threat is **prompt injection**: malicious content in a file or web page that the user asks an AI to analyse causes the AI to call `execute()` with a payload intended to read files, exfiltrate data, run shell commands, or open network connections.
+build123d-mcp executes AI-generated Python code via `exec()`. The primary threat is **prompt injection**: malicious content in a file or web page that the user asks an AI to analyse causes the AI to call `execute()` with a payload intended to read files, exfiltrate data, run shell commands, or open network connections.
 
 This is a local development tool. It is not designed for multi-tenant or production deployments.
 
@@ -99,4 +99,4 @@ If you are running this server in an environment where the input is not trusted 
 
 ## Reporting security issues
 
-Open an issue at https://github.com/pzfreo/build123-mcp/issues and label it `security`.
+Open an issue at https://github.com/pzfreo/build123d-mcp/issues and label it `security`.

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@ from tools.measure import measure as measure_fn
 from tools.export import export_file
 from tools.interference import interference as interference_fn
 
-mcp = FastMCP("build123-mcp")
+mcp = FastMCP("build123d-mcp")
 _session = Session()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -57,31 +57,6 @@ wheels = [
 ]
 
 [[package]]
-name = "build123-mcp"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "build123d" },
-    { name = "mcp" },
-    { name = "pyvista" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "build123d" },
-    { name = "mcp" },
-    { name = "pyvista" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest" }]
-
-[[package]]
 name = "build123d"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -108,6 +83,31 @@ sdist = { url = "https://files.pythonhosted.org/packages/7e/00/b56ebe1d2a31611db
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/5a/0fe9cc610a6d07eaaddd80629a49ea18ecf9acefb81c6788a854f0dea224/build123d-0.10.0-py3-none-any.whl", hash = "sha256:589f397b1dc7c85c9936aa7b2ee39946cc226a121e14a621b6749263aae5ed7d", size = 278755, upload-time = "2025-11-05T22:04:35.222Z" },
 ]
+
+[[package]]
+name = "build123d-mcp"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "build123d" },
+    { name = "mcp" },
+    { name = "pyvista" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build123d" },
+    { name = "mcp" },
+    { name = "pyvista" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest" }]
 
 [[package]]
 name = "cadquery-ocp"
@@ -633,7 +633,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Renames package from `build123-mcp` to `build123d-mcp` to match the actual library name (`build123d`)
- Updates `pyproject.toml` (name + console script entry point)
- Updates `server.py` FastMCP server name
- Updates all docs: README, CLAUDE.md, llms.md, SPEC.md, PROMPT.md, default_prompt.md, security.md
- Updates `.mcp.json` server key (local `cwd` path unchanged — directory not yet renamed)
- Regenerates `uv.lock`
- GitHub repo already renamed to `build123d-mcp`

## Test plan
- [x] 103/103 tests pass after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)