### PR TITLE
chore: fix release process and consolidate v0.3.13 changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,18 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Set dev version for TestPyPI
+      - name: Set TestPyPI dev version
         if: github.event_name == 'push'
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          uv version "${current}.dev${{ github.run_number }}"
+          base="${current%.dev*}"
+          uv version "${base}.dev${{ github.run_number }}"
+      - name: Strip dev suffix for real release
+        if: github.event_name == 'release'
+        run: |
+          current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          base="${current%.dev*}"
+          uv version "$base"
       - run: uv build
       - uses: actions/upload-artifact@v4
         with:
@@ -68,11 +75,12 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Bump patch version
+      - name: Bump patch version with .dev0 suffix
         run: |
           current=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          IFS='.' read -r major minor patch <<< "$current"
-          uv version "${major}.${minor}.$((patch + 1))"
+          base="${current%.dev*}"
+          IFS='.' read -r major minor patch <<< "$base"
+          uv version "${major}.${minor}.$((patch + 1)).dev0"
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## v0.3.14
+## v0.3.13
+
+### Features
+
+- **`build123d://quickref` MCP resource**: exposes a plain-text quick reference for the build123d API so LLM clients can read accurate syntax before calling `execute()`. Every runnable example is tested automatically to ensure the quickref stays accurate as the codebase evolves.
+- **`start-cad-session` prompt**: primes a design session with the task description plus step-by-step workflow reminders.
+- **`build123d://session` MCP resource**: read-only JSON resource exposing live session state — `current_shape` diagnostics, named objects, snapshots, and user-defined variables. Clients can read session state without spending a tool-call round-trip on `session_state()`.
+- **`build123d://bd_warehouse` MCP resource**: introspects the installed `bd_warehouse` package and returns a plain-text catalogue of all available parametric components (bearings, fasteners, flanges, gears, OpenBuilds parts, pipes, sprockets, threads). Each entry shows the class name, description, constructor signature, and for size-standardised classes the available types and sizes.
+- **`render_view` labels**: two new optional parameters. `label_objects=True` labels each named object from `show()` at its centroid in the PNG. `highlights=[{"object", "type", "index", "label"}, ...]` labels specific faces, edges, or vertices by index — useful for confirming "edge 5 is the one I want to fillet" before committing to an operation. Labels render on a depth-cleared overlay layer so they stay legible even when sitting at a solid's interior centroid. SVG output is unlabelled (a `label_warnings` entry surfaces this).
 
 ### Improvements
 
@@ -14,16 +22,10 @@
 - **`workflow_hints()` expanded** — new items cover bd_warehouse fastener probing, the complex-build workflow (probe → script → import → verify), import→render pattern, and Z-fighting guidance.
 - **README expanded** — "Recommended workflow" and "bd_warehouse fasteners" sections added.
 
----
+### Release process
 
-## v0.3.13
-
-### Features
-
-- **`build123d://quickref` MCP resource**: exposes a plain-text quick reference for the build123d API so LLM clients can read accurate syntax before calling `execute()`. Every runnable example is tested automatically to ensure the quickref stays accurate as the codebase evolves.
-- **`start-cad-session` prompt**: primes a design session with the task description plus step-by-step workflow reminders.
-- **`build123d://session` MCP resource**: read-only JSON resource exposing live session state — `current_shape` diagnostics, named objects, snapshots, and user-defined variables. Clients can read session state without spending a tool-call round-trip on `session_state()`.
-- **`build123d://bd_warehouse` MCP resource**: introspects the installed `bd_warehouse` package and returns a plain-text catalogue of all available parametric components (bearings, fasteners, flanges, gears, OpenBuilds parts, pipes, sprockets, threads). Each entry shows the class name, description, constructor signature, and for size-standardised classes the available types and sizes.
+- **`.dev0` version convention**: between releases, `pyproject.toml` carries a `.dev0` suffix (e.g. `0.3.14.dev0`) so it self-documents that the working version has not yet been published. The publish workflow strips the suffix on real release and TestPyPI builds replace `.dev0` with `.dev<run_number>`. Anyone — human or AI — reading `pyproject.toml` can immediately tell which version is published vs in development.
+- **`CLAUDE.md` documents release process**: only `gh release create vX.Y.Z` cuts a release; never edit `pyproject.toml` or push tags manually.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,13 @@ Known limits: memory exhaustion is not bounded; Python introspection chains can 
 - `show()` stores shapes by reference; mutating the shape object after calling `show()` will affect the stored object.
 - Clip plane in `render_view` slices at the mesh's own bounding-box midpoint, not world origin.
 - Interference uses a 1 × 10⁻⁶ mm³ volume threshold to ignore floating-point noise.
