### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-## v0.3.0 (unreleased)
+## v0.3.1
+
+### Features
+
+- Add `--version` flag to the CLI (`uvx build123d-mcp --version`).
+
+### CI
+
+- Fix TestPyPI publish failures: dev builds now use a unique `.devNNN` version suffix, and the patch version is auto-bumped in `pyproject.toml` after each release.
+- Cap `requires-python` at `<3.14` to surface a clear error for Python versions where `cadquery-ocp` has no wheels.
+
+---
+
+## v0.3.0
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "build123d-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "build123d-mcp"
-version = "0.2.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
## v0.3.1

### Features
- Add `--version` flag to the CLI (`uvx build123d-mcp --version`)

### CI / packaging
- Fix TestPyPI publish failures: dev builds now use a unique `.devNNN` version suffix; patch version auto-bumps after each release
- Cap `requires-python < 3.14` to give a clear error on Python versions without `cadquery-ocp` wheels

Once merged, create a GitHub release tagged `v0.3.1` to trigger the PyPI publish.