### PR TITLE
docs: pin uvx to Python 3.13 in MCP client examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Or just use `uvx` — it fetches and runs the package in one step with no prior 
 
 The server runs over stdio — the client launches it as a subprocess using `uvx build123d-mcp`.
 
+> **Note on Python version.** All examples below pass `--python 3.13` to `uvx`. The `cadquery-ocp` dependency does not yet ship wheels for Python 3.14+, so on machines where the default Python is 3.14 (recent macOS Homebrew, for example) `uvx build123d-mcp` will fail to resolve. Pinning to 3.13 makes the bare command work everywhere; uv will auto-download a managed Python 3.13 if you don't already have one.
+
 ### Claude Code
 
 Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
@@ -49,7 +51,7 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["build123d-mcp"]
+      "args": ["--python", "3.13", "build123d-mcp"]
     }
   }
 }
@@ -66,7 +68,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["build123d-mcp"]
+      "args": ["--python", "3.13", "build123d-mcp"]
     }
   }
 }
@@ -83,7 +85,7 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["build123d-mcp"]
+      "args": ["--python", "3.13", "build123d-mcp"]
     }
   }
 }
@@ -99,7 +101,7 @@ For **Continue** extension, add to `.continue/config.json`:
     {
       "name": "build123d-mcp",
       "command": "uvx",
-      "args": ["build123d-mcp"]
+      "args": ["--python", "3.13", "build123d-mcp"]
     }
   ]
 }
@@ -113,7 +115,7 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
     "build123d-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["build123d-mcp"]
+      "args": ["--python", "3.13", "build123d-mcp"]
     }
   }
 }

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -143,7 +143,7 @@ MCP client configuration example:
     "mcpServers": {
       "build123d": {
         "command": "uvx",
-        "args": ["build123d-mcp", "--library", "/path/to/parts"]
+        "args": ["--python", "3.13", "build123d-mcp", "--library", "/path/to/parts"]
       }
     }
   }


### PR DESCRIPTION
## Summary

Bare \`uvx build123d-mcp\` fails on machines where the default Python is 3.14+ (recent macOS Homebrew), because:
- \`cadquery-ocp\` has no wheels for Python 3.14
- \`uv tool run\` selects an interpreter *before* checking the package's \`requires-python\`, so our \`<3.14\` cap doesn't help here

Workaround: pass \`--python 3.13\` to \`uvx\`. uv auto-downloads a managed 3.13 if the user doesn't have one.

This PR updates the five MCP client examples (Claude Code, Claude Desktop, Cursor, Continue, VS Code Copilot) and the example shown in \`build123d-mcp --help\`.

The \`.mcp.json\` in the repo uses \`uv run\` (dev config), which goes through the project's venv where \`requires-python\` is enforced — no change needed there.

## Test plan
- [x] \`uv run build123d-mcp --help\` shows the updated example
- [ ] Verify on a Mac with default Python 3.14 that \`uvx --python 3.13 build123d-mcp\` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)