### PR TITLE
Add AST check to load_part for consistency with execute

### DIFF
--- a/src/build123d_mcp/tools/library.py
+++ b/src/build123d_mcp/tools/library.py
@@ -135,9 +135,10 @@ def load_part(session, index: _LibraryIndex, name: str, params: str = "") -> str
         )
 
     # Execute part file in isolated restricted namespace
-    from build123d_mcp.security import make_restricted_builtins
+    from build123d_mcp.security import check_ast, make_restricted_builtins
     with open(entry["path"]) as f:
         source = f.read()
+    check_ast(source)
     namespace: dict[str, Any] = {"__builtins__": make_restricted_builtins()}
     exec(compile(source, entry["path"], "exec"), namespace)  # noqa: S102
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -246,3 +246,10 @@ def test_load_part_no_make_raises(tmp_path, session):
     idx = _LibraryIndex(str(tmp_path))
     with pytest.raises(ValueError, match="no make\\(\\) function"):
         load_part(session, idx, "broken")
+
+
+def test_load_part_blocked_import_raises(tmp_path, session):
+    (tmp_path / "evil.py").write_text("import os\ndef make(): pass")
+    idx = _LibraryIndex(str(tmp_path))
+    with pytest.raises(ValueError, match="not allowed"):
+        load_part(session, idx, "evil")


### PR DESCRIPTION
Fixes #25.

`load_part` exec'd part files applying only restricted builtins (layer 2) but skipping the AST inspection (layer 1). User-submitted code hits both layers; part files only hit one — an unnecessary inconsistency.

**Fix:** Call `check_ast(source)` before `exec` in `load_part`, matching the defence applied to user code.

Added `test_load_part_blocked_import_raises` to verify a part file containing `import os` is rejected.

## Test plan
- [x] `uv run pytest tests/test_library.py` — 26/26 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)