### PR TITLE
Add part library: search_library and load_part tools

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -20,20 +20,20 @@ _library_index: _LibraryIndex | None = None
 
 @mcp.tool()
 def execute(code: str) -> str:
-    """Execute build123d Python code in the persistent session. Use show(shape, name) to register named objects; name is optional and defaults to 'shape'."""
+    """Execute build123d Python code in the persistent session. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure(topology) or measure(volume) to confirm it succeeded before calling render_view."""
     return execute_code(_session, code)
 
 
 @mcp.tool()
 def render_view(direction: str = "iso", objects: str = "", quality: str = "standard", clip_plane: str = "", clip_at: float = None, azimuth: float = 0.0, elevation: float = 0.0, save_to: str = "") -> Image:
-    """Render model as PNG. direction: top, front, side, iso. objects: comma-separated names or name:color pairs e.g. 'u_frame:blue,roller:red' (default: all, auto-coloured). quality: standard, high. clip_plane: x, y, z to slice; clip_at: absolute world coordinate along that axis (default: each mesh's midpoint). azimuth/elevation: camera rotation in degrees applied after the direction preset. save_to: optional file path to save the PNG (extension auto-appended if omitted)."""
+    """Render model as PNG. Renders confirm appearance, not geometry — verify boolean operations with measure() before rendering. direction: top, front, side, iso. objects: comma-separated names or name:color pairs e.g. 'u_frame:blue,roller:red' (default: all, auto-coloured). quality: standard, high. clip_plane: x, y, z to slice; clip_at: absolute world coordinate along that axis (default: each mesh's midpoint). azimuth/elevation: camera rotation in degrees applied after the direction preset. save_to: optional file path to save the PNG (extension auto-appended if omitted)."""
     png_bytes = render_view_fn(_session, direction, objects, quality, clip_plane, clip_at, azimuth, elevation, save_to)
     return Image(data=png_bytes, format="png")
 
 
 @mcp.tool()
 def measure(query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
-    """Query geometry. query: bounding_box, volume, area, min_wall_thickness, clearance, topology. topology returns face/edge/vertex counts — use it to verify a boolean cut happened. object_name/object_name2: named objects from show() (clearance requires both)."""
+    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
     return measure_fn(_session, query, object_name, object_name2)
 
 
@@ -102,6 +102,48 @@ def reset() -> str:
     return "Session reset."
 
 
+@mcp.tool()
+def workflow_hints() -> str:
+    """Return guidance on how to use these tools effectively. Call this at the start of a session or whenever unsure which tool to reach for."""
+    return """\
+BUILD123D-MCP WORKFLOW GUIDE
+
+1. MEASURE BEFORE YOU LOOK
+   After building or modifying geometry, verify with measure() before calling render_view.
+   Numbers are unambiguous; renders can look correct even when the geometry is wrong.
+   Recommended order: execute → measure → render_view (if you need to see it).
+
+2. VERIFY BOOLEAN OPERATIONS WITH TOPOLOGY
+   After any cut, union, or intersection, call measure(topology) on the result.
+   A successful boolean changes face/edge/vertex counts; a failed one leaves them unchanged.
+   measure(volume) confirms the magnitude of the change.
+
+3. MEASURE THE OBJECT IN QUESTION — NOT A PROXY
+   When debugging, call measure() on the actual disputed object.
+   Testing an isolated reconstruction and using that as proof of the full assembly is a
+   common mistake — the two may differ in ways that matter.
+
+4. NAME AND AUDIT YOUR SHAPES
+   Use show(shape, "name") after creating important geometry.
+   The execute() output immediately confirms name, volume, and face count.
+   Call list_objects() any time to see all registered shapes and their geometry.
+
+5. CHECKPOINT BEFORE EXPERIMENTS
+   Call save_snapshot("name") before any operation you might want to undo.
+   Snapshots are instant. restore_snapshot("name") reverts geometry without re-running code.
+
+6. CROSS-SECTIONS FOR INTERNAL GEOMETRY
+   render_view with clip_plane + clip_at reveals interior features.
+   Use clip_at to position the cut at a specific world coordinate, not just the midpoint.
+   Combine with measure(topology) on the unclipped shape to confirm what you see.
+
+7. PART LIBRARY
+   search_library("keyword") returns full parameter specs.
+   Call load_part("name", '{"param": value}') immediately — no second lookup needed.
+   Unspecified parameters use the defaults shown in search results.
+"""
+
+
 def main():
     import argparse
     import os
@@ -131,6 +173,7 @@ Available tools:
   load_part         Load a named part with optional parameter overrides (requires --library)
   save_snapshot     Save a named geometric checkpoint
   restore_snapshot  Restore geometry from a named checkpoint
+  workflow_hints    Return guidance on using these tools effectively
   reset             Clear the session (namespace, shapes, snapshots)
 
 Part library file format (Python, any .py file under --library path):

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -7,9 +7,15 @@ from build123d_mcp.tools.measure import measure as measure_fn
 from build123d_mcp.tools.export import export_file
 from build123d_mcp.tools.interference import interference as interference_fn
 from build123d_mcp.tools.list_objects import list_objects as list_objects_fn
+from build123d_mcp.tools.library import (
+    _LibraryIndex,
+    search_library as search_library_fn,
+    load_part as load_part_fn,
+)
 
 mcp = FastMCP("build123d-mcp")
 _session = Session()
+_library_index: _LibraryIndex | None = None
 
 
 @mcp.tool()
@@ -41,6 +47,22 @@ def export(filename: str, format: str = "step", object_name: str = "") -> str:
 def interference(object_a: str, object_b: str) -> str:
     """Check whether two named objects (from show()) intersect. Returns interferes (bool), volume (mm³ of overlap), and bounds of the interference region."""
     return interference_fn(_session, object_a, object_b)
+
+
+@mcp.tool()
+def search_library(query: str = "") -> str:
+    """Search the part library. query: keywords matched against name, description, tags, category (empty returns all). Returns name, category, description, tags, and full parameter specs including types, defaults, and descriptions."""
+    if _library_index is None:
+        return "No part library configured. Start the server with --library PATH or set BUILD123D_PART_LIBRARY."
+    return search_library_fn(_library_index, query)
+
+
+@mcp.tool()
+def load_part(name: str, params: str = "") -> str:
+    """Load a named part from the library into the session. name: part name from search_library. params: optional JSON object of parameter overrides e.g. '{\"od\": 8.0, \"length\": 20.0}' — unspecified params use their defaults. The part is registered as a named object and becomes current_shape."""
+    if _library_index is None:
+        return "No part library configured. Start the server with --library PATH or set BUILD123D_PART_LIBRARY."
+    return load_part_fn(_session, _library_index, name, params)
 
 
 @mcp.tool()
@@ -82,6 +104,7 @@ def reset() -> str:
 
 def main():
     import argparse
+    import os
     parser = argparse.ArgumentParser(
         prog="build123d-mcp",
         description="MCP server for interactive 3D CAD via build123d. Communicates over stdio.",
@@ -92,7 +115,7 @@ MCP client configuration example:
     "mcpServers": {
       "build123d": {
         "command": "uvx",
-        "args": ["build123d-mcp"]
+        "args": ["build123d-mcp", "--library", "/path/to/parts"]
       }
     }
   }
@@ -104,12 +127,38 @@ Available tools:
   export            Export model to STEP or STL
   interference      Check intersection volume between two named shapes
   list_objects      List all named shapes with volume, faces, edges, vertices
+  search_library    Search the part library by keyword (requires --library)
+  load_part         Load a named part with optional parameter overrides (requires --library)
   save_snapshot     Save a named geometric checkpoint
   restore_snapshot  Restore geometry from a named checkpoint
   reset             Clear the session (namespace, shapes, snapshots)
+
+Part library file format (Python, any .py file under --library path):
+  PART_INFO = {
+      "description": "Short description",
+      "tags": ["tag1", "tag2"],
+      "parameters": {
+          "width": {"type": "float", "default": 10.0, "description": "width mm"},
+      }
+  }
+  from build123d import *
+  def make(width=10.0):
+      return Box(width, width, width)
 """,
     )
-    parser.parse_args()
+    parser.add_argument(
+        "--library", metavar="PATH",
+        default=os.environ.get("BUILD123D_PART_LIBRARY", ""),
+        help="Path to part library directory (overrides BUILD123D_PART_LIBRARY env var)",
+    )
+    args = parser.parse_args()
+
+    if args.library:
+        if not os.path.isdir(args.library):
+            parser.error(f"Library path is not a directory: {args.library}")
+        global _library_index
+        _library_index = _LibraryIndex(args.library)
+
     mcp.run()
 
 

--- a/src/build123d_mcp/tools/library.py
+++ b/src/build123d_mcp/tools/library.py
@@ -1,0 +1,155 @@
+import ast
+import json
+import os
+import time
+
+
+def _extract_part_info(source: str) -> dict:
+    """Extract PART_INFO dict from module source using AST literal_eval (no exec)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "PART_INFO":
+                    try:
+                        return ast.literal_eval(node.value)
+                    except Exception:
+                        pass
+    return {}
+
+
+class _LibraryIndex:
+    def __init__(self, library_path: str):
+        self.library_path = os.path.realpath(library_path)
+        self._index: dict = {}
+        self._last_scan: float = 0.0
+
+    def _needs_rescan(self) -> bool:
+        for dirpath, _, filenames in os.walk(self.library_path):
+            for filename in filenames:
+                if filename.endswith(".py"):
+                    mtime = os.path.getmtime(os.path.join(dirpath, filename))
+                    if mtime > self._last_scan:
+                        return True
+        return False
+
+    def ensure_fresh(self):
+        if self._needs_rescan():
+            self._scan()
+
+    def _scan(self):
+        new_index = {}
+        for dirpath, _, filenames in os.walk(self.library_path):
+            for filename in sorted(filenames):
+                if not filename.endswith(".py"):
+                    continue
+                filepath = os.path.join(dirpath, filename)
+                name = os.path.splitext(filename)[0]
+                rel = os.path.relpath(dirpath, self.library_path)
+                category = "" if rel == "." else rel
+                try:
+                    with open(filepath) as f:
+                        source = f.read()
+                    info = _extract_part_info(source)
+                except Exception as e:
+                    info = {"description": f"Error reading part: {e}", "tags": [], "parameters": {}}
+                new_index[name] = {
+                    "name": name,
+                    "category": category,
+                    "path": filepath,
+                    "mtime": os.path.getmtime(filepath),
+                    "description": info.get("description", ""),
+                    "tags": info.get("tags", []),
+                    "parameters": info.get("parameters", {}),
+                }
+        self._index = new_index
+        self._last_scan = time.time()
+
+    def search(self, query: str) -> list:
+        self.ensure_fresh()
+        parts = self._index.values()
+        if not query.strip():
+            return [_public(p) for p in parts]
+        terms = query.lower().split()
+        results = []
+        for part in parts:
+            text = " ".join([
+                part["name"],
+                part["description"],
+                part["category"],
+                " ".join(part["tags"]),
+            ]).lower()
+            if all(term in text for term in terms):
+                results.append(_public(part))
+        return results
+
+    def get(self, name: str):
+        self.ensure_fresh()
+        return self._index.get(name)
+
+
+def _public(part: dict) -> dict:
+    return {
+        "name": part["name"],
+        "category": part["category"],
+        "description": part["description"],
+        "tags": part["tags"],
+        "parameters": part["parameters"],
+    }
+
+
+def search_library(index: _LibraryIndex, query: str = "") -> str:
+    results = index.search(query)
+    if not results:
+        msg = f"No parts found matching '{query}'." if query.strip() else "Part library is empty."
+        return msg
+    return json.dumps(results, indent=2)
+
+
+def load_part(session, index: _LibraryIndex, name: str, params: str = "") -> str:
+    entry = index.get(name)
+    if entry is None:
+        available = sorted(index._index.keys())
+        raise ValueError(f"Unknown part '{name}'. Available: {available}")
+
+    overrides = {}
+    if params.strip():
+        try:
+            overrides = json.loads(params)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid params JSON: {e}")
+
+    # Merge defaults from PART_INFO with caller overrides
+    final_params = {}
+    for param_name, spec in entry["parameters"].items():
+        final_params[param_name] = overrides.pop(param_name, spec.get("default"))
+    if overrides:
+        raise ValueError(
+            f"Unknown parameters: {list(overrides.keys())}. "
+            f"Expected: {list(entry['parameters'].keys())}"
+        )
+
+    # Execute part file in isolated restricted namespace
+    from build123d_mcp.security import make_restricted_builtins
+    with open(entry["path"]) as f:
+        source = f.read()
+    namespace = {"__builtins__": make_restricted_builtins()}
+    exec(compile(source, entry["path"], "exec"), namespace)  # noqa: S102
+
+    if "make" not in namespace:
+        raise ValueError(f"Part '{name}' has no make() function.")
+
+    shape = namespace["make"](**final_params)
+
+    session.objects[name] = shape
+    session.current_shape = shape
+
+    try:
+        vol = shape.volume
+        faces = len(shape.faces())
+        return f"Loaded '{name}': volume={vol:.4g} mm³, faces={faces}. Parameters: {final_params}"
+    except Exception:
+        return f"Loaded '{name}'. Parameters: {final_params}"

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,248 @@
+import json
+import os
+import time
+
+import pytest
+
+from build123d_mcp.session import Session
+from build123d_mcp.tools.library import _LibraryIndex, load_part, search_library
+
+# --- fixture helpers ---
+
+PART_BOX = """\
+PART_INFO = {
+    "description": "A parametric box",
+    "tags": ["basic", "box"],
+    "parameters": {
+        "width":  {"type": "float", "default": 10.0, "description": "width mm"},
+        "height": {"type": "float", "default": 5.0,  "description": "height mm"},
+    }
+}
+from build123d import *
+def make(width=10.0, height=5.0):
+    return Box(width, width, height)
+"""
+
+PART_CYLINDER = """\
+PART_INFO = {
+    "description": "A simple cylinder",
+    "tags": ["basic", "round"],
+    "parameters": {
+        "radius": {"type": "float", "default": 3.0, "description": "radius mm"},
+        "height": {"type": "float", "default": 8.0, "description": "height mm"},
+    }
+}
+from build123d import *
+def make(radius=3.0, height=8.0):
+    return Cylinder(radius, height)
+"""
+
+# Part with no PART_INFO — still has make(), just no searchable metadata
+PART_BARE = """\
+from build123d import *
+def make():
+    return Box(2, 2, 2)
+"""
+
+# Part with no make() — should fail on load
+PART_NO_MAKE = """\
+PART_INFO = {"description": "broken part", "tags": [], "parameters": {}}
+from build123d import *
+result = Box(1, 1, 1)
+"""
+
+
+@pytest.fixture
+def lib_dir(tmp_path):
+    """Library with two parts at root and one in a subdirectory."""
+    (tmp_path / "box.py").write_text(PART_BOX)
+    (tmp_path / "cylinder.py").write_text(PART_CYLINDER)
+    sub = tmp_path / "hardware"
+    sub.mkdir()
+    (sub / "bare.py").write_text(PART_BARE)
+    return tmp_path
+
+
+@pytest.fixture
+def index(lib_dir):
+    return _LibraryIndex(str(lib_dir))
+
+
+@pytest.fixture
+def session():
+    s = Session()
+    s.execute("from build123d import *")
+    return s
+
+
+# --- scanning ---
+
+def test_scan_finds_root_parts(index):
+    index.ensure_fresh()
+    assert "box" in index._index
+    assert "cylinder" in index._index
+
+
+def test_scan_finds_subdirectory_part(index):
+    index.ensure_fresh()
+    assert "bare" in index._index
+    assert index._index["bare"]["category"] == "hardware"
+
+
+def test_scan_ignores_non_py_files(tmp_path):
+    (tmp_path / "readme.txt").write_text("not a part")
+    (tmp_path / "box.py").write_text(PART_BOX)
+    idx = _LibraryIndex(str(tmp_path))
+    idx.ensure_fresh()
+    assert list(idx._index.keys()) == ["box"]
+
+
+def test_scan_extracts_metadata(index):
+    index.ensure_fresh()
+    part = index._index["box"]
+    assert part["description"] == "A parametric box"
+    assert "box" in part["tags"]
+    assert "width" in part["parameters"]
+    assert part["parameters"]["width"]["default"] == 10.0
+
+
+def test_scan_part_without_part_info(index):
+    index.ensure_fresh()
+    bare = index._index["bare"]
+    assert bare["description"] == ""
+    assert bare["tags"] == []
+    assert bare["parameters"] == {}
+
+
+# --- mtime invalidation ---
+
+def test_mtime_triggers_rescan(tmp_path):
+    (tmp_path / "box.py").write_text(PART_BOX)
+    idx = _LibraryIndex(str(tmp_path))
+    idx.ensure_fresh()
+    assert "cylinder" not in idx._index
+
+    # Write a new file and backdate _last_scan so mtime check fires
+    (tmp_path / "cylinder.py").write_text(PART_CYLINDER)
+    idx._last_scan = 0.0  # force rescan
+    idx.ensure_fresh()
+    assert "cylinder" in idx._index
+
+
+def test_no_rescan_when_nothing_changed(tmp_path):
+    (tmp_path / "box.py").write_text(PART_BOX)
+    idx = _LibraryIndex(str(tmp_path))
+    idx.ensure_fresh()
+    scan_time = idx._last_scan
+    idx.ensure_fresh()
+    assert idx._last_scan == scan_time  # no re-scan happened
+
+
+# --- search ---
+
+def test_search_empty_returns_all(index):
+    results = index.search("")
+    names = {r["name"] for r in results}
+    assert {"box", "cylinder", "bare"} == names
+
+
+def test_search_by_keyword(index):
+    results = index.search("box")
+    assert any(r["name"] == "box" for r in results)
+    assert all(r["name"] != "cylinder" for r in results)
+
+
+def test_search_by_tag(index):
+    results = index.search("round")
+    assert len(results) == 1
+    assert results[0]["name"] == "cylinder"
+
+
+def test_search_by_category(index):
+    results = index.search("hardware")
+    assert len(results) == 1
+    assert results[0]["name"] == "bare"
+
+
+def test_search_no_match(index):
+    results = index.search("nonexistent_xyz")
+    assert results == []
+
+
+def test_search_returns_parameter_specs(index):
+    results = index.search("box")
+    box = next(r for r in results if r["name"] == "box")
+    assert "width" in box["parameters"]
+    assert box["parameters"]["width"]["default"] == 10.0
+
+
+def test_search_library_empty_message(tmp_path):
+    idx = _LibraryIndex(str(tmp_path))
+    result = search_library(idx, "")
+    assert "empty" in result.lower()
+
+
+def test_search_library_no_match_message(index):
+    result = search_library(index, "xyz_not_found")
+    assert "No parts found" in result
+
+
+def test_search_library_returns_json(index):
+    result = search_library(index, "box")
+    data = json.loads(result)
+    assert isinstance(data, list)
+    assert data[0]["name"] == "box"
+
+
+# --- load_part ---
+
+def test_load_part_default_params(session, index):
+    result = load_part(session, index, "box")
+    assert "box" in session.objects
+    assert abs(session.objects["box"].volume - 500.0) < 1.0  # 10*10*5
+
+
+def test_load_part_with_override(session, index):
+    load_part(session, index, "box", '{"width": 20.0}')
+    # 20*20*5 = 2000
+    assert abs(session.objects["box"].volume - 2000.0) < 1.0
+
+
+def test_load_part_sets_current_shape(session, index):
+    load_part(session, index, "cylinder")
+    assert session.current_shape is session.objects["cylinder"]
+
+
+def test_load_part_returns_feedback(session, index):
+    result = load_part(session, index, "box")
+    assert "box" in result
+    assert "volume" in result
+    assert "faces" in result
+
+
+def test_load_part_bare_no_params(session, index):
+    result = load_part(session, index, "bare")
+    assert "bare" in session.objects
+    assert abs(session.objects["bare"].volume - 8.0) < 0.1  # 2*2*2
+
+
+def test_load_part_unknown_raises(session, index):
+    with pytest.raises(ValueError, match="Unknown part"):
+        load_part(session, index, "nonexistent")
+
+
+def test_load_part_bad_json_raises(session, index):
+    with pytest.raises(ValueError, match="Invalid params JSON"):
+        load_part(session, index, "box", "{not valid json")
+
+
+def test_load_part_unknown_param_raises(session, index):
+    with pytest.raises(ValueError, match="Unknown parameters"):
+        load_part(session, index, "box", '{"totally_wrong": 1.0}')
+
+
+def test_load_part_no_make_raises(tmp_path, session):
+    (tmp_path / "broken.py").write_text(PART_NO_MAKE)
+    idx = _LibraryIndex(str(tmp_path))
+    with pytest.raises(ValueError, match="no make\\(\\) function"):
+        load_part(session, idx, "broken")

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -345,7 +345,8 @@ def test_mcp_lists_all_tools():
 
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
-                     "save_snapshot", "restore_snapshot", "interference", "list_objects"}
+                     "save_snapshot", "restore_snapshot", "interference", "list_objects",
+                     "search_library", "load_part"}
 
 
 def test_mcp_execute_and_measure_round_trip():

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -346,7 +346,7 @@ def test_mcp_lists_all_tools():
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "interference", "list_objects",
-                     "search_library", "load_part"}
+                     "search_library", "load_part", "workflow_hints"}
 
 
 def test_mcp_execute_and_measure_round_trip():


