### PR TITLE
Cap requires-python at <3.14 (cadquery-ocp has no cp314 wheels)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "build123d-mcp"
 version = "0.3.0"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 license = { text = "MIT" }
 authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
 keywords = ["mcp", "build123d", "cad", "3d", "ai"]


### PR DESCRIPTION
## Summary

- Change `requires-python = ">=3.10"` to `">=3.10,<3.14"` in `pyproject.toml`

`cadquery-ocp` (pulled in transitively via `build123d`) only ships wheels for `cp310`–`cp313`. Without an upper bound, running `uvx build123d-mcp` on Python 3.14 produces a confusing resolver error about missing ABI tags rather than a clear "unsupported Python version" message.

## Test plan

- [ ] Verify `uvx --python 3.14 build123d-mcp` now fails with a clear Python version error
- [ ] Verify `uvx --python 3.13 build123d-mcp` still installs successfully