### PR TITLE
fix: render PNG via tessellate(), transactional execute(), assembly export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,12 @@ build123d-mcp = "build123d_mcp.server:main"
 packages = ["src/build123d_mcp"]
 
 [dependency-groups]
-dev = ["pytest", "pytest-timeout", "mypy"]
+dev = [
+    "pytest",
+    "pytest-timeout",
+    "mypy",
+    "pytest-cov>=7.1.0",
+]
 
 [tool.mypy]
 files = ["src"]

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -1,8 +1,9 @@
+import base64
 import os
 import tempfile
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import TextContent
+from mcp.types import ImageContent, TextContent
 
 from build123d_mcp.worker import WorkerSession
 
@@ -27,17 +28,26 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
     )
 
     contents: list = []
-    for key, suffix in (("png", ".png"), ("svg", ".svg")):
+    for key, suffix, mime in (("png", ".png", "image/png"), ("svg", ".svg", "image/svg+xml")):
         if key in result:
+            data = result[key]
             fd, path = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
             os.close(fd)
             with open(path, "wb") as f:
-                f.write(result[key])
+                f.write(data)
+            contents.append(ImageContent(
+                type="image",
+                data=base64.b64encode(data).decode(),
+                mimeType=mime,
+            ))
             contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
     if result.get("fallback"):
         contents.append(TextContent(type="text", text=result["fallback"]))
     if result.get("png_error"):
         contents.append(TextContent(type="text", text=f"PNG render failed: {result['png_error']}"))
+    if result.get("png_warnings"):
+        for w in result["png_warnings"]:
+            contents.append(TextContent(type="text", text=f"Warning: {w}"))
     return contents
 
 
@@ -49,7 +59,7 @@ def measure(query: str = "bounding_box", object_name: str = "", object_name2: st
 
 @mcp.tool()
 def export(filename: str, format: str = "step", object_name: str = "") -> str:
-    """Export model. format: step, stl, or comma-separated list e.g. 'step,stl'. object_name: named object from show() (default: current shape)."""
+    """Export model. format: step, stl, or comma-separated list e.g. 'step,stl'. object_name: named object from show(), '*' to export all named shapes as a combined assembly (default: current shape)."""
     return _session.export_file(filename, format, object_name)
 
 
@@ -191,7 +201,7 @@ MCP client configuration example:
     "mcpServers": {
       "build123d": {
         "command": "uvx",
-        "args": ["--python", "3.13", "build123d-mcp", "--library", "/path/to/parts"]
+        "args": ["--python", "3.12", "build123d-mcp", "--library", "/path/to/parts"]
       }
     }
   }

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -70,6 +70,7 @@ class Session:
 
         keys_before = {k for k in self.namespace if k not in ("__builtins__", "show")}
         shape_before = self.current_shape
+        objects_before = dict(self.objects)
 
         buf = io.StringIO()
         exc: Exception | None = None
@@ -94,8 +95,14 @@ class Session:
             with redirect_stdout(buf), redirect_stderr(buf):
                 exec(compiled, self.namespace)  # noqa: S102
         except ExecutionTimeout as e:
+            self.current_shape = shape_before
+            self.objects.clear()
+            self.objects.update(objects_before)
             return f"Error: ExecutionTimeout: {e}"
         except AssertionError as e:
+            self.current_shape = shape_before
+            self.objects.clear()
+            self.objects.update(objects_before)
             return f"Constraint failed: {e}" if str(e) else "Constraint failed"
         except Exception as e:
             exc = e
@@ -105,6 +112,9 @@ class Session:
                 signal.signal(signal.SIGALRM, _old_handler)
 
         if exc is not None:
+            self.current_shape = shape_before
+            self.objects.clear()
+            self.objects.update(objects_before)
             return f"Error: {type(exc).__name__}: {exc}"
 
         new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - keys_before

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -1,9 +1,16 @@
+import struct
+
 from build123d_mcp.tools._paths import safe_output_path
 
 _VALID_FORMATS = ("step", "stl")
 
 
 def _resolve_shape(session, object_name: str):
+    if object_name == "*":
+        if not session.objects:
+            raise ValueError("No named objects in session. Use show() to register shapes first.")
+        from build123d import Compound
+        return Compound(children=list(session.objects.values()))
     if object_name:
         if object_name not in session.objects:
             raise ValueError(f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}")
