### PR TITLE
Fix library name collision for same-named parts in different subdirs

### DIFF
--- a/src/build123d_mcp/tools/library.py
+++ b/src/build123d_mcp/tools/library.py
@@ -48,9 +48,10 @@ class _LibraryIndex:
                 if not filename.endswith(".py"):
                     continue
                 filepath = os.path.join(dirpath, filename)
-                name = os.path.splitext(filename)[0]
+                stem = os.path.splitext(filename)[0]
                 rel = os.path.relpath(dirpath, self.library_path)
                 category = "" if rel == "." else rel
+                name = f"{category}/{stem}" if category else stem
                 try:
                     with open(filepath) as f:
                         source = f.read()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -85,8 +85,8 @@ def test_scan_finds_root_parts(index):
 
 def test_scan_finds_subdirectory_part(index):
     index.ensure_fresh()
-    assert "bare" in index._index
-    assert index._index["bare"]["category"] == "hardware"
+    assert "hardware/bare" in index._index
+    assert index._index["hardware/bare"]["category"] == "hardware"
 
 
 def test_scan_ignores_non_py_files(tmp_path):
@@ -108,7 +108,7 @@ def test_scan_extracts_metadata(index):
 
 def test_scan_part_without_part_info(index):
     index.ensure_fresh()
-    bare = index._index["bare"]
+    bare = index._index["hardware/bare"]
     assert bare["description"] == ""
     assert bare["tags"] == []
     assert bare["parameters"] == {}
@@ -143,7 +143,7 @@ def test_no_rescan_when_nothing_changed(tmp_path):
 def test_search_empty_returns_all(index):
     results = index.search("")
     names = {r["name"] for r in results}
-    assert {"box", "cylinder", "bare"} == names
+    assert {"box", "cylinder", "hardware/bare"} == names
 
 
 def test_search_by_keyword(index):
@@ -161,7 +161,7 @@ def test_search_by_tag(index):
 def test_search_by_category(index):
     results = index.search("hardware")
     assert len(results) == 1
-    assert results[0]["name"] == "bare"
+    assert results[0]["name"] == "hardware/bare"
 
 
 def test_search_no_match(index):
@@ -221,9 +221,9 @@ def test_load_part_returns_feedback(session, index):
 
 
 def test_load_part_bare_no_params(session, index):
-    result = load_part(session, index, "bare")
-    assert "bare" in session.objects
-    assert abs(session.objects["bare"].volume - 8.0) < 0.1  # 2*2*2
+    result = load_part(session, index, "hardware/bare")
+    assert "hardware/bare" in session.objects
+    assert abs(session.objects["hardware/bare"].volume - 8.0) < 0.1  # 2*2*2
 
 
 def test_load_part_unknown_raises(session, index):


### PR DESCRIPTION
Fixes #23.

`_scan()` used the bare filename stem as the index key (`name = os.path.splitext(filename)[0]`). Two parts in different subdirectories with the same filename (e.g. `bearings/m3.py` and `fasteners/m3.py`) would silently overwrite each other in the index.

**Fix:** Use `"category/stem"` as the key when the file is in a subdirectory. Root-level parts are unaffected (key stays as bare stem).

Tests updated to use the new `"hardware/bare"` key format for the fixture part that lives in a subdirectory.

## Test plan
- [x] `uv run pytest tests/test_library.py` — 25/25 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)