### PR TITLE
feat: simplify LLM interface — inline repair hints, drop list_objects and validate_code

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -14,8 +14,9 @@ _has_library = False
 
 @mcp.tool()
 def execute(code: str) -> str:
-    """Execute build123d Python code in the persistent session. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure(topology) or measure(volume) to confirm it succeeded before calling render_view. named_face(shape, name) is available as a built-in helper: named_face(box, 'top') returns the highest-Z face, named_face(box, 'bottom'/'front'/'back'/'left'/'right') returns the corresponding face by axis — useful for placing geometry relative to a shape without computing coordinates. (Named 'named_face' not 'face' to avoid shadowing build123d's own face() export.)"""
-    return _session.execute(code)
+    """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly."""
+    from build123d_mcp.tools.execute import execute_code
+    return execute_code(_session, code)
 
 
 @mcp.tool()
@@ -98,12 +99,6 @@ def load_part(name: str, params: str = "") -> str:
 
 
 @mcp.tool()
-def list_objects() -> str:
-    """List all named shapes registered via show(), each with volume (mm³), face, edge, and vertex counts. Call this to audit session state without guessing what show() has been called on."""
-    return _session.list_objects()
-
-
-@mcp.tool()
 def save_snapshot(name: str) -> str:
     """Save a named checkpoint of the current geometric state (current_shape and the show() object registry).
     The Python variable namespace is NOT saved — only geometry. Call this before risky experiments so you can
@@ -128,7 +123,7 @@ def diff_snapshot(snapshot_a: str, snapshot_b: str = "", format: str = "text") -
 
 @mcp.tool()
 def session_state() -> str:
-    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects with geometry stats, snapshot names, and a variables summary of the Python namespace (type + volume for shapes, type + length for collections, type + value for scalars). Use this to orient after a reset, restore, or multi-step build to confirm what geometry and variables are active."""
+    """Return a structured JSON snapshot of the current session: current_shape metrics, all named objects (replaces list_objects) with geometry stats, snapshot names, and a variables summary of the Python namespace (type + volume for shapes, type + length for collections, type + value for scalars). Use this to orient after a reset, restore, or multi-step build to confirm what geometry and variables are active."""
     return _session.session_state()
 
 
@@ -142,13 +137,6 @@ def health_check() -> str:
 def reset() -> str:
     """Clear the current session back to empty state, including all snapshots."""
     return _session.reset()
-
-
-@mcp.tool()
-def validate_code(code: str) -> str:
-    """Check build123d code for syntax errors, blocked imports/calls, and common omissions before executing. Returns {syntax, blocked, warnings, ok}. blocked items prevent execution; warnings are advisory (e.g. no build123d import in this snippet, no result/show() call). Use this before a long generated script to catch obvious problems without burning a session execute()."""
-    from build123d_mcp.tools.validate_code import validate_code as _validate_code
-    return _validate_code(code)
 
 
 @mcp.tool()
@@ -213,6 +201,7 @@ BUILD123D-MCP WORKFLOW GUIDE
    Use show(shape, "name") after creating important geometry — it also sets current_shape.
    The execute() output immediately confirms name, volume, and face count.
    Call session_state() for a full JSON view of all active shapes, objects, and snapshots.
+   session_state() includes the named-object list — no separate list_objects() call needed.
 
 6. CHECKPOINT BEFORE EXPERIMENTS
    Call save_snapshot("name") before any operation you might want to undo.
@@ -251,15 +240,14 @@ MCP client configuration example:
   }
 
 Available tools:
-  execute           Run build123d Python code in the persistent session
+  execute           Run build123d Python code; errors include automatic fix hints
   render_view       Render model as PNG (direction, azimuth, elevation, clip_plane, clip_at, save_to)
   measure           Full geometric summary: volume, area, topology, bbox, center_of_mass, inertia, face_inventory
   clearance         Minimum distance between two named shapes
   cross_sections    Cross-sectional areas along X/Y/Z axis at evenly-spaced planes
   export            Export model to STEP or STL
   interference      Check intersection volume between two named shapes
-  list_objects      List all named shapes with volume, faces, edges, vertices
-  session_state     Full session JSON: current_shape, all objects, snapshot names
+  session_state     Full session JSON: current_shape, all named objects, snapshot names, variables
   health_check      Verify VTK/SVG/STEP/STL dependencies work end-to-end
   search_library    Search the part library by keyword (requires --library)
   load_part         Load a named part with optional parameter overrides (requires --library)
