### PR TITLE
feat: last_error(), namespace vars in session_state(), measure(summary)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -53,7 +53,7 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
 
 @mcp.tool()
 def measure(query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
-    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
+    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary. summary returns bbox + volume + area + topology + center in one call — use it to orient quickly. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
     return _session.measure(query, object_name, object_name2)
 
 
@@ -116,7 +116,7 @@ def diff_snapshot(snapshot_a: str, snapshot_b: str = "", format: str = "text") -
 
 @mcp.tool()
 def session_state() -> str:
-    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, and snapshot names. Use this to orient after a reset, restore, or multi-step build to confirm what geometry is active."""
+    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, snapshot names, and a variables summary of the Python namespace (type + volume for shapes, type + length for collections, type + value for scalars). Use this to orient after a reset, restore, or multi-step build to confirm what geometry and variables are active."""
     return _session.session_state()
 
 
@@ -130,6 +130,12 @@ def health_check() -> str:
 def reset() -> str:
     """Clear the current session back to empty state, including all snapshots."""
     return _session.reset()
+
+
+@mcp.tool()
+def last_error() -> str:
+    """Return details of the last failed execute() call: exception type, message, line number within the submitted code, and a 5-line excerpt around the failing line. Returns {\"error\": null} if the last execute() succeeded or no execute() has failed yet. Call this immediately after an execute() error to get the exact failing line — much faster than re-reading the submitted code."""
+    return _session.last_error()
 
 
 @mcp.tool()

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -18,6 +18,7 @@ class Session:
         self.current_shape: Any = None
         self.objects: dict[str, Any] = {}
         self.snapshots: dict[str, Any] = {}
+        self.last_error_detail: dict[str, Any] | None = None
         self._inject_builtins()
 
     def _inject_builtins(self) -> None:
@@ -98,11 +99,14 @@ class Session:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            self.last_error_detail = {"type": "ExecutionTimeout", "message": str(e), "line": None, "excerpt": None}
             return f"Error: ExecutionTimeout: {e}"
         except AssertionError as e:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            msg = str(e) or "Constraint failed"
+            self.last_error_detail = {"type": "AssertionError", "message": msg, "line": None, "excerpt": None}
             return f"Constraint failed: {e}" if str(e) else "Constraint failed"
         except Exception as e:
             exc = e
@@ -115,8 +119,10 @@ class Session:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            self.last_error_detail = self._make_error_detail(exc, code)
             return f"Error: {type(exc).__name__}: {exc}"
 
+        self.last_error_detail = None
         new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - keys_before
         self._update_current_shape(new_keys)
 
@@ -126,6 +132,22 @@ class Session:
             if diag:
                 output = output.rstrip("\n") + "\n" + diag
         return output
+
+    def _make_error_detail(self, exc: Exception, code: str) -> dict[str, Any]:
+        import traceback as tb_module
+        frames = tb_module.extract_tb(exc.__traceback__)
+        mcp_frames = [f for f in frames if f.filename == "<mcp>"]
+        lineno: int | None = mcp_frames[-1].lineno if mcp_frames else None
+        excerpt: str | None = None
+        if lineno is not None:
+            lines = code.splitlines()
+            start = max(0, lineno - 3)
+            end = min(len(lines), lineno + 2)
+            excerpt = "\n".join(
+                f"{i + 1:3d}{'→ ' if i + 1 == lineno else '  '}{lines[i]}"
+                for i in range(start, end)
+            )
+        return {"type": type(exc).__name__, "message": str(exc), "line": lineno, "excerpt": excerpt}
 
     def _update_current_shape(self, new_keys: set[str]) -> None:
         try:
@@ -174,4 +196,5 @@ class Session:
         self.current_shape = None
         self.objects.clear()
         self.snapshots.clear()
+        self.last_error_detail = None
         self._inject_builtins()

--- a/src/build123d_mcp/tools/last_error.py
+++ b/src/build123d_mcp/tools/last_error.py
@@ -1,0 +1,7 @@
+import json
+
+
+def last_error(session) -> str:
+    if session.last_error_detail is None:
+        return json.dumps({"error": None}, indent=2)
+    return json.dumps(session.last_error_detail, indent=2)

--- a/src/build123d_mcp/tools/measure.py
+++ b/src/build123d_mcp/tools/measure.py
@@ -77,4 +77,23 @@ def measure(session, query: str = "bounding_box", object_name: str = "", object_
             "vertices": len(shape.vertices()),
         }, indent=2)
 
