### PR TITLE
feat: add server.json and mcp-name tag for MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ For best results, paste the contents of [default_prompt.md](default_prompt.md) a
 ## Status
 
 Active development (v0.1.0).
+
+<!-- mcp-name: io.github.pzfreo/build123d-mcp -->

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pzfreo/build123d-mcp",
+  "title": "build123d MCP",
+  "description": "AI-driven 3D CAD via build123d: execute, render, measure, and export geometry interactively.",
+  "repository": {
+    "url": "https://github.com/pzfreo/build123d-mcp",
+    "source": "github"
+  },
+  "version": "0.3.11",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "build123d-mcp",
+      "version": "0.3.11",
+      "transport": {
+        "type": "stdio"
+      },
+      "installationInstructions": "uv tool run --python 3.12 build123d-mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `server.json` for submission to the official [modelcontextprotocol registry](https://github.com/modelcontextprotocol/registry)
- Adds `<!-- mcp-name: io.github.pzfreo/build123d-mcp -->` to README.md — required by the registry to verify PyPI package ownership

## Test plan

- [ ] CI green
- [ ] After merge + v0.3.11 release, `mcp-publisher publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)