### PR TITLE
Add --version flag

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -132,6 +132,7 @@ BUILD123D-MCP WORKFLOW GUIDE
 def main():
     import argparse
     import os
+    from importlib.metadata import version
     parser = argparse.ArgumentParser(
         prog="build123d-mcp",
         description="MCP server for interactive 3D CAD via build123d. Communicates over stdio.",
@@ -174,6 +175,7 @@ Part library file format (Python, any .py file under --library path):
       return Box(width, width, width)
 """,
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {version('build123d-mcp')}")
     parser.add_argument(
         "--library", metavar="PATH",
         default=os.environ.get("BUILD123D_PART_LIBRARY", ""),


### PR DESCRIPTION
Adds `--version` to the CLI using `importlib.metadata.version()` so it always reflects the installed package version without manual string maintenance.

```
$ build123d-mcp --version
build123d-mcp 0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)