### PR TITLE
feat: validate_code(), shape_compare(), repair_hints()

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -133,6 +133,26 @@ def reset() -> str:
 
 
 @mcp.tool()
+def validate_code(code: str) -> str:
+    """Check build123d code for syntax errors, blocked imports/calls, and common omissions before executing. Returns {syntax, blocked, warnings, ok}. blocked items prevent execution; warnings are advisory (e.g. no build123d import in this snippet, no result/show() call). Use this before a long generated script to catch obvious problems without burning a session execute()."""
+    from build123d_mcp.tools.validate_code import validate_code as _validate_code
+    return _validate_code(code)
+
+
+@mcp.tool()
+def shape_compare(object_a: str, object_b: str) -> str:
+    """Compare two named shapes (from show()) by geometry metrics: volume delta, bbox delta, topology delta (faces/edges/vertices), and center offset. Useful when you have an intended design and a reference/test shape and want to verify they match — or to quantify how a modification changed the geometry."""
+    return _session.shape_compare(object_a, object_b)
+
+
+@mcp.tool()
+def repair_hints(error_text: str) -> str:
+    """Given an error message from execute(), return targeted fix suggestions for common build123d mistakes: wrong Location syntax, missing .part, CadQuery idioms, blocked imports, degenerate boolean results, fillet edge selection, and more. Pass the full error string from execute() or last_error()."""
+    from build123d_mcp.tools.repair_hints import repair_hints as _repair_hints
+    return _repair_hints(error_text)
+
+
+@mcp.tool()
 def last_error() -> str:
     """Return details of the last failed execute() call: exception type, message, line number within the submitted code, and a 5-line excerpt around the failing line. Returns {\"error\": null} if the last execute() succeeded or no execute() has failed yet. Call this immediately after an execute() error to get the exact failing line — much faster than re-reading the submitted code."""
     return _session.last_error()

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -53,7 +53,7 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
 
 @mcp.tool()
 def measure(query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
-    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
+    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary. summary returns bbox + volume + area + topology + center in one call — use it to orient quickly. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
     return _session.measure(query, object_name, object_name2)
 
 
@@ -116,7 +116,7 @@ def diff_snapshot(snapshot_a: str, snapshot_b: str = "", format: str = "text") -
 
 @mcp.tool()
 def session_state() -> str:
-    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, and snapshot names. Use this to orient after a reset, restore, or multi-step build to confirm what geometry is active."""
+    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, snapshot names, and a variables summary of the Python namespace (type + volume for shapes, type + length for collections, type + value for scalars). Use this to orient after a reset, restore, or multi-step build to confirm what geometry and variables are active."""
     return _session.session_state()
 
 
@@ -130,6 +130,12 @@ def health_check() -> str:
 def reset() -> str:
     """Clear the current session back to empty state, including all snapshots."""
     return _session.reset()
+
+
+@mcp.tool()
+def last_error() -> str:
+    """Return details of the last failed execute() call: exception type, message, line number within the submitted code, and a 5-line excerpt around the failing line. Returns {\"error\": null} if the last execute() succeeded or no execute() has failed yet. Call this immediately after an execute() error to get the exact failing line — much faster than re-reading the submitted code."""
+    return _session.last_error()
 
 
 @mcp.tool()

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -18,6 +18,7 @@ class Session:
         self.current_shape: Any = None
         self.objects: dict[str, Any] = {}
         self.snapshots: dict[str, Any] = {}
+        self.last_error_detail: dict[str, Any] | None = None
         self._inject_builtins()
 
     def _inject_builtins(self) -> None:
@@ -98,11 +99,14 @@ class Session:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            self.last_error_detail = {"type": "ExecutionTimeout", "message": str(e), "line": None, "excerpt": None}
             return f"Error: ExecutionTimeout: {e}"
         except AssertionError as e:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            msg = str(e) or "Constraint failed"
+            self.last_error_detail = {"type": "AssertionError", "message": msg, "line": None, "excerpt": None}
             return f"Constraint failed: {e}" if str(e) else "Constraint failed"
         except Exception as e:
             exc = e
@@ -115,8 +119,10 @@ class Session:
             self.current_shape = shape_before
             self.objects.clear()
             self.objects.update(objects_before)
+            self.last_error_detail = self._make_error_detail(exc, code)
             return f"Error: {type(exc).__name__}: {exc}"
 
+        self.last_error_detail = None
         new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - keys_before
         self._update_current_shape(new_keys)
 
@@ -126,6 +132,22 @@ class Session:
             if diag:
                 output = output.rstrip("\n") + "\n" + diag
         return output
+
+    def _make_error_detail(self, exc: Exception, code: str) -> dict[str, Any]:
+        import traceback as tb_module
+        frames = tb_module.extract_tb(exc.__traceback__)
+        mcp_frames = [f for f in frames if f.filename == "<mcp>"]
+        lineno: int | None = mcp_frames[-1].lineno if mcp_frames else None
+        excerpt: str | None = None
+        if lineno is not None:
+            lines = code.splitlines()
+            start = max(0, lineno - 3)
+            end = min(len(lines), lineno + 2)
+            excerpt = "\n".join(
+                f"{i + 1:3d}{'→ ' if i + 1 == lineno else '  '}{lines[i]}"
+                for i in range(start, end)
+            )
+        return {"type": type(exc).__name__, "message": str(exc), "line": lineno, "excerpt": excerpt}
 
     def _update_current_shape(self, new_keys: set[str]) -> None:
         try:
@@ -174,4 +196,5 @@ class Session:
         self.current_shape = None
         self.objects.clear()
         self.snapshots.clear()
+        self.last_error_detail = None
         self._inject_builtins()

--- a/src/build123d_mcp/tools/last_error.py
+++ b/src/build123d_mcp/tools/last_error.py
@@ -1,0 +1,7 @@
+import json
+
+
+def last_error(session) -> str:
+    if session.last_error_detail is None:
+        return json.dumps({"error": None}, indent=2)
+    return json.dumps(session.last_error_detail, indent=2)

--- a/src/build123d_mcp/tools/measure.py
+++ b/src/build123d_mcp/tools/measure.py
@@ -77,4 +77,23 @@ def measure(session, query: str = "bounding_box", object_name: str = "", object_
             "vertices": len(shape.vertices()),
         }, indent=2)
 