@@ -14,10 +21,26 @@ def _resolve_shape(session, object_name: str):
 
 
 def _stl_write(shape, abs_path: str) -> None:
-    from build123d import Mesher
-    mesher = Mesher()
-    mesher.add_shape(shape)
-    mesher.write(abs_path)
+    verts, tris = shape.tessellate(0.001, 0.1)
+
+    with open(abs_path, "wb") as f:
+        f.write(b"\x00" * 80)  # header
+        f.write(struct.pack("<I", len(tris)))
+        for tri in tris:
+            v0 = verts[tri[0]]
+            v1 = verts[tri[1]]
+            v2 = verts[tri[2]]
+            # flat normal via cross product
+            ax, ay, az = v1.X - v0.X, v1.Y - v0.Y, v1.Z - v0.Z
+            bx, by, bz = v2.X - v0.X, v2.Y - v0.Y, v2.Z - v0.Z
+            nx, ny, nz = ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx
+            length = (nx * nx + ny * ny + nz * nz) ** 0.5
+            if length > 0:
+                nx, ny, nz = nx / length, ny / length, nz / length
+            f.write(struct.pack("<3f", nx, ny, nz))
+            for v in (v0, v1, v2):
+                f.write(struct.pack("<3f", v.X, v.Y, v.Z))
+            f.write(b"\x00\x00")  # attribute byte count
 
 
 def _write_one(shape, abs_path: str, fmt: str) -> None:

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -108,10 +108,9 @@ def _camera_direction(direction: str) -> tuple[tuple[float, float, float], tuple
     return (1.0, 1.0, 1.0), (0.0, 0.0, 1.0)  # iso
 
 
-def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevation) -> bytes:
+def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevation) -> tuple[bytes, list[str]]:
     import tempfile
     import vtk
-    from build123d import Mesher
 
     _ensure_display()
 
@@ -123,77 +122,98 @@ def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevat
     render_window.SetSize(800, 600)
     render_window.AddRenderer(renderer)
 
+    failed: list[str] = []
+    actor_count = 0
+
+    for i, (name, shape, obj_color) in enumerate(shapes):
+        try:
+            verts, tris = shape.tessellate(
+                tess["linear_deflection"], tess["angular_deflection"]
+            )
+        except Exception as exc:
+            failed.append(f"{name}: {exc}")
+            continue
+
+        points = vtk.vtkPoints()
+        for v in verts:
+            points.InsertNextPoint(v.X, v.Y, v.Z)
+
+        cells = vtk.vtkCellArray()
+        for tri in tris:
+            cells.InsertNextCell(3)
+            cells.InsertCellPoint(tri[0])
+            cells.InsertCellPoint(tri[1])
+            cells.InsertCellPoint(tri[2])
+
+        poly = vtk.vtkPolyData()
+        poly.SetPoints(points)
+        poly.SetPolys(cells)
+
+        if clip_plane:
+            if clip_at is not None:
+                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
+            else:
+                bounds = poly.GetBounds()  # xmin, xmax, ymin, ymax, zmin, zmax
+                cx = (bounds[0] + bounds[1]) / 2
+                cy = (bounds[2] + bounds[3]) / 2
+                cz = (bounds[4] + bounds[5]) / 2
+                origin = {"x": (cx, 0, 0), "y": (0, cy, 0), "z": (0, 0, cz)}[clip_plane]
+            normal = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}[clip_plane]
+
+            plane = vtk.vtkPlane()
+            plane.SetOrigin(*origin)
+            plane.SetNormal(*normal)
+
+            clipper = vtk.vtkClipPolyData()
+            clipper.SetInputData(poly)
+            clipper.SetClipFunction(plane)
+            clipper.SetInsideOut(False)
+            clipper.Update()
+            poly = clipper.GetOutput()
+
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputData(poly)
+
+        actor = vtk.vtkActor()
+        actor.SetMapper(mapper)
+
+        r, g, b = _color_to_rgb(obj_color if obj_color else _PALETTE[i % len(_PALETTE)])
+        prop = actor.GetProperty()
+        prop.SetColor(r, g, b)
+        prop.SetAmbient(0.3)
+        prop.SetDiffuse(0.7)
+        prop.SetSpecular(0.2)
+        prop.SetInterpolationToPhong()  # smooth shading
+
+        renderer.AddActor(actor)
+        actor_count += 1
+
+    if actor_count == 0:
+        msg = "All shapes failed to tessellate: " + "; ".join(failed) if failed else "No geometry to render"
+        raise RuntimeError(msg)
+
+    # Camera setup
+    camera = renderer.GetActiveCamera()
+    camera.SetParallelProjection(False)
+    pos, up = _camera_direction(direction)
+    camera.SetPosition(*pos)
+    camera.SetFocalPoint(0.0, 0.0, 0.0)
+    camera.SetViewUp(*up)
+    renderer.ResetCamera()
+
+    if azimuth != 0.0 or elevation != 0.0:
+        camera.Azimuth(azimuth)
+        camera.Elevation(elevation)
+        camera.OrthogonalizeViewUp()
+        renderer.ResetCameraClippingRange()
+
+    render_window.Render()
+
+    w2i = vtk.vtkWindowToImageFilter()
+    w2i.SetInput(render_window)
+    w2i.Update()
+
     with tempfile.TemporaryDirectory() as tmpdir:
-        for i, (_name, shape, obj_color) in enumerate(shapes):
-            stl_path = os.path.join(tmpdir, f"shape_{i}.stl")
-            mesher = Mesher()
-            mesher.add_shape(shape, **tess)  # type: ignore[arg-type]
-            mesher.write(stl_path)
-
-            reader = vtk.vtkSTLReader()
-            reader.SetFileName(stl_path)
-            reader.Update()
-            poly = reader.GetOutput()
-
-            if clip_plane:
-                if clip_at is not None:
-                    origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
-                else:
-                    bounds = poly.GetBounds()  # xmin, xmax, ymin, ymax, zmin, zmax
-                    cx = (bounds[0] + bounds[1]) / 2
-                    cy = (bounds[2] + bounds[3]) / 2
-                    cz = (bounds[4] + bounds[5]) / 2
-                    origin = {"x": (cx, 0, 0), "y": (0, cy, 0), "z": (0, 0, cz)}[clip_plane]
-                normal = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}[clip_plane]
-
-                plane = vtk.vtkPlane()
-                plane.SetOrigin(*origin)
-                plane.SetNormal(*normal)
-
-                clipper = vtk.vtkClipPolyData()
-                clipper.SetInputData(poly)
-                clipper.SetClipFunction(plane)
-                clipper.SetInsideOut(False)
-                clipper.Update()
-                poly = clipper.GetOutput()
-
-            mapper = vtk.vtkPolyDataMapper()
-            mapper.SetInputData(poly)
-
-            actor = vtk.vtkActor()
-            actor.SetMapper(mapper)
-
-            r, g, b = _color_to_rgb(obj_color if obj_color else _PALETTE[i % len(_PALETTE)])
-            prop = actor.GetProperty()
-            prop.SetColor(r, g, b)
-            prop.SetAmbient(0.3)
-            prop.SetDiffuse(0.7)
-            prop.SetSpecular(0.2)
-            prop.SetInterpolationToPhong()  # smooth shading
-
-            renderer.AddActor(actor)
-
-        # Camera setup
-        camera = renderer.GetActiveCamera()
-        camera.SetParallelProjection(False)
-        pos, up = _camera_direction(direction)
-        camera.SetPosition(*pos)
-        camera.SetFocalPoint(0.0, 0.0, 0.0)
-        camera.SetViewUp(*up)
-        renderer.ResetCamera()
-
-        if azimuth != 0.0 or elevation != 0.0:
-            camera.Azimuth(azimuth)
-            camera.Elevation(elevation)
-            camera.OrthogonalizeViewUp()
-            renderer.ResetCameraClippingRange()
-
-        render_window.Render()
-
-        w2i = vtk.vtkWindowToImageFilter()
-        w2i.SetInput(render_window)
-        w2i.Update()
-
         png_path = os.path.join(tmpdir, "render.png")
         writer = vtk.vtkPNGWriter()
         writer.SetFileName(png_path)