@@ -267,10 +255,9 @@ Available tools:
   restore_snapshot  Restore geometry from a named checkpoint
   diff_snapshot     Compare two snapshots; format="json" for structured output
   last_error        Details of the last failed execute() (type, message, line, excerpt)
-  validate_code     Check code for syntax/security errors before executing
   shape_compare     Compare two named shapes by geometry metrics
   import_cad_file   Import a STEP or STL file as a named object for comparison
-  repair_hints      Get fix suggestions for a given execute() error message
+  repair_hints      Get additional fix suggestions for a given execute() error message
   version           Return the server version string
   workflow_hints    Return guidance on using these tools effectively
   reset             Clear the session (namespace, shapes, snapshots)

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -1,2 +1,13 @@
+import re
+
+from build123d_mcp.tools.repair_hints import _HINTS
+
+
 def execute_code(session, code: str) -> str:
-    return session.execute(code)
+    result = session.execute(code)
+    if result.startswith("Error:") or result.startswith("Constraint failed"):
+        matched = [hint for patterns, hint in _HINTS
+                   if any(re.search(p, result) for p in patterns)]
+        if matched:
+            result += "\n\nHint: " + ("\n      ".join(matched))
+    return result

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -83,10 +83,6 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.cross_sections import cross_sections
         return cross_sections(session, **args)
 
-    if op == "list_objects":
-        from build123d_mcp.tools.list_objects import list_objects
-        return list_objects(session)
-
     if op == "save_snapshot":
         name = args["name"]
         session.save_snapshot(name)
@@ -283,9 +279,6 @@ class WorkerSession:
             {"object_name": object_name, "axis": axis, "num_slices": num_slices},
             self._SHORT_TIMEOUT,
         )
-
-    def list_objects(self) -> str:
-        return self._call("list_objects", {}, self._SHORT_TIMEOUT)
 
     def save_snapshot(self, name: str) -> str:
         return self._call("save_snapshot", {"name": name}, self._SHORT_TIMEOUT)

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -554,9 +554,9 @@ def test_mcp_lists_all_tools():
 
     names = asyncio.run(_mcp_session(run))
     assert names == {"execute", "render_view", "measure", "export", "reset",
-                     "save_snapshot", "restore_snapshot", "diff_snapshot", "interference", "list_objects",
+                     "save_snapshot", "restore_snapshot", "diff_snapshot", "interference",
                      "search_library", "load_part", "workflow_hints", "session_state", "health_check",
-                     "version", "last_error", "validate_code", "shape_compare", "repair_hints",
+                     "version", "last_error", "shape_compare", "repair_hints",
                      "import_cad_file", "cross_sections", "clearance"}
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -59,6 +59,17 @@ def test_execute_error_returns_message(session):
     assert "bad input" in result
 
 
+def test_execute_error_appends_hint_for_known_pattern(session):
+    result = execute_code(session, "import os")
+    assert "Hint:" in result
+    assert "Import blocked" in result or "not allowed" in result.lower()
+
+
+def test_execute_success_has_no_hint(session):
+    result = execute_code(session, "x = 42")
+    assert "Hint:" not in result
+
+
 def test_execute_creates_shape(session):
     execute_code(session, "result = Box(10, 10, 10)")
     assert session.current_shape is not None


### PR DESCRIPTION
## Summary

- **`execute()` now includes fix hints inline** — on error, matched repair hints are appended to the response automatically. LLMs see fix suggestions on first failure with no extra tool call.
- **Drop `list_objects`** — `session_state()` is a strict superset (includes named objects + current shape + snapshots + variables). Removes a redundant choice.
- **Drop `validate_code`** — `execute()` already returns syntax/security errors inline. LLMs rarely called `validate_code` proactively, so it added noise without benefit.

Result: 23 → 19 tools (from original), execute errors are more self-contained.

## Test plan

- [ ] 198 tests pass locally
- [ ] CI green on all platforms
- [ ] `execute("import os")` returns hint about blocked imports
- [ ] `execute("x = 1")` (success) has no hint appended
- [ ] `session_state()` shows named objects as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)