### PR TITLE
fix: five issues from code review (Python 3.13, session state, mypy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or just use `uvx` — it fetches and runs the package in one step with no prior 
 
 The server runs over stdio — the client launches it as a subprocess using `uvx build123d-mcp`.
 
-> **Note on Python version.** All examples below pass `--python 3.13` to `uvx`. The `cadquery-ocp` dependency does not yet ship wheels for Python 3.14+, so on machines where the default Python is 3.14 (recent macOS Homebrew, for example) `uvx build123d-mcp` will fail to resolve. Pinning to 3.13 makes the bare command work everywhere; uv will auto-download a managed Python 3.13 if you don't already have one.
+> **Note on Python version.** All examples below pass `--python 3.12` to `uvx`. The `vtk` and `cadquery-ocp` dependencies do not yet ship wheels for Python 3.13+, so pinning to 3.12 is required. uv will auto-download a managed Python 3.12 if you don't already have one.
 
 ### Claude Code
 
@@ -51,7 +51,7 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["--python", "3.13", "build123d-mcp"]
+      "args": ["--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -68,7 +68,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["--python", "3.13", "build123d-mcp"]
+      "args": ["--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -85,7 +85,7 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
   "mcpServers": {
     "build123d-mcp": {
       "command": "uvx",
-      "args": ["--python", "3.13", "build123d-mcp"]
+      "args": ["--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -101,7 +101,7 @@ For **Continue** extension, add to `.continue/config.json`:
     {
       "name": "build123d-mcp",
       "command": "uvx",
-      "args": ["--python", "3.13", "build123d-mcp"]
+      "args": ["--python", "3.12", "build123d-mcp"]
     }
   ]
 }
@@ -115,7 +115,7 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
     "build123d-mcp": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["--python", "3.13", "build123d-mcp"]
+      "args": ["--python", "3.12", "build123d-mcp"]
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "build123d-mcp"
 version = "0.3.5"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.13"
 license = { text = "MIT" }
 authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
 keywords = ["mcp", "build123d", "cad", "3d", "ai"]

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -24,10 +24,13 @@ class Session:
         self.namespace["__builtins__"] = make_restricted_builtins()
         objects = self.objects
 
+        session_ref = self
+
         def show(shape: Any, name: str | None = None) -> None:
             if name is None:
                 name = "shape"
             objects[name] = shape
+            session_ref.current_shape = shape
             try:
                 vol = shape.volume
                 faces = len(shape.faces())
@@ -101,11 +104,11 @@ class Session:
                 signal.alarm(0)
                 signal.signal(signal.SIGALRM, _old_handler)
 
-        new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - keys_before
-        self._update_current_shape(new_keys)
-
         if exc is not None:
             return f"Error: {type(exc).__name__}: {exc}"
+
+        new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - keys_before
+        self._update_current_shape(new_keys)
 
         output = buf.getvalue() or "OK"
         if self.current_shape is not None and self.current_shape is not shape_before:

--- a/src/build123d_mcp/tools/diff.py
+++ b/src/build123d_mcp/tools/diff.py
@@ -28,6 +28,7 @@ def _fmt_shape_diff(a: dict | None, b: dict | None, label: str) -> str | None:
     if a is None and b is None:
         return None
     if a is None:
+        assert b is not None
         return f"  {label}: (none) → volume={b['volume']} mm³, {b['faces']}f {b['edges']}e {b['vertices']}v"
     if b is None:
         return f"  {label}: volume={a['volume']} mm³ → (none)"

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -20,14 +20,14 @@ from typing import Any
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
 
-def worker_main(conn: Any, library_path: str = "") -> None:
+def worker_main(conn: Any, library_path: str = "", exec_timeout: int = 30) -> None:
     """Entry point run in the worker subprocess.
 
     Loops receiving requests until the parent closes the connection.
     """
     from build123d_mcp.session import Session
 
-    session = Session()
+    session = Session(exec_timeout=exec_timeout)
     library_index = None
     if library_path:
         from build123d_mcp.tools.library import _LibraryIndex
@@ -136,7 +136,7 @@ class WorkerSession:
         parent_conn, child_conn = ctx.Pipe()
         self._proc = ctx.Process(
             target=worker_main,
-            args=(child_conn, self._library_path),
+            args=(child_conn, self._library_path, self._exec_timeout),
             daemon=True,
         )
         self._proc.start()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -154,6 +154,19 @@ def test_blocked_import_does_not_corrupt_shape(session):
     assert session.current_shape is shape_before
 
 
+def test_runtime_error_does_not_update_current_shape(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    shape_before = session.current_shape
+    execute_code(session, "bad = Box(5, 5, 5); raise ValueError('oops')")
+    assert session.current_shape is shape_before
+
+
+def test_show_sets_current_shape(session):
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+    assert session.current_shape is not None
+    assert session.objects.get("part") is session.current_shape
+
+
 # --- render_view ---
 
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
## Summary

Five issues flagged in code review:

- **Python 3.13 broken**: `vtk 9.3.1` has no `cp313` wheels. Cap `requires-python` to `<3.13` and update all docs/examples from `--python 3.13` to `--python 3.12`.
- **Failed execute() mutates current_shape**: `_update_current_shape` was called before the exception check, so partial code like `bad = Box(1,1,1); raise ValueError()` would update `current_shape` to `bad`. Fixed by checking `exc` first.
- **show() doesn't set current_shape**: `show(Box(10,10,10), "part")` registered the object but left `current_shape = None`, breaking subsequent `measure()`/`export()` calls. Now `show()` sets `current_shape`.
- **exec_timeout not forwarded to worker**: `WorkerSession(exec_timeout=N)` stored the value but `worker_main` always constructed `Session()` with the default. Now passed through.
- **mypy failure in diff.py**: `assert b is not None` added to satisfy the type checker (already fixed on the render PR branch too).

## Test plan
- [x] `test_runtime_error_does_not_update_current_shape` — new regression test for issue 2
- [x] `test_show_sets_current_shape` — new regression test for issue 3
- [x] All 177 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)