### PR TITLE
Update docs for src layout, uvx, and show() arg order

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 
 ## Tools
 
-- `execute` — run build123d Python code in a persistent session; use `show(name, shape)` to register named parts
+- `execute` — run build123d Python code in a persistent session; use `show(shape, name)` to register named parts
 - `render_view` — render one or more shapes as PNG; supports assembly compositing, high-quality tessellation, and cross-section clip planes
 - `measure` — query bounding box, volume, surface area, minimum wall thickness, or clearance between two named bodies
 - `export` — export as STEP, STL, or both in one call; targets a named object or the current shape
@@ -19,43 +19,26 @@ See [llms.md](llms.md) for full tool reference and usage patterns.
 
 ## Requirements
 
-- Python 3.10+
-- [uv](https://github.com/astral-sh/uv) (recommended) or pip
-- build123d, pyvista (installed automatically via uv)
+- [uv](https://github.com/astral-sh/uv)
 - An MCP-compatible client (Claude Code, Claude Desktop, Cursor, etc.)
+
+All Python dependencies (build123d, pyvista, etc.) are installed automatically by uv.
 
 ## Installation
 
-Clone the repository:
+No clone needed. Install directly from PyPI:
 
 ```bash
-git clone https://github.com/pzfreo/build123d-mcp
-cd build123d-mcp
+pip install build123d-mcp
 ```
 
-Install dependencies with uv:
-
-```bash
-uv sync
-```
-
-Or with pip:
-
-```bash
-pip install -e .
-```
+Or just use `uvx` — it fetches and runs the package in one step with no prior install required (see below).
 
 ---
 
 ## Adding to MCP clients
 
-The server runs over stdio — the client launches it as a subprocess. The command in all cases is:
-
-```
-uv run python server.py
-```
-
-run from the `build123d-mcp` directory.
+The server runs over stdio — the client launches it as a subprocess using `uvx build123d-mcp`.
 
 ### Claude Code
 
@@ -65,9 +48,8 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
 {
   "mcpServers": {
     "build123d-mcp": {
-      "command": "uv",
-      "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123d-mcp"
+      "command": "uvx",
+      "args": ["build123d-mcp"]
     }
   }
 }
@@ -83,9 +65,8 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
 {
   "mcpServers": {
     "build123d-mcp": {
-      "command": "uv",
-      "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123d-mcp"
+      "command": "uvx",
+      "args": ["build123d-mcp"]
     }
   }
 }
@@ -101,9 +82,8 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
 {
   "mcpServers": {
     "build123d-mcp": {
-      "command": "uv",
-      "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123d-mcp"
+      "command": "uvx",
+      "args": ["build123d-mcp"]
     }
   }
 }
@@ -118,9 +98,8 @@ For **Continue** extension, add to `.continue/config.json`:
   "mcpServers": [
     {
       "name": "build123d-mcp",
-      "command": "uv",
-      "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123d-mcp"
+      "command": "uvx",
+      "args": ["build123d-mcp"]
     }
   ]
 }
@@ -133,9 +112,8 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
   "servers": {
     "build123d-mcp": {
       "type": "stdio",
-      "command": "uv",
-      "args": ["run", "python", "server.py"],
-      "cwd": "/path/to/build123d-mcp"
+      "command": "uvx",
+      "args": ["build123d-mcp"]
     }
   }
 }
@@ -151,4 +129,4 @@ For best results, paste the contents of [default_prompt.md](default_prompt.md) a
 
 ## Status
 
-Active development (v0.2.0).
+Active development (v0.1.0).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,7 @@
 # build123d-mcp — Specification
 
+> **Historical document.** This spec was written before the initial implementation. The current codebase has diverged significantly: there are now seven tools (not five), rendering uses pyvista not SVG, snapshots and interference checking have been added, and the package is structured as a `src` layout with a PyPI entry point. Refer to `llms.md` for the authoritative tool reference and `README.md` for setup.
+
 ## Purpose
 
 An MCP server that wraps build123d, enabling an AI assistant to build, inspect,

--- a/default_prompt.md
+++ b/default_prompt.md
@@ -43,18 +43,19 @@ result = bp.part
 
 ## Multi-object assemblies
 
-Use `show(name, shape)` inside `execute` to register named parts. This lets you render, measure, and export individual parts independently:
+Use `show(shape, name)` inside `execute` to register named parts. This lets you render, measure, and export individual parts independently:
 
 ```python
 frame = Box(60, 40, 8)
-show("frame", frame)
+show(frame, "frame")
 
 axle = Cylinder(5, 50)
-show("axle", axle)
+show(axle, "axle")
 ```
 
 - `render_view()` — shows all registered objects together, each in a distinct colour
 - `render_view(objects="frame")` — shows only the named part
+- `render_view(objects="frame:blue,axle:red")` — override colours explicitly
 - `measure(query="bounding_box", object_name="frame")` — measures a specific part
 - `measure(query="clearance", object_name="axle", object_name2="frame")` — checks fit
 - `export(filename="frame", format="step", object_name="frame")` — exports a specific part

--- a/llms.md
+++ b/llms.md
@@ -8,14 +8,14 @@ All tool calls share a single Python namespace. Variables and shapes you create 
 
 ### Multi-object sessions
 
-Use `show(name, shape)` inside `execute` to register named objects. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.
+Use `show(shape, name)` inside `execute` to register named objects. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.
 
 ```python
 frame = Box(60, 40, 8)
-show("frame", frame)
+show(frame, "frame")
 
 axle = Cylinder(5, 50)
-show("axle", axle)
+show(axle, "axle")
 ```
 
 ---
@@ -29,7 +29,7 @@ Run build123d Python code in the persistent session.
 
 **Returns:** captured stdout/stderr, or `"OK"` if silent, or an error message on exception.
 
-The server auto-detects the current shape. Prefer assigning your final shape to `result`, or use `show(name, shape)` for named objects:
+The server auto-detects the current shape. Prefer assigning your final shape to `result`, or use `show(shape, name)` for named objects:
 ```python
 result = Box(10, 20, 30)
 ```
@@ -49,7 +49,7 @@ Render one or more shapes and return a PNG image.
 
 **Inputs:**
 - `direction` (string, default `"iso"`) — `top`, `front`, `side`, `iso`
-- `objects` (string, default `""`) — comma-separated names from `show()` to render; empty = all registered objects, or `current_shape` if none registered
+- `objects` (string, default `""`) — comma-separated names from `show()` to render; empty = all registered objects, or `current_shape` if none registered. Optionally suffix a name with `:color` to override the auto-assigned colour, e.g. `"frame:blue,axle:red"`
 - `quality` (string, default `"standard"`) — `standard` or `high`; high uses finer tessellation to eliminate artefacts on curved surfaces
 - `clip_plane` (string, default `""`) — `x`, `y`, or `z`; clips each mesh at its bounding-box midpoint to expose internal geometry (bores, wall thickness)
 


### PR DESCRIPTION
## Summary

- **README**: all MCP config blocks now use `uvx build123d-mcp` (no clone or `cwd` needed); installation simplified to `pip install` / `uvx`; version corrected to v0.1.0; `show()` arg order fixed
- **llms.md / default_prompt.md**: fix `show(shape, name)` arg order throughout; document `render_view` `name:color` syntax for explicit colour overrides
- **SPEC.md**: add historical notice — it predates snapshots, interference, pyvista rendering, and the PyPI packaging; redirects to `llms.md` and `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)