### PR TITLE
Guard testpypi publish to push events only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
 
   publish-testpypi:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:


### PR DESCRIPTION
Adds `if: github.event_name == 'push'` to the testpypi job so it doesn't run on releases. Without this, publishing a release would try to re-upload the same version to TestPyPI and fail.

- push to main → TestPyPI only
- release published → PyPI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)