@@ -201,7 +221,7 @@ def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevat
         writer.Write()
 
         with open(png_path, "rb") as f:
-            return f.read()
+            return f.read(), failed
 
 
 def _viewport_origin_for(direction: str, shapes, azimuth: float, elevation: float):
@@ -365,9 +385,14 @@ def render_view(
 
     if format in ("png", "both"):
         try:
-            result["png"] = _do_render_png(
+            png_bytes, png_failed = _do_render_png(
                 shapes, tess, direction, clip_plane, clip_at, azimuth, elevation,
             )
+            result["png"] = png_bytes
+            if png_failed:
+                result["png_warnings"] = [
+                    f"Skipped shapes (tessellation failed): {', '.join(png_failed)}"
+                ]
         except Exception as exc:
             if format == "png":
                 # Auto-fallback: produce SVG so the AI still gets a visual.

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import json
 import os
+import struct
 import sys
 
 import pytest
@@ -240,6 +241,45 @@ def test_export_named_object_independent_of_current_shape(session, tmp_path, mon
     assert os.path.getsize("big.step") > 1000
 
 
+def test_export_assembly_step_contains_all_parts(session, tmp_path, monkeypatch):
+    """object_name='*' exports a compound of all named shapes; STEP is larger than any single part."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'box')\nshow(Cylinder(5, 20), 'cyl')")
+    export_file(session, "box", "step", "box")
+    export_file(session, "cyl", "step", "cyl")
+    export_file(session, "assembly", "step", "*")
+    box_size = os.path.getsize("box.step")
+    cyl_size = os.path.getsize("cyl.step")
+    asm_size = os.path.getsize("assembly.step")
+    assert asm_size > box_size
+    assert asm_size > cyl_size
+
+
+def test_export_assembly_stl_is_valid_binary(session, tmp_path, monkeypatch):
+    """object_name='*' produces a valid binary STL whose triangle count matches the header."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'a')\nshow(Box(5, 5, 5), 'b')")
+    export_file(session, "assembly", "stl", "*")
+    with open("assembly.stl", "rb") as f:
+        data = f.read()
+    # Binary STL: 80-byte header + 4-byte count + count * 50 bytes
+    tri_count = struct.unpack_from("<I", data, 80)[0]
+    assert tri_count > 0
+    assert len(data) == 84 + tri_count * 50
+
+
+def test_export_stl_avoids_mesher_for_complex_shape(session, tmp_path, monkeypatch):
+    """STL export of a boolean-subtracted shape uses tessellate(), not Mesher, so it doesn't
+    raise '3mf mesh is invalid' for shapes that pass OCCT meshing but fail Lib3MF validation."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(20, 20, 20) - Cylinder(5, 22), 'hollow')")
+    export_file(session, "hollow", "stl", "hollow")
+    with open("hollow.stl", "rb") as f:
+        data = f.read()
+    tri_count = struct.unpack_from("<I", data, 80)[0]
+    assert tri_count > 0
+
+
 def test_reset_clears_show_registry(session):
     """After reset, previously registered objects are gone."""
     execute_code(session, "show(Box(10, 10, 10), 'part')")
@@ -383,19 +423,27 @@ def test_mcp_execute_and_measure_round_trip():
 
 
 @_skip_mcp_on_win
-def test_mcp_render_returns_file_path():
+def test_mcp_render_returns_image_and_file_path():
     async def run(mcp):
         await mcp.call_tool(
             "execute",
             {"code": "from build123d import *\nresult = Box(10, 10, 10)"},
         )
         result = await mcp.call_tool("render_view", {"direction": "iso"})
-        c = result.content[0]
-        return c.type, c.text
+        img = result.content[0]
+        path_item = result.content[1]
+        return img.type, img.data, img.mimeType, path_item.type, path_item.text
 
-    content_type, text = asyncio.run(_mcp_session(run))
-    assert content_type == "text"
-    path = text.removeprefix("[SEND: ").removesuffix("]")
+    img_type, img_data, mime, path_type, path_text = asyncio.run(_mcp_session(run))
+    # ImageContent with base64 PNG
+    assert img_type == "image"
+    assert mime == "image/png"
+    import base64
+    png_bytes = base64.b64decode(img_data)
+    assert png_bytes[:8] == PNG_MAGIC
+    # TextContent with file path for [SEND:] delivery
+    assert path_type == "text"
+    path = path_text.removeprefix("[SEND: ").removesuffix("]")
     assert path.endswith(".png")
     assert os.path.exists(path)
     with open(path, "rb") as f:

--- a/uv.lock
+++ b/uv.lock
@@ -98,6 +98,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
 
@@ -112,6 +113,7 @@ requires-dist = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-timeout" },
 ]
 
@@ -372,6 +374,64 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/33/e8c48488c29a73fd089f9d71f9653c1be7478f2ad6b5bc870db11a55d23d/coverage-7.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0723d2c96324561b9aa76fb982406e11d93cdb388a7a7da2b16e04719cf7ca5", size = 219255, upload-time = "2026-03-17T10:29:51.081Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bd/b0ebe9f677d7f4b74a3e115eec7ddd4bcf892074963a00d91e8b164a6386/coverage-7.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52f444e86475992506b32d4e5ca55c24fc88d73bcbda0e9745095b28ef4dc0cf", size = 219772, upload-time = "2026-03-17T10:29:52.867Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cc/5cb9502f4e01972f54eedd48218bb203fe81e294be606a2bc93970208013/coverage-7.13.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8", size = 246532, upload-time = "2026-03-17T10:29:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/3217636d86c7e7b12e126e4f30ef1581047da73140614523af7495ed5f2d/coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4", size = 248333, upload-time = "2026-03-17T10:29:56.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/2002ac6729ba2d4357438e2ed3c447ad8562866c8c63fc16f6dfc33afe56/coverage-7.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d", size = 250211, upload-time = "2026-03-17T10:29:57.938Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/85/552496626d6b9359eb0e2f86f920037c9cbfba09b24d914c6e1528155f7d/coverage-7.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930", size = 252125, upload-time = "2026-03-17T10:29:59.388Z" },
+    { url = "https://files.pythonhosted.org/packages/44/21/40256eabdcbccdb6acf6b381b3016a154399a75fe39d406f790ae84d1f3c/coverage-7.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d", size = 247219, upload-time = "2026-03-17T10:30:01.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/96e2a6c3f21a0ea77d7830b254a1542d0328acc8d7bdf6a284ba7e529f77/coverage-7.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40", size = 248248, upload-time = "2026-03-17T10:30:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ba/8477f549e554827da390ec659f3c38e4b6d95470f4daafc2d8ff94eaa9c2/coverage-7.13.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878", size = 246254, upload-time = "2026-03-17T10:30:04.832Z" },
+    { url = "https://files.pythonhosted.org/packages/55/59/bc22aef0e6aa179d5b1b001e8b3654785e9adf27ef24c93dc4228ebd5d68/coverage-7.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400", size = 250067, upload-time = "2026-03-17T10:30:06.535Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1b/c6a023a160806a5137dca53468fd97530d6acad24a22003b1578a9c2e429/coverage-7.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0", size = 246521, upload-time = "2026-03-17T10:30:08.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/3532c85a55aa2f899fa17c186f831cfa1aa434d88ff792a709636f64130e/coverage-7.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0", size = 247126, upload-time = "2026-03-17T10:30:09.966Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2e/b9d56af4a24ef45dfbcda88e06870cb7d57b2b0bfa3a888d79b4c8debd76/coverage-7.13.5-cp310-cp310-win32.whl", hash = "sha256:eb7fdf1ef130660e7415e0253a01a7d5a88c9c4d158bcf75cbbd922fd65a5b58", size = 221860, upload-time = "2026-03-17T10:30:11.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cc/d938417e7a4d7f0433ad4edee8bb2acdc60dc7ac5af19e2a07a048ecbee3/coverage-7.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:3e1bb5f6c78feeb1be3475789b14a0f0a5b47d505bfc7267126ccbd50289999e", size = 222788, upload-time = "2026-03-17T10:30:12.886Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/37/d24c8f8220ff07b839b2c043ea4903a33b0f455abe673ae3c03bbdb7f212/coverage-7.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d", size = 219381, upload-time = "2026-03-17T10:30:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/cd129b0ca4afe886a6ce9d183c44d8301acbd4ef248622e7c49a23145605/coverage-7.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587", size = 219880, upload-time = "2026-03-17T10:30:16.231Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/e0e5b237bffdb5d6c530ce87cc1d413a5b7d7dfd60fb067ad6d254c35c76/coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642", size = 250303, upload-time = "2026-03-17T10:30:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b", size = 252218, upload-time = "2026-03-17T10:30:19.804Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/2f47bb6fa1b8d1e3e5d0c4be8ccb4313c63d742476a619418f85740d597b/coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686", size = 254326, upload-time = "2026-03-17T10:30:21.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/79db81da58965bd29dabc8f4ad2a2af70611a57cba9d1ec006f072f30a54/coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743", size = 256267, upload-time = "2026-03-17T10:30:23.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/d0d7cc8168f91ddab44c0ce4806b969df5f5fdfdbb568eaca2dbc2a04936/coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75", size = 250430, upload-time = "2026-03-17T10:30:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/06/a055311d891ddbe231cd69fdd20ea4be6e3603ffebddf8704b8ca8e10a3c/coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209", size = 252017, upload-time = "2026-03-17T10:30:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/d0fd2d21e29a657b5f77a2fe7082e1568158340dceb941954f776dce1b7b/coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a", size = 250080, upload-time = "2026-03-17T10:30:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ab/0d7fb2efc2e9a5eb7ddcc6e722f834a69b454b7e6e5888c3a8567ecffb31/coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e", size = 253843, upload-time = "2026-03-17T10:30:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6f/7467b917bbf5408610178f62a49c0ed4377bb16c1657f689cc61470da8ce/coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd", size = 249802, upload-time = "2026-03-17T10:30:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2c/1172fb689df92135f5bfbbd69fc83017a76d24ea2e2f3a1154007e2fb9f8/coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8", size = 250707, upload-time = "2026-03-17T10:30:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/67/21/9ac389377380a07884e3b48ba7a620fcd9dbfaf1d40565facdc6b36ec9ef/coverage-7.13.5-cp311-cp311-win32.whl", hash = "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf", size = 221880, upload-time = "2026-03-17T10:30:36.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7f/4cd8a92531253f9d7c1bbecd9fa1b472907fb54446ca768c59b531248dc5/coverage-7.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9", size = 222816, upload-time = "2026-03-17T10:30:38.891Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a6/1d3f6155fb0010ca68eba7fe48ca6c9da7385058b77a95848710ecf189b1/coverage-7.13.5-cp311-cp311-win_arm64.whl", hash = "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028", size = 221483, upload-time = "2026-03-17T10:30:40.463Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -475,7 +535,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1450,6 +1510,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Fix #54 — PNG render fails for complex assemblies**: `render_view` was using `Mesher.add_shape()` which calls `mesh_3mf.IsValid()` (Lib3MF) — this rejects shapes that pass OCCT meshing but fail 3MF format validation. Replaced with `shape.tessellate()` + direct VTK PolyData construction, bypassing Lib3MF entirely. Added per-shape error handling: failed shapes are skipped with a `png_warnings` entry rather than aborting the whole render.
- **execute() is now transactional**: `current_shape` and `objects` are snapshotted before exec and restored on all error paths (Exception, AssertionError, ExecutionTimeout). Previously `show()` mutations inside failing code were left in place.
- **Assembly export via `object_name='*'`**: builds a `Compound` of all named shapes for STEP/STL. Also replaced `_stl_write`'s use of `Mesher` with `tessellate()` + binary STL writer for the same reason as render.
- **Dual MCP response for render_view**: returns both `ImageContent` (base64, standard MCP contract) and `TextContent([SEND: path])` for file-delivery clients. Adds `png_warnings` to MCP response. CLI help epilog: `--python 3.13` → `3.12`.

## Test plan

- [x] `uv run pytest tests/` — 184 passed (3 new outcome tests for assembly STEP, assembly STL binary format, and complex-shape STL export)
- [x] Manually verified purfroller assembly (7 parts, boolean subtractions) renders to PNG correctly with the new tessellate() path
- [x] Verified the old code path would have raised `RuntimeError: 3mf mesh is invalid` on purfroller

🤖 Generated with [Claude Code](https://claude.com/claude-code)