### PR TITLE
Fix worker crash paths returning str where bytes expected

### DIFF
--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -155,7 +155,7 @@ class WorkerSession:
     def _call(self, op: str, args: dict, timeout: int) -> Any:
         if not self._proc.is_alive():
             self._start_worker()
-            return "Error: Worker crashed; session restarted. Re-run your setup code."
+            raise RuntimeError("Worker crashed; session restarted. Re-run your setup code.")
 
         self._conn.send({"op": op, "args": args})
 
@@ -173,7 +173,7 @@ class WorkerSession:
             response = self._conn.recv()
         except EOFError:
             self._start_worker()
-            return "Error: Worker process crashed unexpectedly; session restarted."
+            raise RuntimeError("Worker process crashed unexpectedly; session restarted.")
 
         if response["ok"]:
             return response["result"]
@@ -182,7 +182,10 @@ class WorkerSession:
     # --- Session-compatible interface ---
 
     def execute(self, code: str) -> str:
-        return self._call("execute", {"code": code}, self._exec_timeout)
+        try:
+            return self._call("execute", {"code": code}, self._exec_timeout)
+        except RuntimeError as e:
+            return f"Error: {e}"
 
     def render_view(
         self,

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -182,9 +182,10 @@ class WorkerSession:
     # --- Session-compatible interface ---
 
     def execute(self, code: str) -> str:
+        from build123d_mcp.security import ExecutionTimeout
         try:
             return self._call("execute", {"code": code}, self._exec_timeout)
-        except RuntimeError as e:
+        except (RuntimeError, ExecutionTimeout) as e:
             return f"Error: {e}"
 
     def render_view(


### PR DESCRIPTION
Fixes #22.

`_call()` had two crash-recovery paths that returned plain strings. For `execute()` this was fine, but `render_view()` is typed `-> bytes` and `server.py` immediately passes the result to `Image(data=..., format="png")` — passing a str there raises a TypeError.

**Fix:** `_call()` now always raises `RuntimeError` on crash. `execute()` catches `RuntimeError` and formats it as an error string, matching `Session.execute()` behaviour. All other callers let the exception propagate naturally.

## Test plan
- [x] `uv run pytest tests/` — 146/146 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)