### PR TITLE
docs: changelog for v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.3.3
+
+### Bug fixes
+
+- Fix `render_view` crashing with `AttributeError: module 'pyvista' has no attribute 'start_xvfb'` under `uvx build123d-mcp` (#43). pyvista 0.48 removed the helper that the server relied on for headless Linux rendering. Replaced pyvista with direct VTK calls (already pulled in transitively via cadquery-ocp/cadquery-vtk, no install bloat); `_ensure_display()` spawns Xvfb on Linux when needed, mirroring what pyvista's helper used to do.
+- Fix `export` and `render_view(save_to=...)` rejecting `/tmp/` paths as path-traversal (#44). Writes are now allowed under the cwd, `tempfile.gettempdir()`, and `/tmp`. Validation runs against the resolved real path, so symlink escapes (e.g. `/tmp/foo` → `/etc/passwd`) are now caught — the previous textual `..` check missed them.
+
+### Features
+
+- Add `format` parameter to `render_view`: `"png"` (default), `"svg"`, or `"both"`. SVG uses build123d's HLR projection — works without a display backend at all. When `format="png"` is requested but the VTK pipeline fails (no DISPLAY, no OSMesa/EGL), the call automatically falls back to SVG so the AI still gets a visual.
+
+### CI
+
+- Add cross-platform matrix: Ubuntu, macOS, and Windows. Linux gets xvfb, Windows gets Mesa3D for offscreen rendering (via `pyvista/setup-headless-display-action`, CI-tooling only — no pyvista runtime dep). Pin Python to 3.12 in CI because vtk 9.3 has no cp313 wheel.
+
+---
+
 ## v0.3.2
 
 ### Packaging


### PR DESCRIPTION
## Summary

Changelog entry for v0.3.3 covering everything since v0.3.2:

- **Bug fix #43** — pyvista→VTK rewrite (broken `start_xvfb` after pyvista 0.48).
- **Bug fix #44** — allow writes to `/tmp` and `tempfile.gettempdir()`; switch to realpath-based validation that also catches symlink escapes.
- **Feature** — new `format` param on `render_view` (`png` / `svg` / `both`) plus auto-fallback to SVG when raster fails.
- **CI** — cross-platform matrix on Linux, macOS, Windows.

After merging, create release `v0.3.3` to trigger the PyPI publish (the workflow auto-bumps to 0.3.4 on `main` afterwards).

## Test plan

- [x] Docs-only change; no code paths touched. Existing CI matrix applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)