-    raise ValueError(f"Unknown query '{query}'. Use: bounding_box, volume, area, min_wall_thickness, clearance, topology")
+    if query == "summary":
+        bb = shape.bounding_box()
+        cx = round((bb.min.X + bb.max.X) / 2, 4)
+        cy = round((bb.min.Y + bb.max.Y) / 2, 4)
+        cz = round((bb.min.Z + bb.max.Z) / 2, 4)
+        return json.dumps({
+            "volume": round(shape.volume, 4),
+            "area": round(shape.area, 4),
+            "faces": len(shape.faces()),
+            "edges": len(shape.edges()),
+            "vertices": len(shape.vertices()),
+            "bbox": {
+                "xsize": round(bb.size.X, 4),
+                "ysize": round(bb.size.Y, 4),
+                "zsize": round(bb.size.Z, 4),
+            },
+            "center": {"x": cx, "y": cy, "z": cz},
+        }, indent=2)
+
+    raise ValueError(f"Unknown query '{query}'. Use: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary")

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -2,8 +2,47 @@ import json
 
 from build123d_mcp.tools.diff import _collect
 
+_SKIP = {"__builtins__", "show"}
+
+
+def _namespace_summary(namespace: dict) -> dict:
+    try:
+        from build123d import Shape
+    except ImportError:
+        Shape = None
+
+    result = {}
+    for name, val in namespace.items():
+        if name.startswith("_") or name in _SKIP:
+            continue
+        try:
+            typ = type(val).__name__
+            if Shape is not None and isinstance(val, Shape):
+                try:
+                    result[name] = {"type": typ, "volume": round(val.volume, 4)}
+                except Exception:
+                    result[name] = {"type": typ}
+            elif isinstance(val, (list, tuple)):
+                result[name] = {"type": typ, "length": len(val)}
+            elif isinstance(val, dict):
+                result[name] = {"type": "dict", "length": len(val)}
+            elif isinstance(val, bool):
+                result[name] = {"type": "bool", "value": val}
+            elif isinstance(val, (int, float)):
+                result[name] = {"type": typ, "value": val}
+            elif isinstance(val, str):
+                result[name] = {"type": "str", "value": val[:80]}
+            elif callable(val):
+                result[name] = {"type": "function"}
+            else:
+                result[name] = {"type": typ}
+        except Exception:
+            pass
+    return result
+
 
 def session_state(session) -> str:
     state = _collect(session.current_shape, session.objects)
     state["snapshots"] = list(session.snapshots.keys())
+    state["variables"] = _namespace_summary(session.namespace)
     return json.dumps(state, indent=2)

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -6,10 +6,12 @@ _SKIP = {"__builtins__", "show"}
 
 
 def _namespace_summary(namespace: dict) -> dict:
+    _shape_cls: type | None = None
     try:
         from build123d import Shape
+        _shape_cls = Shape
     except ImportError:
-        Shape = None
+        pass
 
     result = {}
     for name, val in namespace.items():
@@ -17,9 +19,9 @@ def _namespace_summary(namespace: dict) -> dict:
             continue
         try:
             typ = type(val).__name__
-            if Shape is not None and isinstance(val, Shape):
+            if _shape_cls is not None and isinstance(val, _shape_cls):
                 try:
-                    result[name] = {"type": typ, "volume": round(val.volume, 4)}
+                    result[name] = {"type": typ, "volume": round(val.volume, 4)}  # type: ignore[attr-defined]
                 except Exception:
                     result[name] = {"type": typ}
             elif isinstance(val, (list, tuple)):

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -122,6 +122,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from importlib.metadata import version
         return version("build123d-mcp")
 
+    if op == "last_error":
+        from build123d_mcp.tools.last_error import last_error
+        return last_error(session)
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -279,6 +283,9 @@ class WorkerSession:
 
     def version(self) -> str:
         return self._call("version", {}, self._SHORT_TIMEOUT)
