### PR TITLE
feat: version tool, updated workflow_hints, docs and README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # build123d-mcp
 
+[![PyPI version](https://img.shields.io/pypi/v/build123d-mcp)](https://pypi.org/project/build123d-mcp/)
+[![Python](https://img.shields.io/pypi/pyversions/build123d-mcp)](https://pypi.org/project/build123d-mcp/)
+[![CI](https://github.com/pzfreo/build123d-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pzfreo/build123d-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 An MCP (Model Context Protocol) server that exposes build123d CAD operations as tools, enabling AI assistants to build, inspect, and iterate on 3D geometry interactively.
 
 ## Why
@@ -9,10 +14,15 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 ## Tools
 
 - `execute` — run build123d Python code in a persistent session; use `show(shape, name)` to register named parts
-- `render_view` — render one or more shapes as PNG; supports assembly compositing, high-quality tessellation, and cross-section clip planes
-- `measure` — query bounding box, volume, surface area, minimum wall thickness, or clearance between two named bodies
+- `render_view` — render one or more shapes as PNG or SVG; supports assembly compositing, high-quality tessellation, and cross-section clip planes
+- `measure` — query bounding box, volume, surface area, topology, minimum wall thickness, or clearance between two named bodies
 - `export` — export as STEP, STL, or both in one call; targets a named object or the current shape
-- `save_snapshot` / `restore_snapshot` — checkpoint and recover geometric state without re-running prior code
+- `session_state` — full JSON snapshot of active shapes, named objects, and snapshot names
+- `health_check` — verify VTK/SVG/STEP/STL dependencies work end-to-end before starting work
+- `save_snapshot` / `restore_snapshot` / `diff_snapshot` — checkpoint, recover, and compare geometric state
+- `interference` — check intersection volume between two named shapes
+- `list_objects` — list all named shapes with geometry stats
+- `version` — return the server version
 - `reset` — clear the session back to empty state
 
 See [llms.md](llms.md) for full tool reference and usage patterns.

--- a/llms.md
+++ b/llms.md
@@ -1,6 +1,6 @@
 # build123d-mcp — LLM Reference
 
-build123d-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you seven tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, and reset.
+build123d-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, inspect session state, and verify dependencies.
 
 ## Key concept: persistent session
 
@@ -8,7 +8,7 @@ All tool calls share a single Python namespace. Variables and shapes you create 
 
 ### Multi-object sessions
 
-Use `show(shape, name)` inside `execute` to register named objects. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.
+Use `show(shape, name)` inside `execute` to register named objects. Calling `show()` also sets `current_shape`, so subsequent `measure()`/`export()`/`render_view()` calls work immediately without an explicit `result` assignment. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.
 
 ```python
 frame = Box(60, 40, 8)
@@ -21,6 +21,15 @@ show(axle, "axle")
 ---
 
 ## Tools
+
+### `version`
+Return the server version string.
+
+**No inputs.**
+
+**Returns:** version string, e.g. `"0.3.5"`
+
+---
 
 ### `execute`
 Run build123d Python code in the persistent session.
@@ -40,20 +49,66 @@ with BuildPart() as bp:
 result = bp.part
 ```
 
-**On error:** the previous shape is preserved; the namespace is not wiped.
+**On error:** the previous `current_shape` is preserved; the namespace is not wiped. Failed code cannot silently advance session state.
+
+---
+
+### `session_state`
+Return a structured JSON snapshot of the full session.
+
+**No inputs.**
+
+**Returns:** JSON with:
+- `current_shape` — geometry metrics (volume, faces, edges, vertices, bbox) or `null`
+- `objects` — dict of name → metrics for all shapes registered via `show()`
+- `snapshots` — list of saved snapshot names
+
+Use this to orient at the start of a session, after a restore, or after a multi-step build to confirm what geometry is active.
+
+```json
+{
+  "current_shape": {"volume": 1000.0, "faces": 6, "edges": 12, "vertices": 8,
+                    "bbox": [10.0, 10.0, 10.0]},
+  "objects": {
+    "frame": {"volume": 1920.0, "faces": 6, "edges": 12, "vertices": 8,
+              "bbox": [60.0, 40.0, 8.0]}
+  },
+  "snapshots": ["before_fillet", "v2"]
+}
+```
+
+---
+
+### `health_check`
+Verify that render and export dependencies are working end-to-end.
+
+**No inputs.**
+
+**Returns:** JSON with per-capability `ok`/`error` status:
+- `render_png` — VTK raster render
+- `render_svg` — build123d HLR line projection
+- `export_step` — STEP file export
+- `export_stl` — STL mesh export
+- `ok` — `true` only if all capabilities pass
+
+Run at session start if you suspect a missing dependency (headless display, missing VTK wheels, etc.).
 
 ---
 
 ### `render_view`
-Render one or more shapes and return a PNG image.
+Render one or more shapes and return a file path to the rendered image.
 
 **Inputs:**
 - `direction` (string, default `"iso"`) — `top`, `front`, `side`, `iso`
 - `objects` (string, default `""`) — comma-separated names from `show()` to render; empty = all registered objects, or `current_shape` if none registered. Optionally suffix a name with `:color` to override the auto-assigned colour, e.g. `"frame:blue,axle:red"`
 - `quality` (string, default `"standard"`) — `standard` or `high`; high uses finer tessellation to eliminate artefacts on curved surfaces
 - `clip_plane` (string, default `""`) — `x`, `y`, or `z`; clips each mesh at its bounding-box midpoint to expose internal geometry (bores, wall thickness)
+- `clip_at` (float, optional) — absolute world coordinate for the clip plane instead of the midpoint
+- `azimuth` / `elevation` (float, default `0.0`) — camera rotation in degrees applied after the direction preset
+- `format` (string, default `"png"`) — `png`, `svg`, or `both`
+- `save_to` (string, default `""`) — optional path to also write the file(s) to disk
 
-**Returns:** PNG image
+**Returns:** `[SEND: /tmp/build123d_xxx.png]` text marker; the file is delivered directly to the client.
 
 Each named object is rendered in a distinct colour. Call this after each significant change to verify geometry visually.
 
@@ -67,6 +122,7 @@ Query geometry of a shape.
   - `bounding_box` — extents, sizes, and centre
   - `volume` — shape volume
   - `area` — total surface area
+  - `topology` — face, edge, and vertex counts; fastest way to confirm a boolean succeeded
   - `min_wall_thickness` — shortest wall crossing via ray cast (accurate for prismatic parts)
   - `clearance` — minimum distance between two named bodies (requires `object_name` and `object_name2`)
 - `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
@@ -87,6 +143,8 @@ Query geometry of a shape.
 
 `volume` example: `{"volume": 1000.0}`
 
+`topology` example: `{"faces": 6, "edges": 12, "vertices": 8}`
+
 `clearance` example: `{"clearance": 1.0}`
 
 ---
@@ -105,6 +163,25 @@ STEP preserves exact geometry for downstream CAD tools. STL is for mesh-based wo
 
 ---
 
+### `interference`
+Check whether two named shapes intersect.
+
+**Inputs:**
+- `object_a`, `object_b` (string) — names from `show()`
+
+**Returns:** JSON with `interferes` (bool), `volume` (mm³ of overlap), and `bounds` of the interference region.
+
+---
+
+### `list_objects`
+List all named shapes registered via `show()`.
+
+**No inputs.**
+
+**Returns:** JSON array of objects with name, volume, faces, edges, vertices.
+
+---
+
 ### `save_snapshot`
 Save a named checkpoint of the current geometric state.
 
@@ -113,9 +190,7 @@ Save a named checkpoint of the current geometric state.
 **Returns:** confirmation listing what was captured
 
 **What is saved:** `current_shape` and the `show()` object registry.
-**What is NOT saved:** the Python variable namespace. After a restore, any intermediate Python variables (e.g. `box`, `cyl`) created after the snapshot are still in scope — but `current_shape` and all `show()` objects revert to the snapshot state.
-
-Call this before risky experiments so you can restore known-good geometry without re-running all prior `execute()` calls.
+**What is NOT saved:** the Python variable namespace. After a restore, any intermediate Python variables created after the snapshot are still in scope — but `current_shape` and all `show()` objects revert to the snapshot state.
 
 ---
 
@@ -126,8 +201,19 @@ Restore geometric state from a previously saved snapshot.
 
 **Returns:** confirmation listing restored geometry, or an error if the name does not exist.
 
-**What is restored:** `current_shape` and the `show()` object registry.
-**What is NOT restored:** the Python variable namespace remains as-is. If you need variables to match the snapshot, re-run the relevant `execute()` calls after restoring.
+---
+
+### `diff_snapshot`
+Compare two snapshots by geometry metrics.
+
+**Inputs:**
+- `snapshot_a` (string) — baseline snapshot name
+- `snapshot_b` (string, default `""`) — comparison snapshot; defaults to current session state
+- `format` (string, default `"text"`) — `"text"` for human-readable output, `"json"` for structured
+
+**Returns:** volume delta, topology changes, and added/removed/changed objects.
+
+JSON format returns `{"a": {"label": ..., "current_shape": ..., "objects": ...}, "b": {...}}`.
 
 ---
 
@@ -138,20 +224,22 @@ Clear the session back to empty state, including all snapshots.
 
 **Returns:** `"Session reset."`
 
-Call this before starting a new model to ensure a clean slate.
-
 ---
 
 ## Recommended workflow
 
-1. `reset` — start clean
-2. `execute` — imports and initial geometry; use `show()` for named parts
-3. `render_view` — visually verify (try `iso` first; use `quality="high"` for curved surfaces)
-4. `measure` — confirm dimensions (`bounding_box`, `volume`, `clearance`, etc.)
-5. `save_snapshot` — checkpoint before complex or risky operations
-6. `execute` — add features; if something breaks, `restore_snapshot`
-7. Repeat 3–6 until satisfied
-8. `export` — write STEP + STL in one call with `format="step,stl"`
+1. `version` — confirm server version
+2. `health_check` — verify dependencies (optional; run if first session or suspect issues)
+3. `reset` — start clean
+4. `execute` — imports and initial geometry; use `show()` for named parts
+5. `session_state` — confirm active shapes after any complex step
+6. `render_view` — visually verify (try `iso` first; use `quality="high"` for curved surfaces)
+7. `measure` — confirm dimensions (`bounding_box`, `volume`, `topology`, `clearance`, etc.)
+8. `save_snapshot` — checkpoint before complex or risky operations
+9. `execute` — add features; if something breaks, `restore_snapshot`
+10. `diff_snapshot` — confirm what changed (use `format="json"` for programmatic checks)
+11. Repeat 5–10 until satisfied
+12. `export` — write STEP + STL in one call with `format="step,stl"`
 
 ---
 
@@ -196,6 +284,6 @@ All units are millimetres by default.
 - **No shape yet:** `render_view`, `measure`, and `export` all fail if no shape exists. Always `execute` geometry first.
 - **Forgetting imports:** the namespace starts empty. Include `from build123d import *` in your first `execute` call.
 - **Shape not detected:** if the server doesn't pick up your shape, assign it explicitly to `result` or use `show()`.
-- **Dirty session:** unexpected results often mean leftover state. Call `reset` first.
+- **Dirty session:** unexpected results often mean leftover state. Call `reset` first, or `session_state` to inspect what's active.
 - **`clearance` missing second object:** `clearance` requires both `object_name` and `object_name2`.
-- **Snapshot restores geometry only:** after `restore_snapshot`, Python variables are not rewound. Re-run `execute()` calls if variables need to match the snapshot.
+- **Failed execute advancing state:** it doesn't — failed code preserves the previous `current_shape`.

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -123,41 +123,54 @@ def reset() -> str:
 
 
 @mcp.tool()
+def version() -> str:
+    """Return the build123d-mcp server version."""
+    from importlib.metadata import version as _version
+    return _version("build123d-mcp")
+
+
+@mcp.tool()
 def workflow_hints() -> str:
     """Return guidance on how to use these tools effectively. Call this at the start of a session or whenever unsure which tool to reach for."""
     return """\
 BUILD123D-MCP WORKFLOW GUIDE
 
-1. MEASURE BEFORE YOU LOOK
+1. ORIENT FIRST
+   At the start of a session, call session_state() to see what geometry, objects, and
+   snapshots are already active. Call health_check() if you suspect a missing dependency
+   (VTK, display, STEP export). Call version() to confirm the server version.
+
+2. MEASURE BEFORE YOU LOOK
    After building or modifying geometry, verify with measure() before calling render_view.
    Numbers are unambiguous; renders can look correct even when the geometry is wrong.
    Recommended order: execute → measure → render_view (if you need to see it).
 
-2. VERIFY BOOLEAN OPERATIONS WITH TOPOLOGY
+3. VERIFY BOOLEAN OPERATIONS WITH TOPOLOGY
    After any cut, union, or intersection, call measure(topology) on the result.
    A successful boolean changes face/edge/vertex counts; a failed one leaves them unchanged.
    measure(volume) confirms the magnitude of the change.
 
-3. MEASURE THE OBJECT IN QUESTION — NOT A PROXY
+4. MEASURE THE OBJECT IN QUESTION — NOT A PROXY
    When debugging, call measure() on the actual disputed object.
    Testing an isolated reconstruction and using that as proof of the full assembly is a
    common mistake — the two may differ in ways that matter.
 
-4. NAME AND AUDIT YOUR SHAPES
-   Use show(shape, "name") after creating important geometry.
+5. NAME AND AUDIT YOUR SHAPES
+   Use show(shape, "name") after creating important geometry — it also sets current_shape.
    The execute() output immediately confirms name, volume, and face count.
-   Call list_objects() any time to see all registered shapes and their geometry.
+   Call session_state() for a full JSON view of all active shapes, objects, and snapshots.
 
-5. CHECKPOINT BEFORE EXPERIMENTS
+6. CHECKPOINT BEFORE EXPERIMENTS
    Call save_snapshot("name") before any operation you might want to undo.
    Snapshots are instant. restore_snapshot("name") reverts geometry without re-running code.
+   Use diff_snapshot("name") to see what changed; pass format="json" for structured output.
 
-6. CROSS-SECTIONS FOR INTERNAL GEOMETRY
+7. CROSS-SECTIONS FOR INTERNAL GEOMETRY
    render_view with clip_plane + clip_at reveals interior features.
    Use clip_at to position the cut at a specific world coordinate, not just the midpoint.
    Combine with measure(topology) on the unclipped shape to confirm what you see.
 
-7. PART LIBRARY
+8. PART LIBRARY
    search_library("keyword") returns full parameter specs.
    Call load_part("name", '{"param": value}') immediately — no second lookup needed.
    Unspecified parameters use the defaults shown in search results.
@@ -190,10 +203,14 @@ Available tools:
   export            Export model to STEP or STL
   interference      Check intersection volume between two named shapes
   list_objects      List all named shapes with volume, faces, edges, vertices
+  session_state     Full session JSON: current_shape, all objects, snapshot names
+  health_check      Verify VTK/SVG/STEP/STL dependencies work end-to-end
   search_library    Search the part library by keyword (requires --library)
   load_part         Load a named part with optional parameter overrides (requires --library)
   save_snapshot     Save a named geometric checkpoint
   restore_snapshot  Restore geometry from a named checkpoint
+  diff_snapshot     Compare two snapshots; format="json" for structured output
+  version           Return the server version string
   workflow_hints    Return guidance on using these tools effectively
   reset             Clear the session (namespace, shapes, snapshots)
 

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -118,6 +118,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.health_check import health_check
         return health_check(session)
 
+    if op == "version":
+        from importlib.metadata import version
+        return version("build123d-mcp")
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -272,6 +276,9 @@ class WorkerSession:
 
     def health_check(self) -> str:
         return self._call("health_check", {}, self._RENDER_TIMEOUT)
+
+    def version(self) -> str:
+        return self._call("version", {}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -363,7 +363,7 @@ def test_mcp_lists_all_tools():
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
-                     "search_library", "load_part", "workflow_hints", "session_state", "health_check"}
+                     "search_library", "load_part", "workflow_hints", "session_state", "health_check", "version"}
 
 
 @_skip_mcp_on_win


### PR DESCRIPTION
## Summary

- **`version()` tool** — returns the server version string via MCP
- **`workflow_hints` rewrite** — orient-first order: session_state → health_check → version before building; show() semantics clarified; diff_snapshot JSON mode documented
- **`--help` tool list** updated with all new tools
- **`llms.md` rewrite** — all new tools documented (version, session_state, health_check, diff_snapshot JSON mode); render_view updated to reflect [SEND: path] delivery; show() semantics corrected; topology query added; recommended workflow updated to 12 steps
- **README** — tool list updated; PyPI version, Python version, CI, and MIT licence badges added

## Test plan
- [x] `test_mcp_lists_all_tools` updated to include `version`
- [x] 181 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)