### PR TITLE
feat: add build123d://quickref resource and start-cad-session prompt

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ImageContent, TextContent
+from mcp.types import ImageContent, PromptMessage, TextContent
 
 from build123d_mcp.worker import WorkerSession
 
@@ -218,6 +218,149 @@ BUILD123D-MCP WORKFLOW GUIDE
    Call load_part("name", '{"param": value}') immediately — no second lookup needed.
    Unspecified parameters use the defaults shown in search results.
 """
+
+
+_QUICKREF = """\
+BUILD123D QUICK REFERENCE — all measurements in mm
+====================================================
+
+## Pattern 1: direct shape algebra (simplest)
+from build123d import *
+result = Box(20, 10, 5)
+result = result - Cylinder(3, 6).move(Location((0, 0, 0)))
+show(result, "part")
+
+## Pattern 2: BuildPart context manager (required for extrude/revolve/loft/fillet)
+from build123d import *
+with BuildPart() as p:
+    Box(20, 10, 5)
+    Cylinder(3, 6, mode=Mode.SUBTRACT)   # cut hole
+result = p.part
+show(result, "part")
+
+## Primitives
+Box(length, width, height)              # centred at origin
+Cylinder(radius, height)
+Sphere(radius)
+Cone(bottom_radius, top_radius, height)
+Torus(major_radius, minor_radius)
+
+## Boolean operators (direct algebra)
+a + b    # union
+a - b    # cut b from a
+a & b    # intersection
+
+## Boolean modes (inside BuildPart)
+mode=Mode.ADD        # default — union with existing solid
+mode=Mode.SUBTRACT   # cut from existing solid
+mode=Mode.INTERSECT  # keep overlap only
+mode=Mode.REPLACE    # replace current solid entirely
+
+## Positioning
+# Alignment (corner vs centred)
+Box(10, 5, 3, align=(Align.MIN, Align.MIN, Align.MIN))        # corner at origin
+Box(10, 5, 3, align=(Align.CENTER, Align.CENTER, Align.MIN))  # centred XY, bottom at Z=0
+
+# Translate (and optionally rotate)
+shape.move(Location((x, y, z)))
+shape.move(Location((x, y, z), (rx_deg, ry_deg, rz_deg)))
+
+# Place multiple instances inside BuildPart
+with Locations((5, 0, 0), (-5, 0, 0)):
+    Cylinder(2, 10, mode=Mode.SUBTRACT)
+with GridLocations(x_spacing, y_spacing, x_count, y_count):
+    Cylinder(2, 10, mode=Mode.SUBTRACT)
+with PolarLocations(radius, count):
+    Cylinder(2, 10, mode=Mode.SUBTRACT)
+
+## Sketch → solid (requires BuildPart)
+# Extrude
+with BuildPart() as p:
+    with BuildSketch() as sk:            # default plane: XY
+        Circle(10)
+        Rectangle(6, 6, mode=Mode.SUBTRACT)   # cutout in sketch
+    extrude(amount=15)
+
+# Revolve — profile in Plane.XZ, offset from axis
+with BuildPart() as p:
+    with BuildSketch(Plane.XZ) as sk:
+        with Locations((12, 0)):
+            Rectangle(4, 8)
+    revolve(axis=Axis.Z)                 # full 360°
+
+# Loft between two profiles
+with BuildPart() as p:
+    with BuildSketch(Plane.XY) as s1:
+        Rectangle(10, 10)
+    with BuildSketch(Plane.XY.offset(15)) as s2:
+        Circle(4)
+    loft()
+
+## Selecting edges and faces
+result.faces().sort_by(Axis.Z)[-1]       # highest-Z face (top)
+result.faces().sort_by(Axis.Z)[0]        # lowest-Z face (bottom)
+result.edges().sort_by(Axis.Z)[-4:]      # 4 edges at highest Z (for fillet)
+result.edges().filter_by(Axis.Z)         # edges parallel to Z
+result.faces().filter_by(GeomType.PLANE) # planar faces only
+
+## Fillets and chamfers (inside BuildPart only)
+with BuildPart() as p:
+    Box(20, 10, 5)
+    fillet(p.part.edges().sort_by(Axis.Z)[-4:], radius=1)
+
+with BuildPart() as p:
+    Box(20, 10, 5)
+    chamfer(p.part.edges().sort_by(Axis.Z)[-4:], length=0.5)
+
+## MCP server conventions
+- Name the final shape 'result' OR call show() — both trigger current_shape auto-detection
+- show(shape, "name")      registers object, prints vol + face count as immediate confirmation
+- named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right
+
+## Common gotchas
+- After every -, +, & : call measure() and check topology.faces — a failed boolean leaves counts unchanged
+- fillet/chamfer radius too large → OCC kernel exception; reduce radius or select fewer edges
+- Cylinder/Sphere are centred at origin; use .move() or align= to reposition
+- Locations() inside BuildPart shifts the construction origin — it does NOT move the whole part
+- Pass p.part (the Shape) to show(), not p (the BuildPart context)
+- revolve() needs the profile offset from the revolution axis — a profile touching the axis produces a solid, one crossing it fails
+"""
+
+
+@mcp.resource("build123d://quickref", mime_type="text/plain",
+              description="build123d API quick reference: primitives, booleans, positioning, sketch-to-3D, selectors, fillets.")
+def build123d_quickref() -> str:
+    """build123d API quick reference."""
+    return _QUICKREF
+
+
+@mcp.prompt(
+    name="start-cad-session",
+    description="Prime a new CAD design session with the task description and workflow reminders.",
+)
+def start_cad_session(description: str) -> list[PromptMessage]:
+    """Start a new CAD design session.
+
+    Args:
+        description: What you want to build.
+    """
+    text = f"""\
+Design task: {description}
+
+Workflow:
+1. Call reset(), then execute 'from build123d import *' to start clean.
+2. Build incrementally — small execute() calls are easier to debug than one large block.
+3. After every execute(), call measure() to verify geometry (check volume and topology.faces).
+4. After every boolean (-, +, &), confirm topology.faces changed — unchanged counts mean the boolean failed.
+5. Use show(shape, "name") to register important intermediate shapes; it prints vol + face count immediately.
+6. Call render_view() only after measure() confirms the geometry is correct.
+7. Call save_snapshot("name") before any experiment you might want to undo.
+8. When complete: export("part", "step,stl").
+
+Read the build123d://quickref resource before writing execute() code — it has accurate API syntax.
+Call workflow_hints() if unsure which tool to use next.
+"""
+    return [PromptMessage(role="user", content=TextContent(type="text", text=text))]
 
 
 def main():

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "build123d-mcp"
-version = "0.3.12"
+version = "0.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "bd-warehouse" },


### PR DESCRIPTION
## Summary

- Adds a `build123d://quickref` MCP resource exposing the full build123d API quick reference as plain text, so LLM clients can read accurate syntax before calling `execute()`
- Adds a `start-cad-session` MCP prompt that accepts a `description` argument and returns a primed user message with the design task and step-by-step workflow reminders (reset → execute → measure → render → snapshot → export)

## Test plan

- [ ] Start the server and verify `build123d://quickref` is listed as an MCP resource and returns the quick-reference text
- [ ] Invoke the `start-cad-session` prompt with a sample description and confirm the returned `PromptMessage` includes the description and workflow steps
- [ ] Run `uv run pytest tests/` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)