### PR TITLE
feat: expand import allowlist + --allow-all-imports flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mcp",
     "build123d",
     "pyvista",
+    "bd_warehouse",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -27,15 +27,46 @@ EXEC_TIMEOUT_SECONDS = 30
 # Modules user code may import. build123d's own internal imports are
 # unaffected — they run through the real import system, not this namespace.
 IMPORT_ALLOWLIST = frozenset({
+    # CAD libraries
     "build123d",
+    "bd_warehouse",
+    # Numeric / math
     "math",
     "numpy",
-    "typing",
+    "decimal",
+    "fractions",
+    "statistics",
+    "numbers",
+    "random",
+    # Data structures / utilities
     "collections",
     "itertools",
     "functools",
     "copy",
+    "operator",
+    "struct",
+    # Type system
+    "typing",
+    "abc",
+    "dataclasses",
+    "enum",
+    # String / text
+    "re",
+    "string",
+    "textwrap",
+    "pprint",
+    # Serialisation (in-memory only — no I/O)
+    "json",
+    "base64",
+    "hashlib",
+    # Misc stdlib
+    "io",
+    "warnings",
+    "contextlib",
 })
+
+# When True, import checks are skipped entirely.  Set via --allow-all-imports.
+ALLOW_ALL_IMPORTS: bool = False
 
 # Builtins that are dangerous even without an import.
 _BLOCKED_BUILTINS = frozenset({
@@ -65,6 +96,14 @@ def check_ast(code: str) -> None:
     try:
         tree = ast.parse(code)
     except SyntaxError:
+        return
+
+    if ALLOW_ALL_IMPORTS:
+        # Still block dangerous calls even in unrestricted mode.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
+                    raise ValueError(f"Call to '{node.func.id}' is not allowed.")
         return
 
     for node in ast.walk(tree):
@@ -117,6 +156,10 @@ def make_restricted_builtins() -> dict[str, Any]:
         safe.pop(name, None)
 
     _original_import = safe["__import__"]
+
+    if ALLOW_ALL_IMPORTS:
+        safe["__import__"] = _original_import
+        return safe
 
     def _safe_import(name: str, *args: Any, **kwargs: Any) -> Any:
         root = name.split(".")[0]

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -273,14 +273,24 @@ Part library file format (Python, any .py file under --library path):
         default=os.environ.get("BUILD123D_PART_LIBRARY", ""),
         help="Path to part library directory (overrides BUILD123D_PART_LIBRARY env var)",
     )
+    parser.add_argument(
+        "--allow-all-imports", action="store_true",
+        default=os.environ.get("BUILD123D_ALLOW_ALL_IMPORTS", "").lower() in ("1", "true", "yes"),
+        help="Disable the import allowlist — any Python module can be imported. "
+             "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
+    )
     args = parser.parse_args()
 
     if args.library and not os.path.isdir(args.library):
         parser.error(f"Library path is not a directory: {args.library}")
 
+    if args.allow_all_imports:
+        import build123d_mcp.security as _sec
+        _sec.ALLOW_ALL_IMPORTS = True
+
     global _session, _has_library
     _has_library = bool(args.library)
-    _session = WorkerSession(library_path=args.library)
+    _session = WorkerSession(library_path=args.library, allow_all_imports=args.allow_all_imports)
 
     mcp.run()
 

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -44,9 +44,12 @@ _HINTS: list[tuple[list[str], str]] = [
     ),
     (
         [r"ImportError", r"SecurityError", r"not allowed.*import", r"import.*not allowed"],
-        "Import blocked. Only these modules are allowed: build123d, math, numpy, "
-        "typing, collections, itertools, functools, copy. "
-        "Remove os, sys, pathlib, subprocess, and network imports.",
+        "Import blocked. Allowed modules: build123d, bd_warehouse, math, numpy, decimal, "
+        "fractions, statistics, numbers, random, collections, itertools, functools, copy, "
+        "operator, struct, typing, abc, dataclasses, enum, re, string, textwrap, pprint, "
+        "json, base64, hashlib, io, warnings, contextlib. "
+        "Remove os, sys, pathlib, subprocess, socket, and network imports. "
+        "Start the server with --allow-all-imports to disable this check entirely.",
     ),
     (
         [r"Constraint failed", r"AssertionError"],

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -20,11 +20,15 @@ from typing import Any
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
 
-def worker_main(conn: Any, library_path: str = "", exec_timeout: int = 30) -> None:
+def worker_main(conn: Any, library_path: str = "", exec_timeout: int = 30, allow_all_imports: bool = False) -> None:
     """Entry point run in the worker subprocess.
 
     Loops receiving requests until the parent closes the connection.
     """
+    if allow_all_imports:
+        import build123d_mcp.security as _sec
+        _sec.ALLOW_ALL_IMPORTS = True
+
     from build123d_mcp.session import Session
 
     session = Session(exec_timeout=exec_timeout)
@@ -144,9 +148,10 @@ class WorkerSession:
     _INTERFERENCE_TIMEOUT = 30
     _SHORT_TIMEOUT = 10
 
-    def __init__(self, exec_timeout: int = 30, library_path: str = "") -> None:
+    def __init__(self, exec_timeout: int = 30, library_path: str = "", allow_all_imports: bool = False) -> None:
         self._exec_timeout = exec_timeout
         self._library_path = library_path
+        self._allow_all_imports = allow_all_imports
         self._conn: Any = None
         self._proc: Any = None
         self._start_worker()
@@ -156,7 +161,7 @@ class WorkerSession:
         parent_conn, child_conn = ctx.Pipe()
         self._proc = ctx.Process(
             target=worker_main,
-            args=(child_conn, self._library_path, self._exec_timeout),
+            args=(child_conn, self._library_path, self._exec_timeout, self._allow_all_imports),
             daemon=True,
         )
         self._proc.start()

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,19 @@ wheels = [
 ]
 
 [[package]]
+name = "bd-warehouse"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "build123d" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/67/60edfe8be58d2a76b179a013be714d7e88006b064a71964d9dc912537bb2/bd_warehouse-0.2.0.tar.gz", hash = "sha256:9f2efe3aba208d25df87f48d4c5a387768c1e5111c20d8250f81c47c83562857", size = 7495756, upload-time = "2026-02-19T16:39:40.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/bb/207f7d92a33fff90530e044d3ac4227ff5cafdd22e142fdd3569919b8df1/bd_warehouse-0.2.0-py3-none-any.whl", hash = "sha256:1fe66a491a81dd131a864677bab15257c9b6e32412cd5a5ab85c2c24b3c3617b", size = 113580, upload-time = "2026-02-19T16:39:38.942Z" },
+]
+
+[[package]]
 name = "build123d"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -89,6 +102,7 @@ name = "build123d-mcp"
 version = "0.3.8"
 source = { editable = "." }
 dependencies = [
+    { name = "bd-warehouse" },
     { name = "build123d" },
     { name = "mcp" },
     { name = "pyvista" },
@@ -104,6 +118,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bd-warehouse" },
     { name = "build123d" },
     { name = "mcp" },
     { name = "pyvista" },


### PR DESCRIPTION
## Summary

- Add `bd_warehouse` as a package dependency so MCP users can import pre-made hardware parts (fasteners, etc.) without hitting the security sandbox
- Expand `IMPORT_ALLOWLIST` with 21 additional stdlib modules commonly needed in parametric CAD scripts: `dataclasses`, `enum`, `json`, `random`, `re`, `decimal`, `fractions`, `statistics`, `numbers`, `abc`, `io`, `warnings`, `contextlib`, `operator`, `struct`, `string`, `textwrap`, `pprint`, `hashlib`, `base64`
- Add `--allow-all-imports` CLI flag (and `BUILD123D_ALLOW_ALL_IMPORTS` env var) to disable the import allowlist entirely for fully trusted environments — dangerous builtins (`eval`, `exec`, `getattr`, etc.) remain blocked in all modes

## Test plan

- [ ] 198/198 tests pass (`uv run pytest tests/`)
- [ ] `from bd_warehouse.fastener import SocketHeadCapScrew` works in execute()
- [ ] `import dataclasses`, `import enum`, `import json` etc. work without security errors
- [ ] `import os` is still blocked (unless `--allow-all-imports` is set)
- [ ] `--allow-all-imports` allows `import os`, `import sys`, etc.
- [ ] `eval(...)` and `exec(...)` remain blocked even with `--allow-all-imports`

🤖 Generated with [Claude Code](https://claude.com/claude-code)