### PR TITLE
feat: make quickref a tested single source of truth

### DIFF
--- a/src/build123d_mcp/quickref.py
+++ b/src/build123d_mcp/quickref.py
@@ -1,0 +1,218 @@
+"""Single source of truth for the build123d quick reference.
+
+Each Section with a label is a fully self-contained, executable code block.
+Prose-only sections (no label) are reference documentation that cannot be run.
+
+build_quickref_text() assembles all sections into the MCP resource text.
+RUNNABLE_EXAMPLES is the list used by tests/test_quickref.py.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Section:
+    text: str
+    label: Optional[str] = None  # None = prose only, not tested
+
+
+SECTIONS: list[Section] = [
+    Section(
+        "BUILD123D QUICK REFERENCE — all measurements in mm\n"
+        "===================================================="
+    ),
+
+    Section(
+        label="pattern1",
+        text="""\
+## Pattern 1: direct shape algebra (simplest)
+from build123d import *
+result = Box(20, 10, 5)
+result = result - Cylinder(3, 6).move(Location((0, 0, 0)))
+show(result, "part")""",
+    ),
+
+    Section(
+        label="pattern2",
+        text="""\
+## Pattern 2: BuildPart context manager (required for extrude/revolve/loft/fillet)
+from build123d import *
+with BuildPart() as p:
+    Box(20, 10, 5)
+    Cylinder(3, 6, mode=Mode.SUBTRACT)   # cut hole
+result = p.part
+show(result, "part")""",
+    ),
+
+    Section(
+        text="""\
+## Primitives
+Box(length, width, height)              # centred at origin
+Cylinder(radius, height)
+Sphere(radius)
+Cone(bottom_radius, top_radius, height)
+Torus(major_radius, minor_radius)""",
+    ),
+
+    Section(
+        text="""\
+## Boolean operators (direct algebra)
+a + b    # union
+a - b    # cut b from a
+a & b    # intersection""",
+    ),
+
+    Section(
+        text="""\
+## Boolean modes (inside BuildPart)
+mode=Mode.ADD        # default — union with existing solid
+mode=Mode.SUBTRACT   # cut from existing solid
+mode=Mode.INTERSECT  # keep overlap only
+mode=Mode.REPLACE    # replace current solid entirely""",
+    ),
+
+    Section(
+        label="align",
+        text="""\
+## Positioning
+# Alignment — corner vs centred
+from build123d import *
+corner = Box(10, 5, 3, align=(Align.MIN, Align.MIN, Align.MIN))        # corner at origin
+result = Box(10, 5, 3, align=(Align.CENTER, Align.CENTER, Align.MIN))  # centred XY, bottom at Z=0""",
+    ),
+
+    Section(
+        label="translate",
+        text="""\
+# Translate (and optionally rotate)
+from build123d import *
+shape = Box(10, 5, 3)
+result = shape.move(Location((5, 0, 0)))
+rotated = shape.move(Location((5, 0, 0), (0, 0, 45)))""",
+    ),
+
+    Section(
+        label="locations",
+        text="""\
+# Place multiple instances inside BuildPart
+from build123d import *
+with BuildPart() as p:
+    Box(30, 30, 8)
+    with Locations((10, 0, 0), (-10, 0, 0)):
+        Cylinder(2, 10, mode=Mode.SUBTRACT)
+result = p.part
+
+from build123d import *
+with BuildPart() as p:
+    Box(40, 40, 8)
+    with GridLocations(12, 12, 3, 3):
+        Cylinder(2, 10, mode=Mode.SUBTRACT)
+result = p.part
+
+from build123d import *
+with BuildPart() as p:
+    Box(40, 40, 8)
+    with PolarLocations(12, 6):
+        Cylinder(2, 10, mode=Mode.SUBTRACT)
+result = p.part""",
+    ),
+
+    Section(
+        label="extrude",
+        text="""\
+## Sketch → solid (requires BuildPart)
+# Extrude
+from build123d import *
+with BuildPart() as p:
+    with BuildSketch() as sk:            # default plane: XY
+        Circle(10)
+        Rectangle(6, 6, mode=Mode.SUBTRACT)   # cutout in sketch
+    extrude(amount=15)
+result = p.part""",
+    ),
+
+    Section(
+        label="revolve",
+        text="""\
+# Revolve — profile in Plane.XZ, offset from axis
+from build123d import *
+with BuildPart() as p:
+    with BuildSketch(Plane.XZ) as sk:
+        with Locations((12, 0)):
+            Rectangle(4, 8)
+    revolve(axis=Axis.Z)                 # full 360°
+result = p.part""",
+    ),
+
+    Section(
+        label="loft",
+        text="""\
+# Loft between two profiles
+from build123d import *
+with BuildPart() as p:
+    with BuildSketch(Plane.XY) as s1:
+        Rectangle(10, 10)
+    with BuildSketch(Plane.XY.offset(15)) as s2:
+        Circle(4)
+    loft()
+result = p.part""",
+    ),
+
+    Section(
+        label="selectors",
+        text="""\
+## Selecting edges and faces
+from build123d import *
+result = Box(20, 10, 5)
+top_face    = result.faces().sort_by(Axis.Z)[-1]        # highest-Z face
+bottom_face = result.faces().sort_by(Axis.Z)[0]         # lowest-Z face
+top_edges   = result.edges().sort_by(Axis.Z)[-4:]       # 4 edges at highest Z (for fillet)
+z_edges     = result.edges().filter_by(Axis.Z)          # edges parallel to Z
+flat_faces  = result.faces().filter_by(GeomType.PLANE)  # planar faces only""",
+    ),
+
+    Section(
+        label="fillet_chamfer",
+        text="""\
+## Fillets and chamfers (inside BuildPart only)
+from build123d import *
+with BuildPart() as p:
+    Box(20, 10, 5)
+    fillet(p.part.edges().sort_by(Axis.Z)[-4:], radius=1)
+result = p.part
+
+from build123d import *
+with BuildPart() as p:
+    Box(20, 10, 5)
+    chamfer(p.part.edges().sort_by(Axis.Z)[-4:], length=0.5)
+result = p.part""",
+    ),
+
+    Section(
+        text="""\
+## MCP server conventions
+- Name the final shape 'result' OR call show() — both trigger current_shape auto-detection
+- show(shape, "name")      registers object, prints vol + face count as immediate confirmation
+- named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right""",
+    ),
+
+    Section(
+        text="""\
+## Common gotchas
+- After every -, +, & : call measure() and check topology.faces — a failed boolean leaves counts unchanged
+- fillet/chamfer radius too large → OCC kernel exception; reduce radius or select fewer edges
+- Cylinder/Sphere are centred at origin; use .move() or align= to reposition
+- Locations() inside BuildPart shifts the construction origin — it does NOT move the whole part
+- Pass p.part (the Shape) to show(), not p (the BuildPart context)
+- revolve() needs the profile offset from the revolution axis — a profile touching the axis produces a solid, one crossing it fails""",
+    ),
+]
+
+
+def build_quickref_text() -> str:
+    return "\n\n".join(s.text for s in SECTIONS)
+
+
+RUNNABLE_EXAMPLES: list[tuple[str, str]] = [
+    (s.label, s.text) for s in SECTIONS if s.label is not None
+]

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -220,118 +220,12 @@ BUILD123D-MCP WORKFLOW GUIDE
 """
 
 
-_QUICKREF = """\
-BUILD123D QUICK REFERENCE — all measurements in mm
-====================================================
-
-## Pattern 1: direct shape algebra (simplest)
-from build123d import *
-result = Box(20, 10, 5)
-result = result - Cylinder(3, 6).move(Location((0, 0, 0)))
-show(result, "part")
-
-## Pattern 2: BuildPart context manager (required for extrude/revolve/loft/fillet)
-from build123d import *
-with BuildPart() as p:
-    Box(20, 10, 5)
-    Cylinder(3, 6, mode=Mode.SUBTRACT)   # cut hole
-result = p.part
-show(result, "part")
-
-## Primitives
-Box(length, width, height)              # centred at origin
-Cylinder(radius, height)
-Sphere(radius)
-Cone(bottom_radius, top_radius, height)
-Torus(major_radius, minor_radius)
-
-## Boolean operators (direct algebra)
-a + b    # union
-a - b    # cut b from a
-a & b    # intersection
-
-## Boolean modes (inside BuildPart)
-mode=Mode.ADD        # default — union with existing solid
-mode=Mode.SUBTRACT   # cut from existing solid
-mode=Mode.INTERSECT  # keep overlap only
-mode=Mode.REPLACE    # replace current solid entirely
-
-## Positioning
-# Alignment (corner vs centred)
-Box(10, 5, 3, align=(Align.MIN, Align.MIN, Align.MIN))        # corner at origin
-Box(10, 5, 3, align=(Align.CENTER, Align.CENTER, Align.MIN))  # centred XY, bottom at Z=0
-
-# Translate (and optionally rotate)
-shape.move(Location((x, y, z)))
-shape.move(Location((x, y, z), (rx_deg, ry_deg, rz_deg)))
-
-# Place multiple instances inside BuildPart
-with Locations((5, 0, 0), (-5, 0, 0)):
-    Cylinder(2, 10, mode=Mode.SUBTRACT)
-with GridLocations(x_spacing, y_spacing, x_count, y_count):
-    Cylinder(2, 10, mode=Mode.SUBTRACT)
-with PolarLocations(radius, count):
-    Cylinder(2, 10, mode=Mode.SUBTRACT)
-
-## Sketch → solid (requires BuildPart)
-# Extrude
-with BuildPart() as p:
-    with BuildSketch() as sk:            # default plane: XY
-        Circle(10)
-        Rectangle(6, 6, mode=Mode.SUBTRACT)   # cutout in sketch
-    extrude(amount=15)
-
-# Revolve — profile in Plane.XZ, offset from axis
-with BuildPart() as p:
-    with BuildSketch(Plane.XZ) as sk:
-        with Locations((12, 0)):
-            Rectangle(4, 8)
-    revolve(axis=Axis.Z)                 # full 360°
-
-# Loft between two profiles
-with BuildPart() as p:
-    with BuildSketch(Plane.XY) as s1:
-        Rectangle(10, 10)
-    with BuildSketch(Plane.XY.offset(15)) as s2:
-        Circle(4)
-    loft()
-
-## Selecting edges and faces
-result.faces().sort_by(Axis.Z)[-1]       # highest-Z face (top)
-result.faces().sort_by(Axis.Z)[0]        # lowest-Z face (bottom)
-result.edges().sort_by(Axis.Z)[-4:]      # 4 edges at highest Z (for fillet)
-result.edges().filter_by(Axis.Z)         # edges parallel to Z
-result.faces().filter_by(GeomType.PLANE) # planar faces only
-
-## Fillets and chamfers (inside BuildPart only)
-with BuildPart() as p:
-    Box(20, 10, 5)
-    fillet(p.part.edges().sort_by(Axis.Z)[-4:], radius=1)
-
-with BuildPart() as p:
-    Box(20, 10, 5)
-    chamfer(p.part.edges().sort_by(Axis.Z)[-4:], length=0.5)
-
-## MCP server conventions
-- Name the final shape 'result' OR call show() — both trigger current_shape auto-detection
-- show(shape, "name")      registers object, prints vol + face count as immediate confirmation
-- named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right
-
-## Common gotchas
-- After every -, +, & : call measure() and check topology.faces — a failed boolean leaves counts unchanged
-- fillet/chamfer radius too large → OCC kernel exception; reduce radius or select fewer edges
-- Cylinder/Sphere are centred at origin; use .move() or align= to reposition
-- Locations() inside BuildPart shifts the construction origin — it does NOT move the whole part
-- Pass p.part (the Shape) to show(), not p (the BuildPart context)
-- revolve() needs the profile offset from the revolution axis — a profile touching the axis produces a solid, one crossing it fails
-"""
-
-
 @mcp.resource("build123d://quickref", mime_type="text/plain",
               description="build123d API quick reference: primitives, booleans, positioning, sketch-to-3D, selectors, fillets.")
 def build123d_quickref() -> str:
     """build123d API quick reference."""
-    return _QUICKREF
+    from build123d_mcp.quickref import build_quickref_text
+    return build_quickref_text()
 
 
 @mcp.prompt(

--- a/tests/test_quickref.py
+++ b/tests/test_quickref.py
@@ -1,0 +1,29 @@
+"""Verify every runnable quickref example executes without error and produces a shape."""
+import pytest
+
+from build123d_mcp.quickref import RUNNABLE_EXAMPLES, build_quickref_text
+from build123d_mcp.session import Session
+
+
+@pytest.fixture
+def fresh_session():
+    return Session()
+
+
+@pytest.mark.parametrize(
+    "label,code",
+    RUNNABLE_EXAMPLES,
+    ids=[label for label, _ in RUNNABLE_EXAMPLES],
+)
+def test_quickref_example_runs(fresh_session, label, code):
+    result = fresh_session.execute(code)
+    assert not result.startswith("Error:"), f"Example '{label}' failed:\n{result}"
+    assert fresh_session.current_shape is not None, (
+        f"Example '{label}' produced no shape"
+    )
+
+
+def test_quickref_resource_uses_generated_text():
+    """Confirm the MCP resource returns exactly what build_quickref_text() produces."""
+    from build123d_mcp.server import build123d_quickref
+    assert build123d_quickref() == build_quickref_text()


### PR DESCRIPTION
## Summary

- Moves the quick reference out of a hardcoded string in `server.py` into a new `src/build123d_mcp/quickref.py` module
- Each runnable example is a `Section(label=..., text=...)` where the `text` field is both what appears in the MCP resource *and* what the tests execute — no divergence possible
- Prose-only sections (primitives list, boolean modes, gotchas) are unlabelled and not tested
- Two pseudo-code snippets from the old quickref (`translate` with placeholder `x,y,z`, `locations` with `x_spacing` etc.) are rewritten with real values so they actually run
- `server.py` drops `_QUICKREF` entirely; `build123d_quickref()` calls `build_quickref_text()`

## Test plan

- `tests/test_quickref.py` — 10 parametrised tests, one per labelled example, each run through a fresh `Session`; asserts no `"Error:"` in output and `current_shape is not None`
- 1 additional test asserts the MCP resource returns exactly `build_quickref_text()` (catches any future drift)
- Full suite: 235 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)