### PR TITLE
Fix TestPyPI versioning: unique dev builds + post-release patch bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+      - name: Set dev version for TestPyPI
+        if: github.event_name == 'push'
+        run: |
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          uv version "${current}.dev${{ github.run_number }}"
       - run: uv build
       - uses: actions/upload-artifact@v4
         with:
@@ -49,3 +54,30 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  bump-version:
+    needs: publish-pypi
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Bump patch version
+        run: |
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          IFS='.' read -r major minor patch <<< "$current"
+          uv version "${major}.${minor}.$((patch + 1))"
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          new_version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump version to ${new_version} after release"
+          git push


### PR DESCRIPTION
## Summary

- **On push to main**: appends `.devNNN` (GitHub run number) to the current version before building, so every commit gets a unique TestPyPI upload (e.g. `0.3.1.dev42`). Fixes the recurring `400 File already exists` failures.
- **After a release**: a new `bump-version` job runs after `publish-pypi` succeeds, increments the patch version in `pyproject.toml`, and commits it back to `main` via `GITHUB_TOKEN` (no PAT needed). This means dev builds are always one patch ahead of the last release.

## How it flows

1. Release `v0.3.0` is published → PyPI gets `0.3.0` → `bump-version` commits `0.3.1` to main
2. Next push to main → TestPyPI gets `0.3.1.dev<run_number>`
3. Release `v0.3.1` is published → PyPI gets `0.3.1` → `bump-version` commits `0.3.2` to main

## Notes

- The `GITHUB_TOKEN` push does **not** retrigger the `push` workflow (GitHub prevents recursive triggers), so no infinite loop.
- `grep`+`sed` is used to read the version rather than `uv version --short` (flag availability varies across uv versions).

## Test plan

- [ ] Merge to main and confirm TestPyPI receives a `.devNNN` build without a 400 error
- [ ] Cut a release and confirm `bump-version` job commits an incremented patch version to main