-    raise ValueError(f"Unknown query '{query}'. Use: bounding_box, volume, area, min_wall_thickness, clearance, topology")
+    if query == "summary":
+        bb = shape.bounding_box()
+        cx = round((bb.min.X + bb.max.X) / 2, 4)
+        cy = round((bb.min.Y + bb.max.Y) / 2, 4)
+        cz = round((bb.min.Z + bb.max.Z) / 2, 4)
+        return json.dumps({
+            "volume": round(shape.volume, 4),
+            "area": round(shape.area, 4),
+            "faces": len(shape.faces()),
+            "edges": len(shape.edges()),
+            "vertices": len(shape.vertices()),
+            "bbox": {
+                "xsize": round(bb.size.X, 4),
+                "ysize": round(bb.size.Y, 4),
+                "zsize": round(bb.size.Z, 4),
+            },
+            "center": {"x": cx, "y": cy, "z": cz},
+        }, indent=2)
+
+    raise ValueError(f"Unknown query '{query}'. Use: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary")

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -1,0 +1,92 @@
+import json
+import re
+
+_HINTS: list[tuple[list[str], str]] = [
+    (
+        [r"NoneType.*has no attribute", r"AttributeError.*None"],
+        "Shape is None. If you used BuildPart context manager, access the result with "
+        "`.part` (e.g. `result = bp.part`). In algebra mode, assign directly: "
+        "`result = Box(10,10,10) - Cylinder(3,12)`.",
+    ),
+    (
+        [r"None context requested", r"No context.*requested"],
+        "build123d algebra mode requires no context manager — create shapes directly "
+        "and assign to `result` or call `show()`. Remove `with BuildPart()` wrappers "
+        "if you're using operator-based construction.",
+    ),
+    (
+        [r"cq\.", r"Workplane", r"CadQuery"],
+        "CadQuery syntax detected. build123d uses a different API: "
+        "`Box(w,h,d)` not `cq.Workplane().box(w,h,d)`. "
+        "Replace `.translate()` with `.move(Location((x,y,z)))`, "
+        "`.rotate()` with `.rotate(Axis.Z, angle)`, "
+        "and `.union()`/`.cut()` with `+`/`-` operators.",
+    ),
+    (
+        [r"TypeError.*Location", r"Location.*argument"],
+        "Location syntax: pass a tuple — `Location((x, y, z))` not `Location(x, y, z)`. "
+        "For combined translation + rotation: `Location((x,y,z), (rx,ry,rz))`.",
+    ),
+    (
+        [r"[Ff]illet.*edge", r"[Ee]dge.*fillet", r"ValueError.*edges.*fillet"],
+        "Fillet edge selection: edges must be non-tangent and the radius must be smaller "
+        "than the adjacent wall thickness. Select edges with "
+        "`shape.edges().filter_by(Axis.Z)` or index them with `shape.edges()[0]`. "
+        "Avoid `shape.edges()` (all edges) on complex shapes — pick specific ones.",
+    ),
+    (
+        [r"NameError.*\b(Box|Cylinder|Sphere|Cone|Torus|Extrude|BuildPart|"
+         r"BuildSketch|Align|Axis|Location|Plane|Vector|Color|Compound|Shell|"
+         r"Fillet|Chamfer|extrude|loft|sweep)\b"],
+        "build123d name not in scope. Add `from build123d import *` at the top of "
+        "the execute() call. If it was imported in a previous call, re-run that import "
+        "or include it in this snippet.",
+    ),
+    (
+        [r"ImportError", r"SecurityError", r"not allowed.*import", r"import.*not allowed"],
+        "Import blocked. Only these modules are allowed: build123d, math, numpy, "
+        "typing, collections, itertools, functools, copy. "
+        "Remove os, sys, pathlib, subprocess, and network imports.",
+    ),
+    (
+        [r"Constraint failed", r"AssertionError"],
+        "Constraint failed — a dimension is physically impossible. Common causes: "
+        "fillet radius larger than the adjacent face, hole diameter larger than "
+        "the wall, or zero/negative dimensions. Check all numeric parameters.",
+    ),
+    (
+        [r"empty.*[Ss]hape", r"[Ss]hape.*empty", r"degenerate", r"no.*solid"],
+        "Degenerate or empty shape after boolean operation. The cutter probably doesn't "
+        "overlap the base, or the result has zero volume. Verify positions with "
+        "measure(bounding_box) on both shapes before the boolean.",
+    ),
+    (
+        [r"ExecutionTimeout"],
+        "Execution timed out. Likely causes: very high-resolution mesh "
+        "(lower angular_deflection), deeply nested boolean operations, or an "
+        "infinite loop. Simplify the geometry or break it into smaller steps.",
+    ),
+    (
+        [r"\.part\b"],
+        "If you see an error referencing `.part`: in BuildPart context manager usage "
+        "you must explicitly read `context.part` to get the Shape. "
+        "In algebra mode (recommended) you don't need `.part` at all.",
+    ),
+]
+
+
+def repair_hints(error_text: str) -> str:
+    matches = []
+    for patterns, hint in _HINTS:
+        if any(re.search(p, error_text) for p in patterns):
+            matches.append(hint)
+
+    if not matches:
+        matches.append(
+            "No specific hint matched. Call last_error() for the exact line and "
+            "exception, then check: (1) shapes are non-None before boolean ops, "
+            "(2) `from build123d import *` is in scope, "
+            "(3) Location uses a tuple argument."
+        )
+
+    return json.dumps({"hints": matches}, indent=2)

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -2,8 +2,47 @@ import json
 
 from build123d_mcp.tools.diff import _collect
 
