### PR TITLE
feat: add build123d://session live state resource

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -334,6 +334,14 @@ def build123d_quickref() -> str:
     return _QUICKREF
 
 
+@mcp.resource("build123d://session", mime_type="application/json",
+              description="Live session state: current shape diagnostics, named objects, snapshots, and user-defined variables.")
+def build123d_session_state() -> str:
+    """Live session state as JSON."""
+    from build123d_mcp.tools.session_state import session_state
+    return session_state(_session)
+
+
 @mcp.prompt(
     name="start-cad-session",
     description="Prime a new CAD design session with the task description and workflow reminders.",

--- a/tests/test_session_resource.py
+++ b/tests/test_session_resource.py
@@ -1,0 +1,34 @@
+"""Test the build123d://session MCP resource wiring."""
+import json
+
+import pytest
+
+from build123d_mcp.session import Session
+
+
+@pytest.fixture
+def patched_server(monkeypatch):
+    """Return the server module with _session set to a real Session."""
+    import build123d_mcp.server as srv
+    s = Session()
+    monkeypatch.setattr(srv, "_session", s, raising=False)
+    return srv, s
+
+
+def test_session_resource_empty(patched_server):
+    srv, _ = patched_server
+    data = json.loads(srv.build123d_session_state())
+    assert data["current_shape"] is None
+    assert data["objects"] == {}
+    assert data["snapshots"] == []
+
+
+def test_session_resource_reflects_live_state(patched_server):
+    srv, s = patched_server
+    s.execute("from build123d import *\nresult = Box(10, 10, 10)")
+    s.execute("show(Cylinder(3, 15), 'pin')")
+    s.save_snapshot("v1")
+    data = json.loads(srv.build123d_session_state())
+    assert data["current_shape"]["volume"] == pytest.approx(1000, rel=0.01)
+    assert "pin" in data["objects"]
+    assert "v1" in data["snapshots"]


### PR DESCRIPTION
## Summary

- Adds `build123d://session` as a read-only MCP resource (JSON, `application/json`)
- Returns current shape diagnostics, named objects, snapshots, and user-defined variables — the same data as the `session_state()` tool, but accessible as a resource so clients can stay oriented without spending a tool-call round-trip
- Wires through to the existing `session_state()` function in `tools/session_state.py` — no logic duplicated

## Test plan

- `tests/test_session_resource.py` — 2 tests: empty session returns null shape/empty objects/empty snapshots; populated session reflects live state (shape volume, named objects, snapshot list)
- Full suite: 226 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)