### PR DESCRIPTION
## Summary

- **`search_library(query)`** — keyword search against name, description, tags, and category. Empty query returns all parts. Returns full parameter specs (type, default, description) so `load_part` can be called immediately without a follow-up lookup.
- **`load_part(name, params)`** — loads a named part into the session with optional JSON parameter overrides. Unspecified params use their PART_INFO defaults. Shape registered as a named object and set as current_shape.
- **`--library PATH`** CLI flag (or `BUILD123D_PART_LIBRARY` env var) to configure the library directory.

## Design decisions

- `PART_INFO` dict (not docstring parsing) — reliable, explicit, zero-ambiguity
- Metadata extracted via `ast.literal_eval` during scan — no exec on untrusted files
- Mtime-based auto-invalidation — library files are rescanned automatically when changed, no manual `scan_library` call needed
- Subdirectory = category: `hardware/bolt.py` → `category: "hardware"`
- `load_part` executes each file in an isolated restricted namespace — library code never pollutes the session namespace
- Tools return a clear message when no library is configured

## Part file format

```python
PART_INFO = {
    "description": "Hex standoff for PCB mounting",
    "tags": ["fastener", "hardware"],
    "parameters": {
        "od":     {"type": "float", "default": 6.0,  "description": "outer diameter mm"},
        "length": {"type": "float", "default": 10.0, "description": "height mm"},
    }
}
from build123d import *
def make(od=6.0, length=10.0):
    ...
    return result
```

## Test plan

- [ ] `uv run pytest tests/` — 144 tests, all passing
- [ ] `build123d-mcp --help` shows `--library` flag and part file format
- [ ] `search_library("")` returns all parts; keyword search filters correctly
- [ ] `load_part("box")` with defaults; `load_part("box", '{"width": 20}')` with override

🤖 Generated with [Claude Code](https://claude.com/claude-code)