+_SKIP = {"__builtins__", "show"}
+
+
+def _namespace_summary(namespace: dict) -> dict:
+    try:
+        from build123d import Shape
+    except ImportError:
+        Shape = None
+
+    result = {}
+    for name, val in namespace.items():
+        if name.startswith("_") or name in _SKIP:
+            continue
+        try:
+            typ = type(val).__name__
+            if Shape is not None and isinstance(val, Shape):
+                try:
+                    result[name] = {"type": typ, "volume": round(val.volume, 4)}
+                except Exception:
+                    result[name] = {"type": typ}
+            elif isinstance(val, (list, tuple)):
+                result[name] = {"type": typ, "length": len(val)}
+            elif isinstance(val, dict):
+                result[name] = {"type": "dict", "length": len(val)}
+            elif isinstance(val, bool):
+                result[name] = {"type": "bool", "value": val}
+            elif isinstance(val, (int, float)):
+                result[name] = {"type": typ, "value": val}
+            elif isinstance(val, str):
+                result[name] = {"type": "str", "value": val[:80]}
+            elif callable(val):
+                result[name] = {"type": "function"}
+            else:
+                result[name] = {"type": typ}
+        except Exception:
+            pass
+    return result
+
 
 def session_state(session) -> str:
     state = _collect(session.current_shape, session.objects)
     state["snapshots"] = list(session.snapshots.keys())
