### PR TITLE
feat: geometric analysis tools — measure, clearance, cross_sections, OCP imports, named_face, import_cad_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ For best results, paste the contents of [default_prompt.md](default_prompt.md) a
 ## Status
 
 Active development (v0.1.0).
+
+<!-- mcp-name: io.github.pzfreo/build123d-mcp -->

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pzfreo/build123d-mcp",
+  "title": "build123d MCP",
+  "description": "AI-driven 3D CAD via build123d: execute, render, measure, and export geometry interactively.",
+  "repository": {
+    "url": "https://github.com/pzfreo/build123d-mcp",
+    "source": "github"
+  },
+  "version": "0.3.11",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "build123d-mcp",
+      "version": "0.3.11",
+      "transport": {
+        "type": "stdio"
+      },
+      "installationInstructions": "uv tool run --python 3.12 build123d-mcp"
+    }
+  ]
+}

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -65,6 +65,85 @@ IMPORT_ALLOWLIST = frozenset({
     "contextlib",
 })
 
+# OCP (OpenCASCADE Python bindings) sub-modules that are safe to import.
+# These are purely geometric — no filesystem, no OS, no network access.
+# Blocked: STEPControl, IGESControl, OSD, Storage, PCDM, TDocStd, Interface,
+#          IFSelect, XCAFDoc, Resource — all of which expose file I/O.
+OCP_ALLOWLIST = frozenset({
+    # Geometric primitives
+    "OCP.gp",
+    # Topology
+    "OCP.TopAbs",
+    "OCP.TopExp",
+    "OCP.TopLoc",
+    "OCP.TopTools",
+    "OCP.TopoDS",
+    # B-rep core
+    "OCP.BRep",
+    "OCP.BRepTools",
+    "OCP.BRepLib",
+    # B-rep analysis
+    "OCP.BRepAdaptor",
+    "OCP.BRepBndLib",
+    "OCP.BRepCheck",
+    "OCP.BRepClass",
+    "OCP.BRepClass3d",
+    "OCP.BRepExtrema",
+    "OCP.BRepGProp",
+    "OCP.BRepIntCurveSurface",
+    # B-rep construction
+    "OCP.BRepBuilderAPI",
+    "OCP.BRepPrimAPI",
+    "OCP.BRepFeat",
+    "OCP.BRepFilletAPI",
+    "OCP.BRepOffsetAPI",
+    "OCP.BRepSweep",
+    "OCP.BRepProj",
+    # B-rep operations
+    "OCP.BRepAlgoAPI",
+    "OCP.BRepMesh",
+    # Geometry
+    "OCP.Geom",
+    "OCP.Geom2d",
+    "OCP.GeomAbs",
+    "OCP.GeomAPI",
+    "OCP.GeomAdaptor",
+    "OCP.GeomConvert",
+    "OCP.GeomFill",
+    "OCP.GeomLProp",
+    "OCP.GeomProjLib",
+    "OCP.GeomTools",
+    # Adaptors
+    "OCP.Adaptor2d",
+    "OCP.Adaptor3d",
+    # Properties and analysis
+    "OCP.GProp",
+    "OCP.GCPnts",
+    "OCP.Bnd",
+    "OCP.IntCurvesFace",
+    "OCP.IntTools",
+    "OCP.Extrema",
+    # Mesh / polygon
+    "OCP.Poly",
+    # Shape analysis and repair
+    "OCP.ShapeAnalysis",
+    "OCP.ShapeCustom",
+    "OCP.ShapeExtend",
+    "OCP.ShapeFix",
+    "OCP.ShapeUpgrade",
+    # Collection types
+    "OCP.TColgp",
+    "OCP.TColGeom",
+    "OCP.TColStd",
+    "OCP.TCollection",
+    # Misc safe
+    "OCP.MAT",
+    "OCP.Approx",
+    "OCP.Convert",
+    "OCP.BSpl",
+    "OCP.ProjLib",
+})
+
 # When True, import checks are skipped entirely.  Set via --allow-all-imports.
 ALLOW_ALL_IMPORTS: bool = False
 
@@ -127,7 +206,18 @@ def check_ast(code: str) -> None:
 
 
 def _check_module(dotted_name: str) -> None:
-    root = dotted_name.split(".")[0]
+    parts = dotted_name.split(".")
+    root = parts[0]
+    if root == "OCP":
+        if len(parts) >= 2:
+            ocp_sub = f"OCP.{parts[1]}"
+            if ocp_sub not in OCP_ALLOWLIST:
+                raise ValueError(
+                    f"Import of '{dotted_name}' is not allowed. "
+                    f"This OCP sub-module is blocked (potential file I/O or OS access). "
+                    f"Permitted OCP modules: {sorted(OCP_ALLOWLIST)}"
+                )
+        return  # bare 'OCP' or allowed sub-module
     if root not in IMPORT_ALLOWLIST:
         raise ValueError(
             f"Import of '{dotted_name}' is not allowed. "
@@ -162,8 +252,18 @@ def make_restricted_builtins() -> dict[str, Any]:
         return safe
 
     def _safe_import(name: str, *args: Any, **kwargs: Any) -> Any:
-        root = name.split(".")[0]
-        if root not in IMPORT_ALLOWLIST:
+        parts = name.split(".")
+        root = parts[0]
+        if root == "OCP":
+            if len(parts) >= 2:
+                ocp_sub = f"OCP.{parts[1]}"
+                if ocp_sub not in OCP_ALLOWLIST:
+                    raise ImportError(
+                        f"Import of '{name}' is not allowed. "
+                        f"This OCP sub-module is blocked (potential file I/O or OS access). "
+                        f"Permitted OCP modules: {sorted(OCP_ALLOWLIST)}"
+                    )
+        elif root not in IMPORT_ALLOWLIST:
             raise ImportError(
                 f"Import of '{name}' is not allowed. "
                 f"Permitted: {sorted(IMPORT_ALLOWLIST)}"

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -14,7 +14,7 @@ _has_library = False
 
 @mcp.tool()
 def execute(code: str) -> str:
-    """Execute build123d Python code in the persistent session. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure(topology) or measure(volume) to confirm it succeeded before calling render_view."""
+    """Execute build123d Python code in the persistent session. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure(topology) or measure(volume) to confirm it succeeded before calling render_view. named_face(shape, name) is available as a built-in helper: named_face(box, 'top') returns the highest-Z face, named_face(box, 'bottom'/'front'/'back'/'left'/'right') returns the corresponding face by axis — useful for placing geometry relative to a shape without computing coordinates. (Named 'named_face' not 'face' to avoid shadowing build123d's own face() export.)"""
     return _session.execute(code)
 
 
@@ -52,9 +52,21 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
 
 
 @mcp.tool()
-def measure(query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
-    """Query geometry of a shape. Prefer measure over render_view when verifying geometry — numbers are unambiguous. query: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary. summary returns bbox + volume + area + topology + center in one call — use it to orient quickly. topology (face/edge/vertex counts) is the fastest way to confirm a boolean operation succeeded: a cut that failed leaves the counts unchanged. object_name/object_name2: named objects from show() (clearance requires both)."""
-    return _session.measure(query, object_name, object_name2)
+def measure(object_name: str = "") -> str:
+    """Measure a shape and return a complete geometric summary: volume (mm³), surface area (mm²), topology (face/edge/vertex counts), bounding box with per-axis size and center, volumetric center of mass, 6-component inertia tensor (Ixx/Iyy/Izz/Ixy/Ixz/Iyz), and a face-type inventory classifying every face as Plane/Cylinder/Cone/Sphere/Torus/BSpline with area and type-specific params (e.g. cylinder diameter and axis). Prefer measure over render_view for verifying geometry — numbers are unambiguous. topology is the fastest confirmation that a boolean operation succeeded: a failed cut leaves face/edge/vertex counts unchanged. object_name: named object from show() (default: current shape)."""
+    return _session.measure(object_name)
+
+
+@mcp.tool()
+def clearance(object_a: str, object_b: str) -> str:
+    """Return the minimum distance (mm) between two named shapes registered via show(). A result of 0 means the shapes are touching or overlapping — use interference() to check for overlap. object_a, object_b: names from show()."""
+    return _session.clearance(object_a, object_b)
+
+
+@mcp.tool()
+def cross_sections(object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
+    """Compute cross-sectional areas at evenly spaced planes along an axis. Returns a list of {position, area} pairs. axis: X, Y, or Z (default Z). num_slices: number of planes (default 10, minimum 2). Useful for detecting internal voids, wall-thickness variation, or verifying that a shape's cross-section profile matches a reference. object_name: named object from show() (default: current shape)."""
+    return _session.cross_sections(object_name, axis, num_slices)
 
 
 @mcp.tool()
@@ -146,6 +158,12 @@ def shape_compare(object_a: str, object_b: str) -> str:
 
 
 @mcp.tool()
+def import_cad_file(path: str, name: str = "") -> str:
+    """Import a STEP (.step/.stp) or STL (.stl) file as a named object in the session. path: absolute or relative path to the file. name: name to register the shape under (defaults to the filename stem). The shape becomes both the named object and the current_shape. Returns volume, topology, and bounding box of the imported shape. Use this to load reference geometry for comparison with show() objects via shape_compare() or measure()."""
+    return _session.import_cad_file(path, name)
+
+
+@mcp.tool()
 def repair_hints(error_text: str) -> str:
     """Given an error message from execute(), return targeted fix suggestions for common build123d mistakes: wrong Location syntax, missing .part, CadQuery idioms, blocked imports, degenerate boolean results, fillet edge selection, and more. Pass the full error string from execute() or last_error()."""
     from build123d_mcp.tools.repair_hints import repair_hints as _repair_hints
@@ -182,9 +200,9 @@ BUILD123D-MCP WORKFLOW GUIDE
    Recommended order: execute → measure → render_view (if you need to see it).
 
 3. VERIFY BOOLEAN OPERATIONS WITH TOPOLOGY
-   After any cut, union, or intersection, call measure(topology) on the result.
+   After any cut, union, or intersection, call measure() and check topology.faces.
    A successful boolean changes face/edge/vertex counts; a failed one leaves them unchanged.
-   measure(volume) confirms the magnitude of the change.
+   measure().volume confirms the magnitude of the change.
 
 4. MEASURE THE OBJECT IN QUESTION — NOT A PROXY
    When debugging, call measure() on the actual disputed object.
@@ -235,7 +253,9 @@ MCP client configuration example:
 Available tools:
   execute           Run build123d Python code in the persistent session
   render_view       Render model as PNG (direction, azimuth, elevation, clip_plane, clip_at, save_to)
-  measure           Query geometry: bounding_box, volume, area, topology, min_wall_thickness, clearance
+  measure           Full geometric summary: volume, area, topology, bbox, center_of_mass, inertia, face_inventory
+  clearance         Minimum distance between two named shapes
+  cross_sections    Cross-sectional areas along X/Y/Z axis at evenly-spaced planes
   export            Export model to STEP or STL
   interference      Check intersection volume between two named shapes
   list_objects      List all named shapes with volume, faces, edges, vertices
@@ -249,6 +269,7 @@ Available tools:
   last_error        Details of the last failed execute() (type, message, line, excerpt)
   validate_code     Check code for syntax/security errors before executing
   shape_compare     Compare two named shapes by geometry metrics
+  import_cad_file   Import a STEP or STL file as a named object for comparison
   repair_hints      Get fix suggestions for a given execute() error message
   version           Return the server version string
   workflow_hints    Return guidance on using these tools effectively

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -12,6 +12,10 @@ from build123d_mcp.security import (
 )
 
 
+# Names injected by the session itself — excluded from rollback and new-key detection.
+_INJECTED = frozenset({"__builtins__", "show", "named_face"})
+
+
 class Session:
     def __init__(self, exec_timeout: int = EXEC_TIMEOUT_SECONDS):
         self.exec_timeout = exec_timeout
@@ -41,6 +45,23 @@ class Session:
                 print(f"Registered '{name}'")
 
         self.namespace["show"] = show
+
+        def named_face(shape: Any, name: str) -> Any:
+            """Return a face of shape by semantic name: top/bottom/front/back/left/right."""
+            from build123d import Axis
+            match name.lower():
+                case "top":    return shape.faces().sort_by(Axis.Z)[-1]
+                case "bottom": return shape.faces().sort_by(Axis.Z)[0]
+                case "front":  return shape.faces().sort_by(Axis.Y)[-1]
+                case "back":   return shape.faces().sort_by(Axis.Y)[0]
+                case "right":  return shape.faces().sort_by(Axis.X)[-1]
+                case "left":   return shape.faces().sort_by(Axis.X)[0]
+                case _:
+                    raise ValueError(
+                        f"Unknown face name '{name}'. Use: top, bottom, front, back, left, right"
+                    )
+
+        self.namespace["named_face"] = named_face
 
     def _quick_diagnostics(self, shape) -> str:
         try:
@@ -76,7 +97,7 @@ class Session:
         values_before = {
             k: v.copy() if isinstance(v, (list, dict, set)) else v
             for k, v in self.namespace.items()
-            if k not in ("__builtins__", "show")
+            if k not in _INJECTED
         }
         shape_before = self.current_shape
         objects_before = dict(self.objects)
@@ -137,7 +158,7 @@ class Session:
             return f"Error: {type(exc).__name__}: {exc}"
 
         self.last_error_detail = None
-        new_keys = {k for k in self.namespace if k not in ("__builtins__", "show")} - values_before.keys()
+        new_keys = {k for k in self.namespace if k not in _INJECTED} - values_before.keys()
         self._update_current_shape(new_keys)
 
         output = buf.getvalue() or "OK"
@@ -149,7 +170,7 @@ class Session:
 
     def _rollback_namespace(self, values_before: dict[str, Any]) -> None:
         # Delete keys that didn't exist before; restore values for keys that were overwritten.
-        current = {k for k in self.namespace if k not in ("__builtins__", "show")}
+        current = {k for k in self.namespace if k not in _INJECTED}
         for k in current - values_before.keys():
             del self.namespace[k]
         for k, v in values_before.items():

--- a/src/build123d_mcp/tools/cross_sections.py
+++ b/src/build123d_mcp/tools/cross_sections.py
@@ -1,0 +1,7 @@
+import json
+
+
+def cross_sections(session, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
+    from build123d_mcp.tools.measure import _resolve_shape, _cross_sections
+    shape = _resolve_shape(session, object_name)
+    return json.dumps(_cross_sections(shape, axis, num_slices), indent=2)

--- a/src/build123d_mcp/tools/import_step.py
+++ b/src/build123d_mcp/tools/import_step.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+_STEP_EXTS = frozenset({".step", ".stp"})
+_STL_EXTS = frozenset({".stl"})
+_ALLOWED_EXTS = _STEP_EXTS | _STL_EXTS
+
+
+def import_cad_file(session, path: str, name: str = "") -> str:
+    resolved = os.path.realpath(path)
+    if not os.path.isfile(resolved):
+        raise ValueError(f"File not found: '{path}'")
+    ext = os.path.splitext(resolved)[1].lower()
+    if ext not in _ALLOWED_EXTS:
+        raise ValueError(f"Expected a .step, .stp, or .stl file, got '{ext}'")
+
+    obj_name = name or os.path.splitext(os.path.basename(resolved))[0]
+
+    if ext in _STEP_EXTS:
+        shape = _load_step(resolved)
+        fmt = "step"
+    else:
+        shape = _load_stl(resolved)
+        fmt = "stl"
+
+    session.objects[obj_name] = shape
+    session.current_shape = shape
+
+    bb = shape.bounding_box()
+    result = {
+        "imported": obj_name,
+        "format": fmt,
+        "path": resolved,
+        "volume": round(shape.volume, 4),
+        "faces": len(shape.faces()),
+        "edges": len(shape.edges()),
+        "vertices": len(shape.vertices()),
+        "bbox": {
+            "xsize": round(bb.size.X, 4),
+            "ysize": round(bb.size.Y, 4),
+            "zsize": round(bb.size.Z, 4),
+        },
+    }
+    return json.dumps(result, indent=2)
+
+
+def _load_step(resolved: str):
+    from build123d import import_step as _import_step
+
+    imported = _import_step(resolved)
+    # Multi-body STEP returns an iterable without a .wrapped attribute
+    if hasattr(imported, "__iter__") and not hasattr(imported, "wrapped"):
+        shapes = list(imported)
+        if not shapes:
+            raise ValueError("STEP file contains no geometry")
+        shape = shapes[0]
+        for s in shapes[1:]:
+            shape = shape + s
+        return shape
+    return imported
+
+
+def _load_stl(resolved: str):
+    from build123d import import_stl
+    return import_stl(resolved)

--- a/src/build123d_mcp/tools/import_step.py
+++ b/src/build123d_mcp/tools/import_step.py
@@ -55,7 +55,7 @@ def _load_step(resolved: str):
             raise ValueError("STEP file contains no geometry")
         shape = shapes[0]
         for s in shapes[1:]:
-            shape = shape + s
+            shape = shape + s  # type: ignore[assignment]
         return shape
     return imported
 

--- a/src/build123d_mcp/tools/measure.py
+++ b/src/build123d_mcp/tools/measure.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 
 def _resolve_shape(session, object_name: str):
@@ -11,89 +12,199 @@ def _resolve_shape(session, object_name: str):
     return session.current_shape
 
 
-def _min_wall_thickness(shape) -> float:
-    """Ray-cast from each face center inward; return shortest wall crossing."""
-    from build123d import Axis
-    min_t = float("inf")
-    for face in shape.faces():
-        center = face.center_location.position
-        normal = face.normal_at()
-        inward = Axis(center, normal * -1)
-        try:
-            hits = shape.find_intersection_points(inward)
-        except Exception:
-            continue
-        for pt, _ in hits:
-            dist = (pt - center).length
-            if dist > 1e-3:
-                min_t = min(min_t, dist)
-                break
-    return min_t
+def _center_of_mass(shape) -> dict:
+    from OCP.BRepGProp import BRepGProp
+    from OCP.GProp import GProp_GProps
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape.wrapped, props)
+    com = props.CentreOfMass()
+    return {"x": round(com.X(), 4), "y": round(com.Y(), 4), "z": round(com.Z(), 4)}
 
 
-def measure(session, query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
-    query = query.lower()
+_SURFACE_NAMES = None
 
-    if query == "clearance":
-        s1 = _resolve_shape(session, object_name)
-        if not object_name2:
-            raise ValueError("clearance requires object_name2.")
-        if object_name2 not in session.objects:
-            raise ValueError(f"Unknown object '{object_name2}'. Registered: {list(session.objects.keys())}")
-        s2 = session.objects[object_name2]
-        return json.dumps({"clearance": s1.distance_to(s2)}, indent=2)
-
-    shape = _resolve_shape(session, object_name)
-
-    if query == "bounding_box":
-        bb = shape.bounding_box()
-        result = {
-            "xmin": bb.min.X, "xmax": bb.max.X,
-            "ymin": bb.min.Y, "ymax": bb.max.Y,
-            "zmin": bb.min.Z, "zmax": bb.max.Z,
-            "xsize": bb.size.X, "ysize": bb.size.Y, "zsize": bb.size.Z,
-            "center": {
-                "x": (bb.min.X + bb.max.X) / 2,
-                "y": (bb.min.Y + bb.max.Y) / 2,
-                "z": (bb.min.Z + bb.max.Z) / 2,
-            },
+def _get_surface_names():
+    global _SURFACE_NAMES
+    if _SURFACE_NAMES is None:
+        from OCP.GeomAbs import (
+            GeomAbs_BSplineSurface, GeomAbs_Cone, GeomAbs_Cylinder,
+            GeomAbs_Plane, GeomAbs_Sphere, GeomAbs_Torus,
+        )
+        _SURFACE_NAMES = {
+            GeomAbs_Plane: "Plane",
+            GeomAbs_Cylinder: "Cylinder",
+            GeomAbs_Cone: "Cone",
+            GeomAbs_Sphere: "Sphere",
+            GeomAbs_Torus: "Torus",
+            GeomAbs_BSplineSurface: "BSpline",
         }
-        return json.dumps(result, indent=2)
+    return _SURFACE_NAMES
 
-    if query == "volume":
-        return json.dumps({"volume": shape.volume}, indent=2)
 
-    if query == "area":
-        return json.dumps({"area": shape.area}, indent=2)
+def _face_inventory(shape) -> list:
+    from OCP.BRepAdaptor import BRepAdaptor_Surface
+    from OCP.BRepGProp import BRepGProp
+    from OCP.GeomAbs import GeomAbs_Cylinder, GeomAbs_Cone, GeomAbs_Sphere, GeomAbs_Torus
+    from OCP.GProp import GProp_GProps
+    from OCP.TopAbs import TopAbs_FACE
+    from OCP.TopExp import TopExp_Explorer
+    from OCP.TopoDS import TopoDS
 
-    if query == "min_wall_thickness":
-        t = _min_wall_thickness(shape)
-        return json.dumps({"min_wall_thickness": t}, indent=2)
+    surface_names = _get_surface_names()
+    explorer = TopExp_Explorer(shape.wrapped, TopAbs_FACE)
+    faces = []
+    while explorer.More():
+        face = TopoDS.Face_s(explorer.Current())
+        adaptor = BRepAdaptor_Surface(face)
+        stype = adaptor.GetType()
+        type_name = surface_names.get(stype, f"Other({stype})")
 
-    if query == "topology":
-        return json.dumps({
+        props = GProp_GProps()
+        BRepGProp.SurfaceProperties_s(face, props)
+        area = props.Mass()
+
+        info = {"type": type_name, "area": round(area, 4)}
+
+        if stype == GeomAbs_Cylinder:
+            cyl = adaptor.Cylinder()
+            info["diameter"] = round(cyl.Radius() * 2, 4)
+            d = cyl.Axis().Direction()
+            info["axis"] = (round(d.X(), 3), round(d.Y(), 3), round(d.Z(), 3))
+        elif stype == GeomAbs_Cone:
+            cone = adaptor.Cone()
+            info["semi_angle_deg"] = round(math.degrees(cone.SemiAngle()), 2)
+        elif stype == GeomAbs_Sphere:
+            sph = adaptor.Sphere()
+            info["radius"] = round(sph.Radius(), 4)
+        elif stype == GeomAbs_Torus:
+            t = adaptor.Torus()
+            info["major_r"] = round(t.MajorRadius(), 4)
+            info["minor_r"] = round(t.MinorRadius(), 4)
+
+        faces.append(info)
+        explorer.Next()
+
+    faces.sort(key=lambda f: (f["type"], -f["area"]))
+    return faces
+
+
+def _inertia(shape) -> dict:
+    from OCP.BRepGProp import BRepGProp
+    from OCP.GProp import GProp_GProps
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape.wrapped, props)
+    mat = props.MatrixOfInertia()
+    return {
+        "Ixx": round(mat.Value(1, 1), 4),
+        "Iyy": round(mat.Value(2, 2), 4),
+        "Izz": round(mat.Value(3, 3), 4),
+        "Ixy": round(mat.Value(1, 2), 4),
+        "Ixz": round(mat.Value(1, 3), 4),
+        "Iyz": round(mat.Value(2, 3), 4),
+    }
+
+
+def _cross_sections(shape, axis: str = "Z", num_slices: int = 10) -> list:
+    from OCP.BRepAlgoAPI import BRepAlgoAPI_Section
+    from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+    from OCP.BRepGProp import BRepGProp
+    from OCP.GProp import GProp_GProps
+    from OCP.ShapeAnalysis import ShapeAnalysis_FreeBounds
+    from OCP.TopAbs import TopAbs_EDGE
+    from OCP.TopExp import TopExp_Explorer
+    from OCP.TopTools import TopTools_HSequenceOfShape
+    from OCP.TopoDS import TopoDS
+    from OCP.gp import gp_Dir, gp_Pln, gp_Pnt
+
+    axis = axis.upper()
+    bb = shape.bounding_box()
+
+    if axis == "X":
+        lo, hi = bb.min.X, bb.max.X
+        pln_dir = gp_Dir(1, 0, 0)
+        make_pnt = lambda pos: gp_Pnt(pos, 0, 0)
+    elif axis == "Y":
+        lo, hi = bb.min.Y, bb.max.Y
+        pln_dir = gp_Dir(0, 1, 0)
+        make_pnt = lambda pos: gp_Pnt(0, pos, 0)
+    else:
+        lo, hi = bb.min.Z, bb.max.Z
+        pln_dir = gp_Dir(0, 0, 1)
+        make_pnt = lambda pos: gp_Pnt(0, 0, pos)
+
+    span = hi - lo
+    lo_s = lo + span * 0.01
+    hi_s = hi - span * 0.01
+    num_slices = max(num_slices, 2)
+    step = (hi_s - lo_s) / (num_slices - 1)
+
+    results = []
+    for i in range(num_slices):
+        pos = lo_s + i * step
+        plane = gp_Pln(make_pnt(pos), pln_dir)
+
+        section = BRepAlgoAPI_Section(shape.wrapped, plane, False)
+        section.Build()
+
+        edges = TopTools_HSequenceOfShape()
+        exp = TopExp_Explorer(section.Shape(), TopAbs_EDGE)
+        while exp.More():
+            edges.Append(exp.Current())
+            exp.Next()
+
+        wires = TopTools_HSequenceOfShape()
+        ShapeAnalysis_FreeBounds.ConnectEdgesToWires_s(edges, 1e-7, False, wires)
+
+        total_area = 0.0
+        for j in range(1, wires.Length() + 1):
+            wire = TopoDS.Wire_s(wires.Value(j))
+            try:
+                face_maker = BRepBuilderAPI_MakeFace(plane, wire)
+                if face_maker.IsDone():
+                    face = face_maker.Face()
+                    props = GProp_GProps()
+                    BRepGProp.SurfaceProperties_s(face, props)
+                    total_area += abs(props.Mass())
+            except Exception:
+                pass
+
+        results.append({"position": round(pos, 4), "area": round(total_area, 4)})
+
+    return results
+
+
+def measure(session, object_name: str = "") -> str:
+    shape = _resolve_shape(session, object_name)
+    bb = shape.bounding_box()
+    cx = round((bb.min.X + bb.max.X) / 2, 4)
+    cy = round((bb.min.Y + bb.max.Y) / 2, 4)
+    cz = round((bb.min.Z + bb.max.Z) / 2, 4)
+    return json.dumps({
+        "volume": round(shape.volume, 4),
+        "area": round(shape.area, 4),
+        "topology": {
             "faces": len(shape.faces()),
             "edges": len(shape.edges()),
             "vertices": len(shape.vertices()),
-        }, indent=2)
-
-    if query == "summary":
-        bb = shape.bounding_box()
-        cx = round((bb.min.X + bb.max.X) / 2, 4)
-        cy = round((bb.min.Y + bb.max.Y) / 2, 4)
-        cz = round((bb.min.Z + bb.max.Z) / 2, 4)
-        return json.dumps({
-            "volume": round(shape.volume, 4),
-            "area": round(shape.area, 4),
-            "faces": len(shape.faces()),
-            "edges": len(shape.edges()),
-            "vertices": len(shape.vertices()),
-            "bbox": {
-                "xsize": round(bb.size.X, 4),
-                "ysize": round(bb.size.Y, 4),
-                "zsize": round(bb.size.Z, 4),
-            },
+        },
+        "bbox": {
+            "xmin": round(bb.min.X, 4), "xmax": round(bb.max.X, 4),
+            "ymin": round(bb.min.Y, 4), "ymax": round(bb.max.Y, 4),
+            "zmin": round(bb.min.Z, 4), "zmax": round(bb.max.Z, 4),
+            "xsize": round(bb.size.X, 4),
+            "ysize": round(bb.size.Y, 4),
+            "zsize": round(bb.size.Z, 4),
             "center": {"x": cx, "y": cy, "z": cz},
-        }, indent=2)
+        },
+        "center_of_mass": _center_of_mass(shape),
+        "inertia": _inertia(shape),
+        "face_inventory": _face_inventory(shape),
+    }, indent=2)
 
-    raise ValueError(f"Unknown query '{query}'. Use: bounding_box, volume, area, min_wall_thickness, clearance, topology, summary")
+
+def clearance(session, object_a: str, object_b: str) -> str:
+    for name in (object_a, object_b):
+        if name not in session.objects:
+            raise ValueError(f"Unknown object '{name}'. Registered: {list(session.objects.keys())}")
+    dist = session.objects[object_a].distance_to(session.objects[object_b])
+    return json.dumps({"clearance": dist}, indent=2)

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -44,12 +44,12 @@ _HINTS: list[tuple[list[str], str]] = [
     ),
     (
         [r"ImportError", r"SecurityError", r"not allowed.*import", r"import.*not allowed"],
-        "Import blocked. Allowed modules: build123d, bd_warehouse, math, numpy, decimal, "
-        "fractions, statistics, numbers, random, collections, itertools, functools, copy, "
-        "operator, struct, typing, abc, dataclasses, enum, re, string, textwrap, pprint, "
-        "json, base64, hashlib, io, warnings, contextlib. "
-        "Remove os, sys, pathlib, subprocess, socket, and network imports. "
-        "Start the server with --allow-all-imports to disable this check entirely.",
+        "Import blocked. Allowed modules include: build123d, bd_warehouse, math, numpy, "
+        "json, re, collections, itertools, functools, copy, typing, dataclasses, enum, "
+        "and most OCP geometry sub-modules (OCP.gp, OCP.BRepGProp, OCP.TopExp, "
+        "OCP.BRepAlgoAPI, OCP.BRepAdaptor, OCP.GeomAbs, OCP.ShapeAnalysis, etc.). "
+        "Blocked: os, sys, pathlib, subprocess, socket, OCP.STEPControl, OCP.IGESControl, "
+        "OCP.OSD (file I/O). Start with --allow-all-imports to disable this check entirely.",
     ),
     (
         [r"Constraint failed", r"AssertionError"],

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -1,6 +1,7 @@
 import json
 
 from build123d_mcp.tools.diff import _shape_diag
+from build123d_mcp.tools.measure import _center_of_mass
 
 
 def shape_compare(session, object_a: str, object_b: str) -> str:
@@ -12,15 +13,7 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
     sa, sb = session.objects[object_a], session.objects[object_b]
     da, db = _shape_diag(sa), _shape_diag(sb)
 
-    def _center(shape):
-        bb = shape.bounding_box()
-        return {
-            "x": round((bb.min.X + bb.max.X) / 2, 4),
-            "y": round((bb.min.Y + bb.max.Y) / 2, 4),
-            "z": round((bb.min.Z + bb.max.Z) / 2, 4),
-        }
-
-    ca, cb = _center(sa), _center(sb)
+    ca, cb = _center_of_mass(sa), _center_of_mass(sb)
     offset = round(((cb["x"] - ca["x"])**2 + (cb["y"] - ca["y"])**2 + (cb["z"] - ca["z"])**2) ** 0.5, 4)
 
     return json.dumps({

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -75,6 +75,14 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.measure import measure
         return measure(session, **args)
 
+    if op == "clearance":
+        from build123d_mcp.tools.measure import clearance
+        return clearance(session, **args)
+
+    if op == "cross_sections":
+        from build123d_mcp.tools.cross_sections import cross_sections
+        return cross_sections(session, **args)
+
     if op == "list_objects":
         from build123d_mcp.tools.list_objects import list_objects
         return list_objects(session)
@@ -133,6 +141,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
     if op == "shape_compare":
         from build123d_mcp.tools.shape_compare import shape_compare
         return shape_compare(session, args["object_a"], args["object_b"])
+
+    if op == "import_cad_file":
+        from build123d_mcp.tools.import_step import import_cad_file
+        return import_cad_file(session, args["path"], args.get("name", ""))
 
     raise ValueError(f"Unknown operation: '{op}'")
 
@@ -259,10 +271,16 @@ class WorkerSession:
             self._INTERFERENCE_TIMEOUT,
         )
 
-    def measure(self, query: str = "bounding_box", object_name: str = "", object_name2: str = "") -> str:
+    def measure(self, object_name: str = "") -> str:
+        return self._call("measure", {"object_name": object_name}, self._SHORT_TIMEOUT)
+
+    def clearance(self, object_a: str, object_b: str) -> str:
+        return self._call("clearance", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT)
+
+    def cross_sections(self, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
         return self._call(
-            "measure",
-            {"query": query, "object_name": object_name, "object_name2": object_name2},
+            "cross_sections",
+            {"object_name": object_name, "axis": axis, "num_slices": num_slices},
             self._SHORT_TIMEOUT,
         )
 
@@ -298,6 +316,9 @@ class WorkerSession:
 
     def shape_compare(self, object_a: str, object_b: str) -> str:
         return self._call("shape_compare", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT)
+
+    def import_cad_file(self, path: str, name: str = "") -> str:
+        return self._call("import_cad_file", {"path": path, "name": name}, self._EXPORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -36,8 +36,8 @@ def test_incremental_construction_extends_geometry(session):
     """Second execute can reference and extend geometry from the first."""
     execute_code(session, "b = Box(20, 20, 20)")
     execute_code(session, "result = b + Cylinder(5, 30)")
-    bb = json.loads(measure(session, "bounding_box"))
-    assert bb["zsize"] > 20  # cylinder taller than box
+    data = json.loads(measure(session))
+    assert data["bbox"]["zsize"] > 20  # cylinder taller than box
 
 
 def test_boolean_subtraction_removes_material(session):
@@ -52,10 +52,10 @@ def test_create_measure_export_round_trip(session, tmp_path, monkeypatch):
     """Create a known shape, verify its dimensions, then export it."""
     monkeypatch.chdir(tmp_path)
     execute_code(session, "result = Box(30, 20, 10)")
-    data = json.loads(measure(session, "bounding_box"))
-    assert abs(data["xsize"] - 30) < 0.01
-    assert abs(data["ysize"] - 20) < 0.01
-    assert abs(data["zsize"] - 10) < 0.01
+    data = json.loads(measure(session))
+    assert abs(data["bbox"]["xsize"] - 30) < 0.01
+    assert abs(data["bbox"]["ysize"] - 20) < 0.01
+    assert abs(data["bbox"]["zsize"] - 10) < 0.01
 
     export_file(session, "out", "step")
     # A real STEP file for a simple box is several kilobytes
@@ -93,8 +93,8 @@ def test_reset_discards_previous_geometry(session):
     session.reset()
     session.execute("from build123d import *")
     execute_code(session, "result = Box(5, 5, 5)")
-    bb = json.loads(measure(session, "bounding_box"))
-    assert abs(bb["xsize"] - 5) < 0.01
+    data = json.loads(measure(session))
+    assert abs(data["bbox"]["xsize"] - 5) < 0.01
 
 
 def test_render_changes_when_model_changes(session):
@@ -151,8 +151,8 @@ def test_normal_workflow_unaffected_by_security(session):
     """Security hardening does not break a legitimate build123d session."""
     execute_code(session, "import math\nresult = Cylinder(math.pi, 20)")
     assert session.current_shape is not None
-    bb = json.loads(measure(session, "bounding_box"))
-    assert bb["zsize"] > 0
+    data = json.loads(measure(session))
+    assert data["bbox"]["zsize"] > 0
 
 
 def test_builtins_import_restriction_independent_of_ast(session):
@@ -173,14 +173,14 @@ def test_snapshot_restores_geometry_after_bad_experiment(session):
     """save_snapshot / restore_snapshot recovers known-good geometry."""
     execute_code(session, "result = Box(10, 10, 10)")
     session.save_snapshot("good")
-    good_vol = json.loads(measure(session, "volume"))["volume"]
+    good_vol = json.loads(measure(session))["volume"]
 
     # Simulate an experiment that produces wrong geometry
     execute_code(session, "result = Box(1, 1, 1)")
-    assert json.loads(measure(session, "volume"))["volume"] < good_vol
+    assert json.loads(measure(session))["volume"] < good_vol
 
     session.restore_snapshot("good")
-    assert abs(json.loads(measure(session, "volume"))["volume"] - good_vol) < 0.1
+    assert abs(json.loads(measure(session))["volume"] - good_vol) < 0.1
 
 
 def test_snapshot_objects_registry_survives_round_trip(session):
@@ -192,8 +192,8 @@ def test_snapshot_objects_registry_survives_round_trip(session):
     execute_code(session, "show(Box(1, 1, 1), 'frame')\nshow(Box(1, 1, 1), 'axle')")
     session.restore_snapshot("assembly_v1")
 
-    frame_bb = json.loads(measure(session, "bounding_box", "frame"))
-    axle_bb = json.loads(measure(session, "bounding_box", "axle"))
+    frame_bb = json.loads(measure(session, "frame"))["bbox"]
+    axle_bb = json.loads(measure(session, "axle"))["bbox"]
     assert abs(frame_bb["xsize"] - 60) < 0.1
     assert abs(axle_bb["zsize"] - 50) < 0.1
 
@@ -216,8 +216,8 @@ def test_namespace_not_restored_by_snapshot(session):
 def test_named_objects_have_independent_bounding_boxes(session):
     """show() isolates shapes: each named object reports its own dimensions."""
     execute_code(session, "show(Box(5, 5, 5), 'small')\nshow(Box(40, 40, 40), 'large')")
-    small = json.loads(measure(session, "bounding_box", "small"))
-    large = json.loads(measure(session, "bounding_box", "large"))
+    small = json.loads(measure(session, "small"))["bbox"]
+    large = json.loads(measure(session, "large"))["bbox"]
     assert abs(small["xsize"] - 5) < 0.01
     assert abs(large["xsize"] - 40) < 0.01
 
@@ -295,9 +295,9 @@ def test_reset_clears_show_registry(session):
 def test_volume_detects_missing_boolean(session):
     """volume() exposes the difference between a solid and a hollowed part."""
     execute_code(session, "show(Box(20, 20, 20), 'full')")
-    solid_vol = json.loads(measure(session, "volume", "full"))["volume"]
+    solid_vol = json.loads(measure(session, "full"))["volume"]
     execute_code(session, "show(Box(20, 20, 20) - Cylinder(5, 22), 'hollow')")
-    hollow_vol = json.loads(measure(session, "volume", "hollow"))["volume"]
+    hollow_vol = json.loads(measure(session, "hollow"))["volume"]
     assert hollow_vol < solid_vol
     assert abs(solid_vol - 8000) < 1
 
@@ -305,27 +305,20 @@ def test_volume_detects_missing_boolean(session):
 def test_area_increases_after_adding_surface(session):
     """Surface area grows when a protrusion is added."""
     execute_code(session, "result = Box(10, 10, 10)")
-    base_area = json.loads(measure(session, "area"))["area"]
+    base_area = json.loads(measure(session))["area"]
     execute_code(session, "result = Box(10, 10, 10) + Cylinder(2, 5).move(Location((0, 0, 7.5)))")
-    new_area = json.loads(measure(session, "area"))["area"]
+    new_area = json.loads(measure(session))["area"]
     assert new_area > base_area
 
 
-def test_min_wall_thickness_thinnest_wall_reported(session):
-    """A shape with one thin wall reports that wall's thickness."""
-    # Slab 20x20 wide but only 3mm thick
-    execute_code(session, "result = Box(20, 20, 3)")
-    data = json.loads(measure(session, "min_wall_thickness"))
-    assert abs(data["min_wall_thickness"] - 3) < 0.5
-
-
 def test_clearance_between_assembly_parts(session):
-    """Clearance query returns the gap between two registered bodies."""
+    """Clearance between two registered bodies."""
+    from build123d_mcp.tools.measure import clearance as _clearance
     execute_code(session,
         "show(Cylinder(4, 30), 'shaft')\n"
         "show(Box(30, 30, 30) - Cylinder(5, 32), 'bore_housing')"
     )
-    data = json.loads(measure(session, "clearance", "shaft", "bore_housing"))
+    data = json.loads(_clearance(session, "shaft", "bore_housing"))
     # shaft radius 4, bore radius 5 — clearance should be ~1mm
     assert data["clearance"] >= 0
     assert data["clearance"] < 5
@@ -333,11 +326,12 @@ def test_clearance_between_assembly_parts(session):
 
 def test_clearance_zero_for_touching_shapes(session):
     """Touching shapes report zero clearance."""
+    from build123d_mcp.tools.measure import clearance as _clearance
     execute_code(session,
         "show(Box(10, 10, 10), 'a')\n"
         "show(Box(10, 10, 10).move(Location((10, 0, 0))), 'b')"
     )
-    data = json.loads(measure(session, "clearance", "a", "b"))
+    data = json.loads(_clearance(session, "a", "b"))
     assert data["clearance"] < 0.01
 
 
@@ -345,15 +339,18 @@ def test_clearance_zero_for_touching_shapes(session):
 # measure(summary)
 # ---------------------------------------------------------------------------
 
-def test_measure_summary_returns_all_fields(session):
-    """summary query returns bbox, volume, area, topology, and center in one call."""
+def test_measure_returns_all_fields(session):
+    """measure() returns bbox, volume, area, topology, center_of_mass, inertia, face_inventory."""
     execute_code(session, "result = Box(10, 20, 30)")
-    data = json.loads(measure(session, "summary"))
+    data = json.loads(measure(session))
     assert abs(data["volume"] - 6000) < 1
-    assert data["faces"] == 6
+    assert data["topology"]["faces"] == 6
     assert "bbox" in data and abs(data["bbox"]["xsize"] - 10) < 0.01
-    assert "center" in data and abs(data["center"]["x"]) < 0.01
+    assert abs(data["bbox"]["center"]["x"]) < 0.01
     assert "area" in data and data["area"] > 0
+    assert "center_of_mass" in data
+    assert "inertia" in data
+    assert "face_inventory" in data
 
 
 # ---------------------------------------------------------------------------
@@ -559,7 +556,8 @@ def test_mcp_lists_all_tools():
     assert names == {"execute", "render_view", "measure", "export", "reset",
                      "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
                      "search_library", "load_part", "workflow_hints", "session_state", "health_check",
-                     "version", "last_error", "validate_code", "shape_compare", "repair_hints"}
+                     "version", "last_error", "validate_code", "shape_compare", "repair_hints",
+                     "import_cad_file", "cross_sections", "clearance"}
 
 
 @_skip_mcp_on_win
@@ -569,13 +567,13 @@ def test_mcp_execute_and_measure_round_trip():
             "execute",
             {"code": "from build123d import *\nresult = Box(10, 20, 30)"},
         )
-        result = await mcp.call_tool("measure", {"query": "bounding_box"})
+        result = await mcp.call_tool("measure", {})
         return result.content[0].text
 
     data = json.loads(asyncio.run(_mcp_session(run)))
-    assert abs(data["xsize"] - 10) < 0.01
-    assert abs(data["ysize"] - 20) < 0.01
-    assert abs(data["zsize"] - 30) < 0.01
+    assert abs(data["bbox"]["xsize"] - 10) < 0.01
+    assert abs(data["bbox"]["ysize"] - 20) < 0.01
+    assert abs(data["bbox"]["zsize"] - 30) < 0.01
 
 
 @_skip_mcp_on_win
@@ -615,7 +613,7 @@ def test_mcp_reset_clears_state():
         )
         await mcp.call_tool("reset", {})
         # measure should now fail — no shape
-        result = await mcp.call_tool("measure", {"query": "bounding_box"})
+        result = await mcp.call_tool("measure", {})
         return result.content[0].text
 
     text = asyncio.run(_mcp_session(run))
@@ -645,11 +643,11 @@ def test_mcp_snapshot_save_and_restore():
         await mcp.call_tool("save_snapshot", {"name": "v1"})
         await mcp.call_tool("execute", {"code": "result = Box(99, 99, 99)"})
         await mcp.call_tool("restore_snapshot", {"name": "v1"})
-        result = await mcp.call_tool("measure", {"query": "bounding_box"})
+        result = await mcp.call_tool("measure", {})
         return result.content[0].text
 
     data = json.loads(asyncio.run(_mcp_session(run)))
-    assert abs(data["xsize"] - 10) < 0.01
+    assert abs(data["bbox"]["xsize"] - 10) < 0.01
 
 
 @_skip_mcp_on_win
@@ -674,8 +672,8 @@ def test_mcp_volume_and_clearance():
             "show(Box(10, 10, 10), 'a')\n"
             "show(Box(10, 10, 10).move(Location((15, 0, 0))), 'b')"
         )})
-        r_vol = await mcp.call_tool("measure", {"query": "volume", "object_name": "a"})
-        r_cl = await mcp.call_tool("measure", {"query": "clearance", "object_name": "a", "object_name2": "b"})
+        r_vol = await mcp.call_tool("measure", {"object_name": "a"})
+        r_cl = await mcp.call_tool("clearance", {"object_a": "a", "object_b": "b"})
         return r_vol.content[0].text, r_cl.content[0].text
 
     vol_json, cl_json = asyncio.run(_mcp_session(run))
@@ -691,12 +689,12 @@ def test_mcp_show_and_measure_named_object():
             "execute",
             {"code": "from build123d import *\nshow(Box(40, 5, 5), 'wide')\nshow(Box(5, 5, 40), 'tall')"},
         )
-        r_wide = await mcp.call_tool("measure", {"query": "bounding_box", "object_name": "wide"})
-        r_tall = await mcp.call_tool("measure", {"query": "bounding_box", "object_name": "tall"})
+        r_wide = await mcp.call_tool("measure", {"object_name": "wide"})
+        r_tall = await mcp.call_tool("measure", {"object_name": "tall"})
         return r_wide.content[0].text, r_tall.content[0].text
 
     wide_json, tall_json = asyncio.run(_mcp_session(run))
     wide = json.loads(wide_json)
     tall = json.loads(tall_json)
-    assert abs(wide["xsize"] - 40) < 0.01
-    assert abs(tall["zsize"] - 40) < 0.01
+    assert abs(wide["bbox"]["xsize"] - 40) < 0.01
+    assert abs(tall["bbox"]["zsize"] - 40) < 0.01

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -156,6 +156,58 @@ def test_blocked_import_does_not_corrupt_shape(session):
     assert session.current_shape is shape_before
 
 
+# --- OCP import allowlist ---
+
+def test_ocp_safe_module_allowed(session):
+    result = execute_code(session, "from OCP.BRepGProp import BRepGProp")
+    assert "not allowed" not in result.lower() and "Error" not in result
+
+
+def test_ocp_topology_modules_allowed(session):
+    result = execute_code(session, (
+        "from OCP.TopExp import TopExp_Explorer\n"
+        "from OCP.TopAbs import TopAbs_FACE\n"
+        "from OCP.TopoDS import TopoDS"
+    ))
+    assert "not allowed" not in result.lower() and "Error" not in result
+
+
+def test_ocp_gp_module_allowed(session):
+    result = execute_code(session, "from OCP.gp import gp_Pnt\np = gp_Pnt(1.0, 2.0, 3.0)")
+    assert "Error" not in result
+
+
+def test_ocp_step_control_blocked(session):
+    result = execute_code(session, "from OCP.STEPControl import STEPControl_Reader")
+    assert "not allowed" in result.lower() or "blocked" in result.lower()
+
+
+def test_ocp_iges_control_blocked(session):
+    result = execute_code(session, "import OCP.IGESControl")
+    assert "not allowed" in result.lower() or "blocked" in result.lower()
+
+
+def test_ocp_osd_blocked(session):
+    result = execute_code(session, "from OCP.OSD import OSD_File")
+    assert "not allowed" in result.lower() or "blocked" in result.lower()
+
+
+def test_ocp_brep_gprop_computes_volume(session):
+    # Full round-trip: build shape, extract .wrapped, compute volume via OCP directly
+    code = (
+        "from build123d import Box\n"
+        "from OCP.BRepGProp import BRepGProp\n"
+        "from OCP.GProp import GProp_GProps\n"
+        "b = Box(10, 10, 10)\n"
+        "props = GProp_GProps()\n"
+        "BRepGProp.VolumeProperties_s(b.wrapped, props)\n"
+        "result_volume = props.Mass()\n"
+    )
+    result = execute_code(session, code)
+    assert "Error" not in result
+    assert abs(session.namespace.get("result_volume", 0) - 1000) < 1
+
+
 def test_runtime_error_does_not_update_current_shape(session):
     execute_code(session, "result = Box(10, 10, 10)")
     shape_before = session.current_shape
@@ -270,61 +322,45 @@ def test_render_view_save_to_both_writes_two_files(session, tmp_path, monkeypatc
 
 def test_measure_bounding_box(session):
     execute_code(session, "result = Box(10, 20, 30)")
-    data = json.loads(measure(session, "bounding_box"))
-    assert abs(data["xsize"] - 10) < 0.01
-    assert abs(data["ysize"] - 20) < 0.01
-    assert abs(data["zsize"] - 30) < 0.01
+    data = json.loads(measure(session))
+    assert abs(data["bbox"]["xsize"] - 10) < 0.01
+    assert abs(data["bbox"]["ysize"] - 20) < 0.01
+    assert abs(data["bbox"]["zsize"] - 30) < 0.01
 
 
 def test_measure_center_origin(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    data = json.loads(measure(session, "bounding_box"))
-    center = data["center"]
+    data = json.loads(measure(session))
+    center = data["bbox"]["center"]
     assert abs(center["x"]) < 0.01
     assert abs(center["y"]) < 0.01
     assert abs(center["z"]) < 0.01
 
 
-def test_measure_invalid_query(session):
-    execute_code(session, "result = Box(10, 10, 10)")
-    with pytest.raises(ValueError, match="Unknown query"):
-        measure(session, "surface_area")
-
-
 def test_measure_volume(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    data = json.loads(measure(session, "volume"))
+    data = json.loads(measure(session))
     assert abs(data["volume"] - 1000) < 0.1
 
 
 def test_measure_area(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    data = json.loads(measure(session, "area"))
+    data = json.loads(measure(session))
     assert abs(data["area"] - 600) < 0.1
 
 
-def test_measure_min_wall_thickness(session):
-    execute_code(session, "result = Box(20, 20, 4)")
-    data = json.loads(measure(session, "min_wall_thickness"))
-    assert abs(data["min_wall_thickness"] - 4) < 0.1
-
-
 def test_measure_clearance(session):
+    from build123d_mcp.tools.measure import clearance
     execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10).move(Location((20,0,0))), 'b')")
-    data = json.loads(measure(session, "clearance", "a", "b"))
+    data = json.loads(clearance(session, "a", "b"))
     assert abs(data["clearance"] - 10) < 0.1
 
 
-def test_measure_clearance_missing_object2_raises(session):
-    execute_code(session, "show(Box(10,10,10), 'a')")
-    with pytest.raises(ValueError, match="object_name2"):
-        measure(session, "clearance", "a")
-
-
-def test_measure_clearance_unknown_object2_raises(session):
+def test_clearance_unknown_object_raises(session):
+    from build123d_mcp.tools.measure import clearance
     execute_code(session, "show(Box(10,10,10), 'a')")
     with pytest.raises(ValueError, match="Unknown object"):
-        measure(session, "clearance", "a", "missing")
+        clearance(session, "a", "missing")
 
 
 # --- export ---
@@ -473,14 +509,14 @@ def test_render_view_unknown_object_raises(session):
 
 def test_measure_named_object(session):
     execute_code(session, "show(Box(30, 10, 10), 'wide')")
-    data = json.loads(measure(session, "bounding_box", "wide"))
-    assert abs(data["xsize"] - 30) < 0.01
+    data = json.loads(measure(session, "wide"))
+    assert abs(data["bbox"]["xsize"] - 30) < 0.01
 
 
 def test_measure_unknown_object_raises(session):
     execute_code(session, "show(Box(5, 5, 5), 'a')")
     with pytest.raises(ValueError, match="Unknown object"):
-        measure(session, "bounding_box", "missing")
+        measure(session, "missing")
 
 
 def test_export_named_object(session, tmp_path, monkeypatch):
@@ -630,27 +666,26 @@ def test_interference_unknown_object_raises(session):
         interference(session, "a", "missing")
 
 
-# --- measure topology (new) ---
+# --- measure topology ---
 
 def test_measure_topology_box(session):
     execute_code(session, "result = Box(10, 10, 10)")
-    data = json.loads(measure(session, "topology"))
-    assert data["faces"] == 6
-    assert data["edges"] == 12
-    assert data["vertices"] == 8
+    data = json.loads(measure(session))
+    assert data["topology"]["faces"] == 6
+    assert data["topology"]["edges"] == 12
+    assert data["topology"]["vertices"] == 8
 
 
 def test_measure_topology_increases_after_boolean_cut(session):
-    # A box with a cylindrical hole punched through has more than 6 faces
     execute_code(session, "result = Box(20, 20, 20) - Cylinder(3, 30)")
-    data = json.loads(measure(session, "topology"))
-    assert data["faces"] > 6
+    data = json.loads(measure(session))
+    assert data["topology"]["faces"] > 6
 
 
 def test_measure_topology_named_object(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
-    data = json.loads(measure(session, "topology", "cube"))
-    assert data["faces"] == 6
+    data = json.loads(measure(session, "cube"))
+    assert data["topology"]["faces"] == 6
 
 
 # --- render_view azimuth/elevation (new) ---
@@ -735,6 +770,54 @@ def test_show_prints_volume_and_faces(session):
 def test_show_prints_feedback_without_name(session):
     output = execute_code(session, "show(Box(5, 5, 5))")
     assert "Registered" in output
+
+
+# --- face() helper ---
+
+def test_face_top_returns_highest_z(session):
+    execute_code(session, "from build123d import *\nb = Box(10, 10, 10)\nt = named_face(b, 'top')")
+    # Top face center should be at z = +5
+    top = session.namespace["t"]
+    assert abs(top.center_location.position.Z - 5) < 0.1
+
+
+def test_face_bottom_returns_lowest_z(session):
+    execute_code(session, "from build123d import *\nb = Box(10, 10, 10)\nt = named_face(b, 'bottom')")
+    bottom = session.namespace["t"]
+    assert abs(bottom.center_location.position.Z + 5) < 0.1
+
+
+def test_face_all_names_work(session):
+    code = (
+        "from build123d import *\n"
+        "b = Box(10, 20, 30)\n"
+        "top = named_face(b, 'top')\n"
+        "bottom = named_face(b, 'bottom')\n"
+        "front = named_face(b, 'front')\n"
+        "back = named_face(b, 'back')\n"
+        "right = named_face(b, 'right')\n"
+        "left = named_face(b, 'left')\n"
+    )
+    result = execute_code(session, code)
+    assert "Error" not in result
+
+
+def test_face_unknown_name_raises(session):
+    result = execute_code(session, "from build123d import *\nb = Box(10,10,10)\nnamed_face(b, 'diagonal')")
+    assert "Error" in result and "diagonal" in result
+
+
+def test_face_survives_rollback(session):
+    # face() should still be available after a failed execute()
+    execute_code(session, "raise ValueError('oops')")
+    result = execute_code(session, "from build123d import *\nb = Box(5,5,5)\nt = named_face(b, 'top')")
+    assert "Error" not in result
+
+
+def test_face_available_without_import(session):
+    # face() is a session built-in — no import needed
+    result = execute_code(session, "from build123d import Box\nb = Box(10,10,10)\nt = named_face(b, 'top')")
+    assert "Error" not in result
 
 
 # --- list_objects (new) ---
@@ -909,6 +992,153 @@ def test_diff_snapshot_json_format(session):
     assert data["a"]["label"] == "s1"
     assert data["b"]["label"] == "current"
     assert data["b"]["current_shape"]["volume"] > data["a"]["current_shape"]["volume"]
+
+
+# --- measure extended fields (center_of_mass, inertia, face_inventory) ---
+
+def test_measure_center_of_mass_symmetric_box(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(measure(session))
+    com = data["center_of_mass"]
+    assert abs(com["x"]) < 0.01
+    assert abs(com["y"]) < 0.01
+    assert abs(com["z"]) < 0.01
+
+
+def test_measure_center_of_mass_offset_box(session):
+    execute_code(session, "result = Box(10, 10, 10).move(Location((5, 5, 5)))")
+    data = json.loads(measure(session))
+    com = data["center_of_mass"]
+    assert abs(com["x"] - 5) < 0.1
+    assert abs(com["y"] - 5) < 0.1
+    assert abs(com["z"] - 5) < 0.1
+
+
+def test_measure_inertia_returns_six_components(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(measure(session))
+    inertia = data["inertia"]
+    for key in ("Ixx", "Iyy", "Izz", "Ixy", "Ixz", "Iyz"):
+        assert key in inertia
+    assert abs(inertia["Ixx"] - inertia["Iyy"]) < 1.0
+    assert abs(inertia["Ixx"] - inertia["Izz"]) < 1.0
+    assert abs(inertia["Ixy"]) < 1.0
+
+
+def test_measure_inertia_differs_for_different_shapes(session):
+    execute_code(session, "show(Box(10,10,10), 'cube')\nshow(Cylinder(5, 20), 'cyl')")
+    cube_data = json.loads(measure(session, "cube"))
+    cyl_data = json.loads(measure(session, "cyl"))
+    assert abs(cube_data["inertia"]["Ixx"] - cyl_data["inertia"]["Ixx"]) > 1.0
+
+
+def test_measure_face_inventory_box(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(measure(session))
+    fi = data["face_inventory"]
+    assert isinstance(fi, list)
+    assert len(fi) == 6
+    assert all(f["type"] == "Plane" for f in fi)
+    assert all(abs(f["area"] - 100) < 1 for f in fi)
+
+
+def test_measure_face_inventory_cylinder(session):
+    execute_code(session, "result = Cylinder(5, 10)")
+    data = json.loads(measure(session))
+    fi = data["face_inventory"]
+    types = [f["type"] for f in fi]
+    assert "Cylinder" in types
+    assert "Plane" in types
+    cyl_faces = [f for f in fi if f["type"] == "Cylinder"]
+    assert len(cyl_faces) == 1
+    assert abs(cyl_faces[0]["diameter"] - 10) < 0.1
+
+
+# --- cross_sections ---
+
+def test_cross_sections_box(session):
+    from build123d_mcp.tools.cross_sections import cross_sections
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(cross_sections(session, axis="Z", num_slices=5))
+    assert isinstance(data, list)
+    assert len(data) == 5
+    for s in data:
+        assert "position" in s and "area" in s
+        assert abs(s["area"] - 100) < 2.0
+
+
+def test_cross_sections_named_object(session):
+    from build123d_mcp.tools.cross_sections import cross_sections
+    execute_code(session, "show(Box(20, 10, 10), 'wide')")
+    data = json.loads(cross_sections(session, "wide", axis="X", num_slices=4))
+    assert len(data) == 4
+    for s in data:
+        assert abs(s["area"] - 100) < 2.0
+
+
+# --- import_cad_file ---
+
+def test_import_step_round_trip(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from build123d_mcp.tools.import_step import import_cad_file
+    execute_code(session, "result = Box(10, 10, 10)")
+    export_file(session, "ref", "step")
+    step_path = str(tmp_path / "ref.step")
+    data = json.loads(import_cad_file(session, step_path, "reference"))
+    assert data["imported"] == "reference"
+    assert data["format"] == "step"
+    assert abs(data["volume"] - 1000) < 1
+    assert data["faces"] == 6
+    assert "reference" in session.objects
+
+
+def test_import_step_default_name_from_filename(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from build123d_mcp.tools.import_step import import_cad_file
+    execute_code(session, "result = Box(5, 5, 5)")
+    export_file(session, "mypart", "step")
+    step_path = str(tmp_path / "mypart.step")
+    data = json.loads(import_cad_file(session, step_path))
+    assert data["imported"] == "mypart"
+    assert "mypart" in session.objects
+
+
+def test_import_stl_round_trip(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from build123d_mcp.tools.import_step import import_cad_file
+    execute_code(session, "result = Box(10, 10, 10)")
+    export_file(session, "ref", "stl")
+    stl_path = str(tmp_path / "ref.stl")
+    data = json.loads(import_cad_file(session, stl_path, "ref_stl"))
+    assert data["imported"] == "ref_stl"
+    assert data["format"] == "stl"
+    # STL is a triangulated mesh face — volume=0 is expected; check bbox instead
+    assert data["bbox"]["xsize"] > 0
+    assert "ref_stl" in session.objects
+
+
+def test_import_cad_file_missing_file_raises(session):
+    from build123d_mcp.tools.import_step import import_cad_file
+    with pytest.raises(ValueError, match="File not found"):
+        import_cad_file(session, "/nonexistent/path/to/file.step")
+
+
+def test_import_cad_file_wrong_extension_raises(session, tmp_path):
+    from build123d_mcp.tools.import_step import import_cad_file
+    bad = tmp_path / "file.obj"
+    bad.write_text("dummy")
+    with pytest.raises(ValueError, match="Expected a .step"):
+        import_cad_file(session, str(bad))
+
+
+def test_import_step_becomes_current_shape(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from build123d_mcp.tools.import_step import import_cad_file
+    execute_code(session, "result = Box(10, 10, 10)")
+    export_file(session, "shape", "step")
+    import_cad_file(session, str(tmp_path / "shape.step"), "imported")
+    assert session.current_shape is not None
+    assert "imported" in session.objects
 
 
 # --- health_check ---


### PR DESCRIPTION
## Summary

- **`measure(object_name)`** returns a single comprehensive JSON per call: volume, area, topology (face/edge/vertex counts), bounding box with center, volumetric center of mass, 6-component inertia tensor, and a face-type inventory classifying every face as Plane/Cylinder/Cone/Sphere/Torus/BSpline with type-specific params (cylinder diameter/axis, cone semi-angle, sphere radius, torus radii)
- **`clearance(object_a, object_b)`** is now a standalone tool (was a query on the old measure)
- **`cross_sections(object_name, axis, num_slices)`** is a standalone tool for cross-sectional area profiles along X/Y/Z
- **`fingerprint` tool dropped** — its data is now in `measure`; cross_sections split out
- **`import_cad_file(path, name)`** loads STEP/STL files as named session objects for comparison with `shape_compare`
- **OCP sub-module imports allowed** in user code via `OCP_ALLOWLIST` in `security.py` (geometric-only; file I/O modules blocked)
- **`named_face(shape, name)`** built-in for semantic face access (`top`/`bottom`/`front`/`back`/`left`/`right`)
- **`shape_compare`** uses volumetric center of mass instead of bbox center

## Test plan

- [ ] All 196 unit tests pass locally (`uv run pytest tests/`)
- [ ] CI green on this PR
- [ ] `measure` JSON structure verified for box and cylinder shapes
- [ ] `clearance` and `cross_sections` tools verified via unit tests
- [ ] OCP allowlist: safe modules allowed, file I/O modules blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)