### PR TITLE
Use spawn context Pipe() instead of default multiprocessing.Pipe()

### DIFF
--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -128,8 +128,8 @@ class WorkerSession:
         self._start_worker()
 
     def _start_worker(self) -> None:
-        parent_conn, child_conn = multiprocessing.Pipe()
         ctx = multiprocessing.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe()
         self._proc = ctx.Process(
             target=worker_main,
             args=(child_conn, self._library_path),


### PR DESCRIPTION
Fixes #27.

`_start_worker()` created the pipe from the default multiprocessing context but the process from the spawn context. Now both use `ctx.Pipe()`.

Functionally equivalent today (OS pipes are context-agnostic), but eliminates the inconsistency.

## Test plan
- [x] `uv run pytest tests/` — 149/149 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)