+    state["variables"] = _namespace_summary(session.namespace)
     return json.dumps(state, indent=2)

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -6,10 +6,12 @@ _SKIP = {"__builtins__", "show"}
 
 
 def _namespace_summary(namespace: dict) -> dict:
+    _shape_cls: type | None = None
     try:
         from build123d import Shape
+        _shape_cls = Shape
     except ImportError:
-        Shape = None
+        pass
 
     result = {}
     for name, val in namespace.items():
@@ -17,9 +19,9 @@ def _namespace_summary(namespace: dict) -> dict:
             continue
         try:
             typ = type(val).__name__
-            if Shape is not None and isinstance(val, Shape):
+            if _shape_cls is not None and isinstance(val, _shape_cls):
                 try:
-                    result[name] = {"type": typ, "volume": round(val.volume, 4)}
+                    result[name] = {"type": typ, "volume": round(val.volume, 4)}  # type: ignore[attr-defined]
                 except Exception:
                     result[name] = {"type": typ}
             elif isinstance(val, (list, tuple)):

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -1,0 +1,37 @@
+import json
+
+from build123d_mcp.tools.diff import _shape_diag
+
+
+def shape_compare(session, object_a: str, object_b: str) -> str:
+    if object_a not in session.objects:
+        raise ValueError(f"Unknown object '{object_a}'. Registered: {list(session.objects.keys())}")
+    if object_b not in session.objects:
+        raise ValueError(f"Unknown object '{object_b}'. Registered: {list(session.objects.keys())}")
+
+    sa, sb = session.objects[object_a], session.objects[object_b]
+    da, db = _shape_diag(sa), _shape_diag(sb)
+
+    def _center(shape):
+        bb = shape.bounding_box()
+        return {
+            "x": round((bb.min.X + bb.max.X) / 2, 4),
+            "y": round((bb.min.Y + bb.max.Y) / 2, 4),
+            "z": round((bb.min.Z + bb.max.Z) / 2, 4),
+        }
+
+    ca, cb = _center(sa), _center(sb)
+    offset = round(((cb["x"] - ca["x"])**2 + (cb["y"] - ca["y"])**2 + (cb["z"] - ca["z"])**2) ** 0.5, 4)
+
+    return json.dumps({
+        "a": {"name": object_a, **da, "center": ca},
+        "b": {"name": object_b, **db, "center": cb},
+        "delta": {
+            "volume": round(db["volume"] - da["volume"], 4),
+            "faces": db["faces"] - da["faces"],
+            "edges": db["edges"] - da["edges"],
+            "vertices": db["vertices"] - da["vertices"],
+            "bbox": [round(db["bbox"][i] - da["bbox"][i], 4) for i in range(3)],
+            "center_offset": offset,
+        },
+    }, indent=2)