+
+## Releasing
+
+**Cutting a release means one command:** `gh release create vX.Y.Z --generate-notes` (or use the GitHub Release UI). That triggers the `Publish` workflow which builds, uploads to PyPI, and auto-bumps `pyproject.toml` to the next `.dev0` version. Nothing else is needed.
+
+**Never edit `pyproject.toml` manually. Never push tags manually.** Manual edits/tags don't trigger the publish workflow and create orphan tags + version drift. If you see `pyproject.toml` showing `0.3.14.dev0`, that means `0.3.13` is the current PyPI release and `0.3.14` is the next planned release; don't "fix" the version.
+
+**Version convention:** between releases, `pyproject.toml` carries a `.dev0` suffix (PEP 440 dev release). `0.3.12 < 0.3.13.dev0 < 0.3.13.dev99 < 0.3.13` — TestPyPI builds (`.devN`) are always newer than the last published release but older than the eventual real release.
+
+**Before cutting a release:** make sure `CHANGELOG.md`'s top entry matches the version you're about to release (strip the `.dev0` suffix mentally — `pyproject.toml = 0.3.14.dev0` means you're cutting `v0.3.14`).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 - `last_error` — details of the last failed `execute()`: type, message, line number, and code excerpt
 
 **Viewing**
-- `render_view` — render one or more shapes as PNG or SVG; supports assembly compositing, high-quality tessellation, and cross-section clip planes
+- `render_view` — render one or more shapes as PNG or SVG; supports assembly compositing, high-quality tessellation, cross-section clip planes, and optional labels for named shapes or specific faces/edges
 
 **Import / export**
 - `export` — export as STEP, STL, or both in one call; targets a named object, the current shape, or `*` for all objects as an assembly

--- a/llms.md
+++ b/llms.md
@@ -96,6 +96,8 @@ Render one or more shapes and return a file path to the rendered image.
 - `azimuth` / `elevation` (float, default `0.0`) — camera rotation in degrees applied after the direction preset
 - `format` (string, default `"png"`) — `png`, `svg`, or `both`
 - `save_to` (string, default `""`) — optional path to also write the file(s) to disk
+- `label_objects` (bool, default `False`) — label each named object from `show()` at its centroid in the PNG. Useful for assemblies where the LLM needs to confirm which shape is which by name.
+- `highlights` (list of dict, default `None`) — label specific faces, edges, or vertices in the PNG. Each entry is `{"object": "name", "type": "face"|"edge"|"vertex", "index": int, "label": "text"}` where `index` matches the position in `shape.faces()` / `.edges()` / `.vertices()`. The referenced object must already be registered with `show()` and included in the rendered set; an unregistered object raises an error naming what to register. Use this to verify "edge 5 is the one I want to fillet" before committing to the operation. Labels are PNG-only — SVG output emits a `label_warnings` notice.
 
 **Returns:** `[SEND: /tmp/build123d_xxx.png]` text marker; the file is delivered directly to the client.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "build123d-mcp"
-version = "0.3.14"
+version = "0.3.13.dev0"
 description = "MCP server wrapping build123d for interactive 3D CAD"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "build123d-mcp"
-version = "0.3.13"
+version = "0.3.13.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bd-warehouse" },


### PR DESCRIPTION
## Summary

Unmuddles the release/version workflow that has been drifting:

- **PyPI is at 0.3.12** — last actual release.
- **Git tags `v0.3.13` and `v0.3.14` exist but were never released** (manual tagging / version bumping that didn't go through `gh release create`, so the publish workflow never fired).
- **`pyproject.toml` was at `0.3.14`** — every AI reading it assumed that was the current PyPI version.

This PR fixes both the workflow and the muddled state.

## Changes

### `pyproject.toml` uses PEP 440 `.dev0` suffix between releases
After publishing `0.3.X` the workflow bumps to `0.3.(X+1).dev0` instead of `0.3.(X+1)`. Anyone reading `pyproject.toml` can immediately tell the working version is unreleased. Sort order: `0.3.12 < 0.3.13.dev0 < 0.3.13.dev99 < 0.3.13` — TestPyPI builds always rank newer than the last release but older than the eventual real release.

`publish.yml` updated to:
- TestPyPI build: strip any existing `.devN` before appending `.dev<run_number>` (only one `.devN` segment is PEP 440 valid)
- Real-release build: strip `.dev0` before `uv build`
- `bump-version`: append `.dev0` to the next patch

### CHANGELOG consolidated into one v0.3.13 entry
The previous v0.3.13 and v0.3.14 entries were both unreleased — PyPI saw neither. Folded them and the `render_view` labels feature (already merged in #73) into a single v0.3.13 entry that will be the next actual PyPI release.

### CLAUDE.md documents the release process
> Cutting a release means one command: `gh release create vX.Y.Z`.

Manual edits to `pyproject.toml` and manual git tags are explicitly forbidden — that's how the drift happened in the first place.

### llms.md and README.md updated for `render_view` labels
- `llms.md` gained `label_objects` and `highlights` parameter docs
- README's `render_view` bullet now mentions labels

## Follow-up after merge (manual, not part of this PR)

```
git push --delete origin v0.3.13 v0.3.14   # remove orphan tags
gh release create v0.3.13 --generate-notes # actually ship it
```

## Test plan

- [x] All 261 tests pass on local
- [x] `publish.yml` parses as valid YAML
- [ ] CI green on this PR
- [ ] After merge, follow-up steps above

🤖 Generated with [Claude Code](https://claude.com/claude-code)