### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## v0.3.0 (unreleased)
+## v0.3.1
+
+### Features
+
+- Add `--version` CLI flag (`build123d-mcp --version`) using `importlib.metadata`.
+
+---
+
+## v0.3.0
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "build123d-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "build123d-mcp"
-version = "0.2.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "build123d" },


### PR DESCRIPTION
## Summary
- Bump version 0.3.0 → 0.3.1
- Adds the `--version` CLI flag (#36) as the user-facing change for this release
- Finalises the v0.3.0 changelog entry (drops `(unreleased)`)

## Test plan
- [x] `uv run pytest tests/` — 149 passed
- [x] `uv run build123d-mcp --version` prints `build123d-mcp 0.3.1`
- [ ] After merge: cut GitHub release `v0.3.1` to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)