--- a/src/build123d_mcp/tools/validate_code.py
+++ b/src/build123d_mcp/tools/validate_code.py
@@ -1,0 +1,66 @@
+import ast
+import json
+
+from build123d_mcp.security import IMPORT_ALLOWLIST, _BLOCKED_CALL_NAMES
+
+
+def validate_code(code: str) -> str:
+    # Syntax check
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return json.dumps({
+            "syntax": f"SyntaxError at line {e.lineno}: {e.msg}",
+            "blocked": [],
+            "warnings": [],
+            "ok": False,
+        }, indent=2)
+
+    blocked = []
+    warnings = []
+
+    # Security: blocked imports and calls
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root not in IMPORT_ALLOWLIST:
+                    blocked.append(f"import '{alias.name}' is not allowed")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                root = node.module.split(".")[0]
+                if root not in IMPORT_ALLOWLIST:
+                    blocked.append(f"import '{node.module}' is not allowed")
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
+                blocked.append(f"call to '{node.func.id}' is not allowed")
+        elif isinstance(node, ast.Attribute):
+            if node.attr.startswith("__") and node.attr.endswith("__"):
+                blocked.append(f"dunder attribute access '{node.attr}' is not allowed")
+
+    # Advisory: no build123d import in this snippet
+    has_b3d_import = any(
+        (isinstance(n, ast.ImportFrom) and n.module and n.module.startswith("build123d"))
+        or (isinstance(n, ast.Import) and any(a.name.startswith("build123d") for a in n.names))
+        for n in ast.walk(tree)
+    )
+    if not has_b3d_import:
+        warnings.append("no build123d import in this snippet — ok if already imported in a prior execute()")
+
+    # Advisory: no result variable or show() call
+    has_output = any(
+        (isinstance(n, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "result" for t in n.targets
+        ))
+        or (isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "show")
+        for n in ast.walk(tree)
+    )
+    if not has_output:
+        warnings.append("no 'result' assignment or show() call — the session won't capture a shape unless current_shape is set by other means")
+
+    return json.dumps({
+        "syntax": "ok",
+        "blocked": blocked,
+        "warnings": warnings,
+        "ok": len(blocked) == 0,
+    }, indent=2)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -126,6 +126,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.last_error import last_error
         return last_error(session)
 
+    if op == "shape_compare":
+        from build123d_mcp.tools.shape_compare import shape_compare
+        return shape_compare(session, args["object_a"], args["object_b"])
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -286,6 +290,9 @@ class WorkerSession:
 
     def last_error(self) -> str:
         return self._call("last_error", {}, self._SHORT_TIMEOUT)
