### PR TITLE
Fix save/restore_snapshot listing current_shape when None

### DIFF
--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -78,7 +78,7 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
     if op == "save_snapshot":
         name = args["name"]
         session.save_snapshot(name)
-        saved = ["current_shape"] + list(session.snapshots[name]["objects"].keys())
+        saved = (["current_shape"] if session.current_shape is not None else []) + list(session.snapshots[name]["objects"].keys())
         return f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
 
     if op == "restore_snapshot":
@@ -87,7 +87,7 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
             session.restore_snapshot(name)
         except KeyError as e:
             return f"Error: {e}"
-        restored = ["current_shape"] + list(session.objects.keys())
+        restored = (["current_shape"] if session.current_shape is not None else []) + list(session.objects.keys())
         return f"Snapshot '{name}' restored. Active geometry: {', '.join(restored) if restored else 'none'}."
 
     if op == "reset":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -408,6 +408,25 @@ def test_reset_clears_snapshots(session):
     assert not session.snapshots
 
 
+def test_dispatch_save_snapshot_no_shape_omits_current_shape():
+    from build123d_mcp.session import Session
+    from build123d_mcp.worker import _dispatch
+    s = Session()
+    msg = _dispatch(s, "save_snapshot", {"name": "empty"}, None)
+    assert "current_shape" not in msg
+    assert "none" in msg.lower()
+
+
+def test_dispatch_restore_snapshot_no_shape_omits_current_shape():
+    from build123d_mcp.session import Session
+    from build123d_mcp.worker import _dispatch
+    s = Session()
+    _dispatch(s, "save_snapshot", {"name": "empty"}, None)
+    msg = _dispatch(s, "restore_snapshot", {"name": "empty"}, None)
+    assert "current_shape" not in msg
+    assert "none" in msg.lower()
+
+
 def test_namespace_preserved_after_restore(session):
     execute_code(session, "x = 42")
     session.save_snapshot("s1")


### PR DESCRIPTION
Fixes #24.

Both snapshot dispatch paths unconditionally prepended `"current_shape"` to the reported geometry list:

```python
saved = ["current_shape"] + list(session.snapshots[name]["objects"].keys())
```

If no code had run yet (`current_shape is None`), the message still said `"Geometry captured: current_shape"` — misleading since nothing was actually captured.

**Fix:** `"current_shape"` is now only included when `session.current_shape is not None`.

## Test plan
- [x] `uv run pytest tests/ -k snapshot` — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)