### PR TITLE
Allow writes to /tmp and $TMPDIR; reject by realpath

### DIFF
--- a/src/build123d_mcp/tools/_paths.py
+++ b/src/build123d_mcp/tools/_paths.py
@@ -1,0 +1,46 @@
+"""Shared output-path validation for file-writing tools.
+
+Allowed write roots:
+  - the current working directory (the MCP server's `cwd`)
+  - `tempfile.gettempdir()` (`$TMPDIR` on macOS, `/tmp` on most Linux)
+  - `/tmp` itself when present (covers Linux installs where `gettempdir()`
+    returns something else, and macOS where `/tmp` is a symlink to `/private/tmp`)
+
+Validation runs after `os.path.realpath()`, so symlink escapes and `..`
+traversal are rejected naturally rather than relying on textual checks.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+
+def _allowed_roots() -> list[str]:
+    roots: list[str] = [
+        os.path.realpath(os.getcwd()),
+        os.path.realpath(tempfile.gettempdir()),
+    ]
+    if os.path.isdir("/tmp"):
+        slash_tmp = os.path.realpath("/tmp")
+        if slash_tmp not in roots:
+            roots.append(slash_tmp)
+    return roots
+
+
+def safe_output_path(filename: str) -> str:
+    """Resolve `filename` and reject paths outside the allowed write roots.
+
+    Returns the resolved absolute path on success. Raises ``ValueError``
+    if the resolved path is not under one of the allowed roots — this
+    covers absolute paths to sensitive locations, `..` traversal, and
+    symlink escapes in a single check.
+    """
+    resolved = os.path.realpath(filename)
+    for root in _allowed_roots():
+        if resolved == root or resolved.startswith(root + os.sep):
+            return resolved
+    raise ValueError(
+        f"Path '{filename}' resolves to '{resolved}', "
+        f"which is outside the allowed write roots."
+    )

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -1,5 +1,4 @@
-import os
-from pathlib import PurePosixPath, PureWindowsPath
+from build123d_mcp.tools._paths import safe_output_path
 
 _VALID_FORMATS = ("step", "stl")
 
@@ -32,10 +31,6 @@ def _write_one(shape, abs_path: str, fmt: str) -> None:
 def export_file(session, filename: str, format: str = "step", object_name: str = "") -> str:
     shape = _resolve_shape(session, object_name)
 
-    # Reject absolute paths and path traversal attempts
-    if os.path.isabs(filename) or ".." in PurePosixPath(filename).parts or ".." in PureWindowsPath(filename).parts:
-        raise ValueError("Path traversal not allowed.")
-
     formats = [f.strip().lower() for f in format.split(",") if f.strip()]
     if not formats:
         raise ValueError("No format specified.")
@@ -50,7 +45,7 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
             path += ".step"
         elif fmt == "stl" and not path.lower().endswith(".stl"):
             path += ".stl"
-        abs_path = os.path.realpath(path)
+        abs_path = safe_output_path(path)
         _write_one(shape, abs_path, fmt)
         exported.append(abs_path)
 

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -1,7 +1,6 @@
 import math
 import os
 import sys
-from pathlib import PurePosixPath, PureWindowsPath
 
 _xvfb_started = False
 
@@ -321,14 +320,6 @@ def _do_render_svg(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
             return f.read()
 
 
-def _save_path_check(path: str) -> str:
-    """Validate `save_to` and return the absolute write path. Mirrors the
-    behaviour of the existing export tool."""
-    if os.path.isabs(path) or ".." in PurePosixPath(path).parts or ".." in PureWindowsPath(path).parts:
-        raise ValueError("Path traversal not allowed.")
-    return os.path.realpath(path)
-
-
 def render_view(
     session,
     direction: str = "iso",
@@ -398,16 +389,16 @@ def render_view(
         )
 
     if save_to:
-        abs_base = _save_path_check(save_to)
+        from build123d_mcp.tools._paths import safe_output_path
         # Strip a known extension so format='both' produces consistent <base>.png and <base>.svg
-        base, ext = os.path.splitext(abs_base)
+        base, ext = os.path.splitext(save_to)
         if ext.lower() in (".png", ".svg"):
-            abs_base = base
+            save_to = base
         if "png" in result:
-            with open(abs_base + ".png", "wb") as f:
+            with open(safe_output_path(save_to + ".png"), "wb") as f:
                 f.write(result["png"])
         if "svg" in result:
-            with open(abs_base + ".svg", "wb") as f:
+            with open(safe_output_path(save_to + ".svg"), "wb") as f:
                 f.write(result["svg"])
 
     return result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,6 +12,15 @@ from build123d_mcp.tools.measure import measure
 from build123d_mcp.tools.list_objects import list_objects
 from build123d_mcp.tools.render import render_view
 
+# A path guaranteed to resolve outside any allowed write root (cwd, tempdir, /tmp)
+# on each platform. /etc/passwd on POSIX; on Windows we use the system hosts file,
+# which is always present and lives under C:\Windows so realpath stays under C:\Windows.
+_OUTSIDE_ROOT_PATH = (
+    r"C:\Windows\System32\drivers\etc\hosts"
+    if sys.platform == "win32"
+    else "/etc/passwd"
+)
+
 
 @pytest.fixture
 def session():
@@ -121,6 +130,20 @@ def test_import_build123d_allowed(session):
 def test_execution_timeout(fast_session):
     result = execute_code(fast_session, "while True: pass")
     assert "timeout" in result.lower() or "time limit" in result.lower()
+
+
+def test_worker_execution_timeout():
+    """The production timeout path (WorkerSession's parent-side multiprocessing
+    poll) works on every platform, including Windows where the in-process
+    SIGALRM guard is a no-op. A `while True: pass` must return a timeout error,
+    not hang the test."""
+    from build123d_mcp.worker import WorkerSession
+    ws = WorkerSession(exec_timeout=2)
+    try:
+        result = ws.execute("while True: pass")
+        assert "timeout" in result.lower() or "time limit" in result.lower()
+    finally:
+        ws._kill_worker()
 
 
 def test_blocked_import_does_not_corrupt_shape(session):
@@ -326,15 +349,50 @@ def test_export_invalid_format(session):
 
 def test_export_path_traversal_rejected(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    with pytest.raises(ValueError, match="Path traversal"):
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
         export_file(session, "../../etc/passwd", "step")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-style absolute path; Windows uses drive-letter paths")
-def test_export_absolute_path_rejected(session):
+def test_export_outside_roots_rejected(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    with pytest.raises(ValueError, match="Path traversal"):
-        export_file(session, "/tmp/evil", "step")
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        export_file(session, _OUTSIDE_ROOT_PATH, "step")
+
+
+def test_export_to_tmp_allowed(session, tmp_path):
+    execute_code(session, "result = Box(10, 10, 10)")
+    target = tmp_path / "exported.step"
+    result = export_file(session, str(target), "step")
+    assert os.path.exists(target)
+    assert str(target) in result
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="/tmp does not exist on Windows; tempfile.gettempdir() coverage in test_export_to_tmp_allowed already runs there")
+def test_export_to_slash_tmp_allowed(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    import tempfile as _tempfile
+    with _tempfile.NamedTemporaryFile(
+        prefix="build123d_mcp_test_", suffix=".step", dir="/tmp", delete=False
+    ) as f:
+        target = f.name
+    try:
+        export_file(session, target, "step")
+        assert os.path.exists(target)
+    finally:
+        if os.path.exists(target):
+            os.unlink(target)
+
+
+def test_export_symlink_escape_rejected(session, tmp_path):
+    execute_code(session, "result = Box(10, 10, 10)")
+    link = tmp_path / "escape.step"
+    os.symlink("/etc/passwd", link)
+    try:
+        with pytest.raises(ValueError, match="outside the allowed write roots"):
+            export_file(session, str(link), "step")
+    finally:
+        if link.is_symlink():
+            link.unlink()
 
 
 # --- reset ---
@@ -624,15 +682,21 @@ def test_render_view_save_to_with_extension(session, tmp_path, monkeypatch):
 
 def test_render_view_save_to_path_traversal_rejected(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    with pytest.raises(ValueError, match="Path traversal"):
-        render_view(session, "iso", save_to="../../tmp/evil")
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        render_view(session, "iso", save_to="../../etc/passwd")
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-style absolute path; Windows uses drive-letter paths")
-def test_render_view_save_to_absolute_path_rejected(session):
+def test_render_view_save_to_outside_roots_rejected(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    with pytest.raises(ValueError, match="Path traversal"):
-        render_view(session, "iso", save_to="/tmp/evil")
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        render_view(session, "iso", save_to=_OUTSIDE_ROOT_PATH)
+
+
+def test_render_view_save_to_tmp_allowed(session, tmp_path):
+    execute_code(session, "result = Box(10, 10, 10)")
+    target = tmp_path / "render.png"
+    render_view(session, "iso", save_to=str(target))
+    assert os.path.exists(target)
 
 
 # --- show() feedback (new) ---


### PR DESCRIPTION
## Summary

- Replaces the textual absolute-path / `..`-segment check in `export.py` and `render.py` with a shared `safe_output_path()` helper that resolves the path via `os.path.realpath` and validates it against an explicit allow-list of write roots: `cwd`, `tempfile.gettempdir()`, and `/tmp`.
- Unblocks the `/tmp/<name>` workflow used by the Telegram-bot `[SEND:]` convention without weakening the defence: realpath-based checks reject `..` traversal, symlink escapes, and absolute paths to sensitive locations in a single check (the previous textual check missed symlink escapes entirely).
- Stops forcing every export/render artefact into the project working tree.

Closes #44.

## Test plan

- [x] `uv run pytest tests/` — all 153 tests pass.
- [x] Updated `test_export_path_traversal_rejected` and `test_render_view_save_to_path_traversal_rejected` to assert against the new error wording.
- [x] Replaced `test_export_absolute_path_rejected` / `test_render_view_save_to_absolute_path_rejected` (which previously pinned `/tmp/` rejection) with `*_outside_roots_rejected` tests using `/etc/passwd`.
- [x] New tests:
  - `test_export_to_tmp_allowed` — pytest's `tmp_path` (under `tempfile.gettempdir()`).
  - `test_export_to_slash_tmp_allowed` — explicit `/tmp/...` path on Linux.
  - `test_export_symlink_escape_rejected` — symlink under `/tmp/` pointing at `/etc/passwd` is rejected post-realpath.
  - `test_render_view_save_to_tmp_allowed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)