+
+    def shape_compare(self, object_a: str, object_b: str) -> str:
+        return self._call("shape_compare", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -122,6 +122,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from importlib.metadata import version
         return version("build123d-mcp")
 
+    if op == "last_error":
+        from build123d_mcp.tools.last_error import last_error
+        return last_error(session)
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -279,6 +283,9 @@ class WorkerSession:
 
     def version(self) -> str:
         return self._call("version", {}, self._SHORT_TIMEOUT)
+
+    def last_error(self) -> str:
+        return self._call("last_error", {}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -411,6 +411,92 @@ def test_session_state_includes_namespace_variables(session):
 
 
 # ---------------------------------------------------------------------------
+# validate_code()
+# ---------------------------------------------------------------------------
+
+def test_validate_code_clean_script_is_ok():
+    """Well-formed build123d code returns ok=True with no blocked items."""
+    from build123d_mcp.tools.validate_code import validate_code
+    result = json.loads(validate_code("from build123d import *\nresult = Box(10, 10, 10)"))
+    assert result["ok"] is True
+    assert result["syntax"] == "ok"
+    assert result["blocked"] == []
+
+
+def test_validate_code_catches_syntax_error():
+    """A syntax error is reported and ok=False."""
+    from build123d_mcp.tools.validate_code import validate_code
+    result = json.loads(validate_code("def foo(\n  pass"))
+    assert result["ok"] is False
+    assert "SyntaxError" in result["syntax"]
+
+
+def test_validate_code_catches_blocked_import():
+    """Importing os is flagged as blocked."""
+    from build123d_mcp.tools.validate_code import validate_code
+    result = json.loads(validate_code("import os\nresult = Box(10,10,10)"))
+    assert result["ok"] is False
+    assert any("os" in b for b in result["blocked"])
+
+
+def test_validate_code_warns_no_output():
+    """Code with no result assignment or show() call gets a warning."""
+    from build123d_mcp.tools.validate_code import validate_code
+    result = json.loads(validate_code("from build123d import *\nx = 1 + 2"))
+    assert result["ok"] is True  # not blocked, just a warning
+    assert any("result" in w or "show" in w for w in result["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# shape_compare()
+# ---------------------------------------------------------------------------
+
+def test_shape_compare_reports_volume_delta(session):
+    """shape_compare() reports the correct volume difference between two named shapes."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+    execute_code(session, "show(Box(10, 10, 10), 'small')\nshow(Box(20, 20, 20), 'large')")
+    data = json.loads(shape_compare(session, "small", "large"))
+    assert abs(data["a"]["volume"] - 1000) < 1
+    assert abs(data["b"]["volume"] - 8000) < 1
+    assert abs(data["delta"]["volume"] - 7000) < 1
+
+
+def test_shape_compare_identical_shapes_zero_delta(session):
+    """Comparing two identical shapes gives zero volume delta and zero center offset."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+    execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10), 'b')")
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert abs(data["delta"]["volume"]) < 0.001
+    assert data["delta"]["center_offset"] < 0.001
+
+
+# ---------------------------------------------------------------------------
+# repair_hints()
+# ---------------------------------------------------------------------------
+
+def test_repair_hints_matches_nonetype_error():
+    """NoneType attribute error gets the .part hint."""
+    from build123d_mcp.tools.repair_hints import repair_hints
+    result = json.loads(repair_hints("AttributeError: 'NoneType' has no attribute 'volume'"))
+    assert any(".part" in h or "None" in h for h in result["hints"])
+
+
+def test_repair_hints_matches_cq_idiom():
+    """CadQuery-style error text gets the API mismatch hint."""
+    from build123d_mcp.tools.repair_hints import repair_hints
+    result = json.loads(repair_hints("NameError: cq is not defined"))
+    assert any("CadQuery" in h or "build123d" in h for h in result["hints"])
+
+
+def test_repair_hints_fallback_for_unknown_error():
+    """Unrecognised error text returns the generic fallback hint."""
+    from build123d_mcp.tools.repair_hints import repair_hints
+    result = json.loads(repair_hints("some totally unknown error xyz"))
+    assert len(result["hints"]) == 1
+    assert "last_error" in result["hints"][0]
+
+
+# ---------------------------------------------------------------------------
 # Rendering quality and clip plane
 # ---------------------------------------------------------------------------
 
@@ -473,7 +559,7 @@ def test_mcp_lists_all_tools():
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
                      "search_library", "load_part", "workflow_hints", "session_state", "health_check",
-                     "version", "last_error"}
+                     "version", "last_error", "validate_code", "shape_compare", "repair_hints"}
 
 
 @_skip_mcp_on_win

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -342,6 +342,75 @@ def test_clearance_zero_for_touching_shapes(session):
 
 
 # ---------------------------------------------------------------------------
+# measure(summary)
+# ---------------------------------------------------------------------------
+
+def test_measure_summary_returns_all_fields(session):
+    """summary query returns bbox, volume, area, topology, and center in one call."""
+    execute_code(session, "result = Box(10, 20, 30)")
+    data = json.loads(measure(session, "summary"))
+    assert abs(data["volume"] - 6000) < 1
+    assert data["faces"] == 6
+    assert "bbox" in data and abs(data["bbox"]["xsize"] - 10) < 0.01
+    assert "center" in data and abs(data["center"]["x"]) < 0.01
+    assert "area" in data and data["area"] > 0
+
+
+# ---------------------------------------------------------------------------
+# last_error()
+# ---------------------------------------------------------------------------
+
+def test_last_error_captures_type_message_and_line(session):
+    """After a failed execute(), last_error() returns the exception type, message,
+    and the 1-based line number within the submitted code."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("x = 1\ny = 2\nraise ValueError('boom')\nz = 3")
+    data = json.loads(get_last_error(session))
+    assert data["type"] == "ValueError"
+    assert "boom" in data["message"]
+    assert data["line"] == 3
+    assert "boom" in data["excerpt"]
+    assert "→" in data["excerpt"]
+
+
+def test_last_error_cleared_after_success(session):
+    """A successful execute() clears last_error."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("raise RuntimeError('oops')")
+    assert json.loads(get_last_error(session))["type"] == "RuntimeError"
+    session.execute("result = Box(5, 5, 5)")
+    assert json.loads(get_last_error(session))["error"] is None
+
+
+def test_last_error_null_before_any_failure(session):
+    """last_error() returns {error: null} when no execute() has failed."""
+    from build123d_mcp.tools.last_error import last_error as get_last_error
+    session.execute("result = Box(1, 1, 1)")
+    assert json.loads(get_last_error(session))["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# session_state() namespace variables
+# ---------------------------------------------------------------------------
+
+def test_session_state_includes_namespace_variables(session):
+    """session_state() variables key summarises Python namespace: scalars, lists, Shapes."""
+    from build123d_mcp.tools.session_state import session_state as get_state
+    execute_code(session,
+        "width = 40.0\n"
+        "tags = ['a', 'b', 'c']\n"
+        "result = Box(width, 10, 10)"
+    )
+    data = json.loads(get_state(session))
+    assert "variables" in data
+    vs = data["variables"]
+    assert vs["width"]["type"] == "float" and abs(vs["width"]["value"] - 40.0) < 0.001
+    assert vs["tags"]["type"] == "list" and vs["tags"]["length"] == 3
+    # result is a Shape — should have volume
+    assert "volume" in vs["result"]
+
+
+# ---------------------------------------------------------------------------
 # Rendering quality and clip plane
 # ---------------------------------------------------------------------------
 
@@ -403,7 +472,8 @@ def test_mcp_lists_all_tools():
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
-                     "search_library", "load_part", "workflow_hints", "session_state", "health_check", "version"}
+                     "search_library", "load_part", "workflow_hints", "session_state", "health_check",
+                     "version", "last_error"}
 
 
 @_skip_mcp_on_win


