### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## v0.3.0 (unreleased)
+
+### Security
+
+- Block subclass-traversal sandbox escapes at AST level: dunder attribute access (`__class__`, `__bases__`, `__subclasses__`, etc.) is now rejected by the AST check, and `getattr`/`vars`/`dir`/`hasattr` are removed from both the AST-level blocklist and the restricted builtins. Closes the most common prompt-injection escape paths without affecting normal build123d usage (operator overloading uses bytecode ops, not explicit dunder access).
+- Add AST check to `load_part` for consistency with `execute` — library part code now goes through the same security validation as user-submitted code.
+
+### Architecture
+
+- Replace fork-per-call worker with a persistent subprocess. The worker process now stays alive across calls; the session (namespace, shapes, snapshots) persists in the worker. On timeout the worker is killed and restarted with a fresh session. This eliminates per-call fork overhead and makes timeout behaviour deterministic.
+- Use `spawn` context `Pipe()` instead of the default `multiprocessing.Pipe()` for cross-platform reliability.
+
+### Bug fixes
+
+- Fix worker crash paths that returned `str` where `bytes` were expected, causing cascading errors after a crash.
+- Fix library name collision when two parts in different subdirectories share the same filename.
+- Fix `save_snapshot` / `restore_snapshot` incorrectly listing `current_shape` in the captured geometry when it was `None`.
+
+### Performance
+
+- Reduce `_needs_rescan` syscall overhead with a directory mtime fast path — the library index skips a full directory walk when the mtime is unchanged.
+
+---
+
+## v0.2.0
+
+### Features
+
+- Add part library: `search_library` and `load_part` tools for parametric part reuse.
+- Add topology queries to `measure` (`face_count`, `edge_count`, `vertex_count`, `shell_count`, `solid_count`, `compound_count`).
+- Add arbitrary camera angles to `render_view` (`azimuth`, `elevation` parameters).
+- Add positional clip plane to `render_view` (`clip_at` parameter to specify cut position rather than always bisecting at the mesh centre).
+
+### Fixes
+
+- Update docs for `src` layout, `uvx` invocation, and corrected `show()` argument order.
+
+---
+
+## v0.1.0
+
+Initial release.
+
+- MCP server with `execute`, `render_view`, `export_file`, `measure`, `interference`, `save_snapshot`, `restore_snapshot`, `reset`, `list_objects` tools.
+- Persistent session: namespace, `current_shape`, and named objects survive across `execute()` calls.
+- Three-layer security model: AST inspection, restricted builtins, execution timeout.
+- Multi-object support via `show(shape, name)`.
+- Security fixes: path traversal in `export_file`, temp-file race in `render_view`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "build123d-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## v0.3.0

Bumps version and adds CHANGELOG.md covering all changes since v0.1.0.

### What's in this release

**Security**
- Block subclass-traversal sandbox escapes (dunder attribute access, `getattr`/`vars`/`dir`/`hasattr`)
- AST check added to `load_part` for consistency with `execute`

**Architecture**
- Persistent worker subprocess (replaces fork-per-call)
- `spawn` context `Pipe()` for cross-platform reliability

**Bug fixes**
- Worker crash paths returning wrong type
- Library name collision across subdirectories
- `save/restore_snapshot` incorrectly listing `None` current_shape

**Performance**
- Directory mtime fast path reduces `_needs_rescan` syscalls

## Test plan
- [x] 149 tests passing
- [x] No open issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)