### PR TITLE
fix: deliver render_view images via file path instead of ImageContent

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -1,7 +1,8 @@
-import base64
+import os
+import tempfile
 
-from mcp.server.fastmcp import FastMCP, Image
-from mcp.types import ImageContent, TextContent
+from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent
 
 from build123d_mcp.worker import WorkerSession
 
@@ -26,11 +27,13 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
     )
 
     contents: list = []
-    if "png" in result:
-        contents.append(Image(data=result["png"], format="png"))
-    if "svg" in result:
-        svg_b64 = base64.b64encode(result["svg"]).decode()
-        contents.append(ImageContent(type="image", data=svg_b64, mimeType="image/svg+xml"))
+    for key, suffix in (("png", ".png"), ("svg", ".svg")):
+        if key in result:
+            fd, path = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
+            os.close(fd)
+            with open(path, "wb") as f:
+                f.write(result[key])
+            contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
     if result.get("fallback"):
         contents.append(TextContent(type="text", text=result["fallback"]))
     if result.get("png_error"):

--- a/src/build123d_mcp/tools/diff.py
+++ b/src/build123d_mcp/tools/diff.py
@@ -28,6 +28,7 @@ def _fmt_shape_diff(a: dict | None, b: dict | None, label: str) -> str | None:
     if a is None and b is None:
         return None
     if a is None:
+        assert b is not None
         return f"  {label}: (none) → volume={b['volume']} mm³, {b['faces']}f {b['edges']}e {b['vertices']}v"
     if b is None:
         return f"  {label}: volume={a['volume']} mm³ → (none)"

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -383,7 +383,7 @@ def test_mcp_execute_and_measure_round_trip():
 
 
 @_skip_mcp_on_win
-def test_mcp_render_returns_valid_png():
+def test_mcp_render_returns_file_path():
     async def run(mcp):
         await mcp.call_tool(
             "execute",
@@ -391,12 +391,15 @@ def test_mcp_render_returns_valid_png():
         )
         result = await mcp.call_tool("render_view", {"direction": "iso"})
         c = result.content[0]
-        return c.type, c.mimeType, c.data
+        return c.type, c.text
 
-    content_type, mime_type, data = asyncio.run(_mcp_session(run))
-    assert content_type == "image"
-    assert mime_type == "image/png"
-    assert base64.b64decode(data)[:8] == PNG_MAGIC
+    content_type, text = asyncio.run(_mcp_session(run))
+    assert content_type == "text"
+    path = text.removeprefix("[SEND: ").removesuffix("]")
+    assert path.endswith(".png")
+    assert os.path.exists(path)
+    with open(path, "rb") as f:
+        assert f.read(8) == PNG_MAGIC
 
 
 @_skip_mcp_on_win


### PR DESCRIPTION
## Summary

- `render_view` no longer returns `ImageContent`/`Image` binary data in the MCP tool result
- PNG and SVG are saved to `/tmp/` and returned as `[SEND: path]` text markers
- Teleclaude delivers the file directly to the user's phone without an Anthropic API round-trip
- Claude Code can inspect the image via its own `Read` tool when visual feedback is needed

## Why

Returning `ImageContent` in MCP tool results fails with `"Could not process image"` from the Anthropic API. With a Claude Code Max subscription, the `Read`-tool pathway works fine and is the correct way for Claude to access images.

Fixes #49.

## Test plan
- [x] `test_mcp_render_returns_file_path` — verifies tool returns `[SEND: /tmp/build123d_*.png]`, file exists, and contains a valid PNG
- [x] All 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)