### PR TITLE
feat: session_state, health_check tools and diff_snapshot JSON mode

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -99,9 +99,21 @@ def restore_snapshot(name: str) -> str:
 
 
 @mcp.tool()
-def diff_snapshot(snapshot_a: str, snapshot_b: str = "") -> str:
-    """Compare two snapshots by geometry metrics (volume, topology, bounding box). snapshot_b defaults to current session state if omitted. Reports volume delta, topology changes, and added/removed/changed objects — useful for confirming that a fillet, cut, or other operation changed geometry as expected."""
-    return _session.diff_snapshot(snapshot_a, snapshot_b)
+def diff_snapshot(snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
+    """Compare two snapshots by geometry metrics (volume, topology, bounding box). snapshot_b defaults to current session state if omitted. format: 'text' (default, human-readable) or 'json' (structured, for programmatic consumption)."""
+    return _session.diff_snapshot(snapshot_a, snapshot_b, format)
+
+
+@mcp.tool()
+def session_state() -> str:
+    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, and snapshot names. Use this to orient after a reset, restore, or multi-step build to confirm what geometry is active."""
+    return _session.session_state()
+
+
+@mcp.tool()
+def health_check() -> str:
+    """Verify that render and export dependencies are working. Tests PNG render (VTK), SVG render (build123d HLR), STEP export, and STL export with a trivial shape. Returns JSON with ok/error per capability. Run at session start if you suspect a missing dependency."""
+    return _session.health_check()
 
 
 @mcp.tool()

--- a/src/build123d_mcp/tools/diff.py
+++ b/src/build123d_mcp/tools/diff.py
@@ -46,7 +46,7 @@ def _fmt_shape_diff(a: dict | None, b: dict | None, label: str) -> str | None:
     return "\n".join(lines)
 
 
-def diff_snapshot(session, snapshot_a: str, snapshot_b: str = "") -> str:
+def diff_snapshot(session, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
     if snapshot_a not in session.snapshots:
         return f"Error: no snapshot named '{snapshot_a}'. Available: {list(session.snapshots.keys())}"
 
@@ -61,6 +61,10 @@ def diff_snapshot(session, snapshot_a: str, snapshot_b: str = "") -> str:
         diag_b = _collect(snap_b["current_shape"], snap_b["objects"])
     else:
         diag_b = _collect(session.current_shape, session.objects)
+
+    if format == "json":
+        import json
+        return json.dumps({"a": {"label": snapshot_a, **diag_a}, "b": {"label": label_b, **diag_b}}, indent=2)
 
     lines = [f"diff: {snapshot_a} → {label_b}", ""]
 

--- a/src/build123d_mcp/tools/health_check.py
+++ b/src/build123d_mcp/tools/health_check.py
@@ -1,0 +1,52 @@
+import json
+import os
+import tempfile
+
+
+def health_check(_session) -> str:
+    results: dict = {}
+
+    # PNG render (VTK + display)
+    try:
+        from build123d import Box
+        from build123d_mcp.tools.render import _QUALITY, _do_render_png
+        png = _do_render_png([("test", Box(1, 1, 1), None)], _QUALITY["standard"], "iso", "", None, 0.0, 0.0)
+        results["render_png"] = {"ok": True, "bytes": len(png)}
+    except Exception as e:
+        results["render_png"] = {"ok": False, "error": str(e)}
+
+    # SVG render (build123d HLR projection)
+    try:
+        from build123d import Box
+        from build123d_mcp.tools.render import _do_render_svg
+        svg = _do_render_svg([("test", Box(1, 1, 1), None)], "iso", "", None, 0.0, 0.0)
+        results["render_svg"] = {"ok": True, "bytes": len(svg)}
+    except Exception as e:
+        results["render_svg"] = {"ok": False, "error": str(e)}
+
+    # STEP export
+    try:
+        from build123d import Box, export_step
+        fd, path = tempfile.mkstemp(suffix=".step")
+        os.close(fd)
+        export_step(Box(1, 1, 1), path)
+        results["export_step"] = {"ok": True, "bytes": os.path.getsize(path)}
+        os.unlink(path)
+    except Exception as e:
+        results["export_step"] = {"ok": False, "error": str(e)}
+
+    # STL export
+    try:
+        from build123d import Box, Mesher
+        fd, path = tempfile.mkstemp(suffix=".stl")
+        os.close(fd)
+        m = Mesher()
+        m.add_shape(Box(1, 1, 1))
+        m.write(path)
+        results["export_stl"] = {"ok": True, "bytes": os.path.getsize(path)}
+        os.unlink(path)
+    except Exception as e:
+        results["export_stl"] = {"ok": False, "error": str(e)}
+
+    results["ok"] = all(v["ok"] for v in results.values() if isinstance(v, dict) and "ok" in v)
+    return json.dumps(results, indent=2)

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -1,0 +1,9 @@
+import json
+
+from build123d_mcp.tools.diff import _collect
+
+
+def session_state(session) -> str:
+    state = _collect(session.current_shape, session.objects)
+    state["snapshots"] = list(session.snapshots.keys())
+    return json.dumps(state, indent=2)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -108,7 +108,15 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
 
     if op == "diff_snapshot":
         from build123d_mcp.tools.diff import diff_snapshot
-        return diff_snapshot(session, args["snapshot_a"], args.get("snapshot_b", ""))
+        return diff_snapshot(session, args["snapshot_a"], args.get("snapshot_b", ""), args.get("format", "text"))
+
+    if op == "session_state":
+        from build123d_mcp.tools.session_state import session_state
+        return session_state(session)
+
+    if op == "health_check":
+        from build123d_mcp.tools.health_check import health_check
+        return health_check(session)
 
     raise ValueError(f"Unknown operation: '{op}'")
 
@@ -256,8 +264,14 @@ class WorkerSession:
             return "Session reset."
         return self._call("reset", {}, self._SHORT_TIMEOUT)
 
-    def diff_snapshot(self, snapshot_a: str, snapshot_b: str = "") -> str:
-        return self._call("diff_snapshot", {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b}, self._SHORT_TIMEOUT)
+    def diff_snapshot(self, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
+        return self._call("diff_snapshot", {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b, "format": format}, self._SHORT_TIMEOUT)
+
+    def session_state(self) -> str:
+        return self._call("session_state", {}, self._SHORT_TIMEOUT)
+
+    def health_check(self) -> str:
+        return self._call("health_check", {}, self._RENDER_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -363,7 +363,7 @@ def test_mcp_lists_all_tools():
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
-                     "search_library", "load_part", "workflow_hints"}
+                     "search_library", "load_part", "workflow_hints", "session_state", "health_check"}
 
 
 @_skip_mcp_on_win

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,8 +10,10 @@ from build123d_mcp.tools.export import export_file
 from build123d_mcp.tools.interference import interference
 from build123d_mcp.tools.measure import measure
 from build123d_mcp.tools.diff import diff_snapshot
+from build123d_mcp.tools.health_check import health_check
 from build123d_mcp.tools.list_objects import list_objects
 from build123d_mcp.tools.render import render_view
+from build123d_mcp.tools.session_state import session_state
 
 # A path guaranteed to resolve outside any allowed write root (cwd, tempdir, /tmp)
 # on each platform. /etc/passwd on POSIX; on Windows we use the system hosts file,
@@ -867,3 +869,47 @@ def test_diff_snapshot_unchanged_object_marked(session):
     session.save_snapshot("s2")
     result = diff_snapshot(session, "s1", "s2")
     assert "unchanged" in result or "= base" in result
+
+
+# --- session_state ---
+
+def test_session_state_empty(session):
+    data = json.loads(session_state(session))
+    assert data["current_shape"] is None
+    assert data["objects"] == {}
+    assert data["snapshots"] == []
+
+
+def test_session_state_with_shape_and_objects(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    execute_code(session, "show(Cylinder(5, 20), 'pin')")
+    session.save_snapshot("v1")
+    data = json.loads(session_state(session))
+    assert data["current_shape"]["volume"] > 0
+    assert "pin" in data["objects"]
+    assert "v1" in data["snapshots"]
+
+
+# --- diff_snapshot JSON mode ---
+
+def test_diff_snapshot_json_format(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    session.save_snapshot("s1")
+    execute_code(session, "result = Box(20, 20, 20)")
+    data = json.loads(diff_snapshot(session, "s1", format="json"))
+    assert data["a"]["label"] == "s1"
+    assert data["b"]["label"] == "current"
+    assert data["b"]["current_shape"]["volume"] > data["a"]["current_shape"]["volume"]
+
+
+# --- health_check ---
+
+def test_health_check_returns_json(session):
+    data = json.loads(health_check(session))
+    assert "ok" in data
+    assert "export_step" in data
+    assert "export_stl" in data
+    assert "render_svg" in data
+    assert data["export_step"]["ok"] is True
+    assert data["export_stl"]["ok"] is True
+    assert data["render_svg"]["ok"] is True


### PR DESCRIPTION
## Summary

Three additions to improve structured state access for agentic clients (Codex, Claude Code):

- **`session_state()`** — returns JSON with `current_shape` metrics, all `objects` with geometry stats, and `snapshots` list. Replaces the need to chain `list_objects` + `measure` + guessing snapshot names.
- **`health_check()`** — runs real end-to-end tests of PNG render (VTK), SVG render (HLR), STEP export, and STL export against a trivial `Box(1,1,1)`. Returns per-capability `ok`/`error` JSON. Run at session start to detect missing dependencies before beginning CAD work.
- **`diff_snapshot(format="json")`** — adds optional JSON output mode to the existing diff tool. Default stays `"text"` for full backwards compatibility.

`execute()` is unchanged — human-readable output is a feature, not a bug.

## Test plan
- [x] `test_session_state_empty` / `test_session_state_with_shape_and_objects`
- [x] `test_diff_snapshot_json_format`
- [x] `test_health_check_returns_json`
- [x] `test_mcp_lists_all_tools` updated
- [x] All 181 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)