+
+    def last_error(self) -> str:
+        return self._call("last_error", {}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -342,6 +342,75 @@ def test_clearance_zero_for_touching_shapes(session):
 
 
 # ---------------------------------------------------------------------------
+# measure(summary)
+# ---------------------------------------------------------------------------
+
+def test_measure_summary_returns_all_fields(session):
+    """summary query returns bbox, volume, area, topology, and center in one call."""
+    execute_code(session, "result = Box(10, 20, 30)")
+    data = json.loads(measure(session, "summary"))
+    assert abs(data["volume"] - 6000) < 1
+    assert data["faces"] == 6
+    assert "bbox" in data and abs(data["bbox"]["xsize"] - 10) < 0.01
+    assert "center" in data and abs(data["center"]["x"]) < 0.01
+    assert "area" in data and data["area"] > 0
+
+
+# ---------------------------------------------------------------------------
+# last_error()
+# ---------------------------------------------------------------------------
+
+def test_last_error_captures_type_message_and_line(session):
+    """After a failed execute(), last_error() returns the exception type, message,
+    and the 1-based line number within the submitted code."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("x = 1\ny = 2\nraise ValueError('boom')\nz = 3")
+    data = json.loads(get_last_error(session))
+    assert data["type"] == "ValueError"
+    assert "boom" in data["message"]
+    assert data["line"] == 3
+    assert "boom" in data["excerpt"]
+    assert "→" in data["excerpt"]
+
+
+def test_last_error_cleared_after_success(session):
+    """A successful execute() clears last_error."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("raise RuntimeError('oops')")
+    assert json.loads(get_last_error(session))["type"] == "RuntimeError"
+    session.execute("result = Box(5, 5, 5)")
+    assert json.loads(get_last_error(session))["error"] is None
+
+
+def test_last_error_null_before_any_failure(session):
+    """last_error() returns {error: null} when no execute() has failed."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("result = Box(1, 1, 1)")
+    assert json.loads(get_last_error(session))["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# session_state() namespace variables
+# ---------------------------------------------------------------------------
+
+def test_session_state_includes_namespace_variables(session):
+    """session_state() variables key summarises Python namespace: scalars, lists, Shapes."""
+    from build123d_mcp.tools.session_state import session_state as get_state
+    execute_code(session,
+        "width = 40.0\n"
+        "tags = ['a', 'b', 'c']\n"
+        "result = Box(width, 10, 10)"
+    )
+    data = json.loads(get_state(session))
+    assert "variables" in data
+    vs = data["variables"]
+    assert vs["width"]["type"] == "float" and abs(vs["width"]["value"] - 40.0) < 0.001
+    assert vs["tags"]["type"] == "list" and vs["tags"]["length"] == 3
+    # result is a Shape — should have volume
+    assert "volume" in vs["result"]
+
+
+# ---------------------------------------------------------------------------
 # Rendering quality and clip plane
 # ---------------------------------------------------------------------------
 
@@ -403,7 +472,8 @@ def test_mcp_lists_all_tools():
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
-                     "search_library", "load_part", "workflow_hints", "session_state", "health_check", "version"}
+                     "search_library", "load_part", "workflow_hints", "session_state", "health_check",
+                     "version", "last_error"}
 
 
 @_skip_mcp_on_win


### PR DESCRIPTION
## Summary

Three tools to improve Codex's ability to iterate on build123d code without external help:

- **`last_error()`** — new tool. After any failed `execute()`, returns `{type, message, line, excerpt}` where `line` is the 1-based line number within the submitted code (from the `<mcp>` traceback frame) and `excerpt` is 5 lines centred on the failure with an arrow marker. Cleared on success and `reset()`. Codex can call this immediately after an error to see the exact failing line.

- **`session_state()` + namespace variables** — adds a `variables` key to the existing response summarising the Python namespace: `{type, volume}` for Shapes, `{type, length}` for lists/tuples/dicts, `{type, value}` for scalars/strings, `{type: "function"}` for callables. Private names, `__builtins__`, and `show` are skipped. Helps Codex recover context after multi-step scripts.

- **`measure(summary)`** — new query that returns `bbox + volume + area + topology + center` in one call, replacing the 3–4 separate `measure()` calls previously needed to orient on a shape.

## Test plan

- [x] 5 new outcome tests: `measure_summary` has all fields, `last_error` captures type/message/line/excerpt, `last_error` cleared after success, `last_error` null before any failure, `session_state` includes namespace variables
- [x] `test_mcp_lists_all_tools` updated for `last_error`
- [x] `uv run pytest tests/` — 189 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)