### PR DESCRIPTION
## Summary

Three tools to improve Codex's ability to author and debug build123d code:

- **`validate_code(code)`** — pre-flight check before executing. Runs syntax check, blocked-import/call detection (reusing `security.py`), and advisory checks for missing `from build123d import *` and missing `result`/`show()`. Returns `{syntax, blocked, warnings, ok}`. Codex can call this before a long generated script to catch obvious mistakes without burning a session execute().

- **`shape_compare(object_a, object_b)`** — compares two named shapes (registered via `show()`) by volume, bbox dimensions, topology (faces/edges/vertices), and 3D center offset. Reuses `_shape_diag()` from `diff.py`. Useful when Codex has an intended design and a reference/test shape and needs to verify they match, or to quantify how a modification changed geometry.

- **`repair_hints(error_text)`** — 11-entry lookup table matched against error text with targeted fix suggestions for common build123d mistakes: missing `.part` from BuildPart context, NoneType shape errors, CadQuery idiom confusion, wrong `Location` tuple syntax, fillet edge selection, blocked imports, degenerate boolean results, constraint failures, execution timeouts. Falls back to a generic hint pointing at `last_error()` if nothing matches.

## Test plan

- [x] 9 new outcome tests covering all three tools
- [x] `test_mcp_lists_all_tools` updated for 3 new tool names
- [x] `uv run pytest tests/` — 198 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)