### PR TITLE
docs: teach LLM to reach for build123d Joints in assemblies

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -311,6 +311,8 @@ Clear the session back to empty state, including all snapshots.
 12. Repeat 6–11 until satisfied
 13. `export` — write STEP + STL in one call with `format="step,stl"`
 
+For assemblies of two or more parts with a mechanical relationship (mounted, hinged, sliding), use build123d Joints (`RigidJoint`/`RevoluteJoint`/`LinearJoint`/`CylindricalJoint`/`BallJoint`) rather than positioning parts with `.move()`. The relationship survives later changes to the parent. See `build123d://quickref` for examples.
+
 ---
 
 ---
@@ -384,5 +386,6 @@ All units are millimetres by default.
 - **Dirty session:** unexpected results often mean leftover state. Call `reset` first, or `session_state` to inspect what's active.
 - **Boolean succeeded but geometry is wrong:** always call `measure()` after a boolean and check `topology.faces` — a failed cut leaves counts unchanged.
 - **Using render_view as geometric proof:** renders can look correct even when geometry is wrong. Use `measure()` to verify numerically first.
+- **Assembling with raw `.move()` instead of joints:** placing parts by absolute position works once but breaks the moment anything changes — the child has no relationship to the parent. Use `RigidJoint`/`RevoluteJoint`/etc. so the relationship is preserved.
 - **Failed execute advancing state:** it doesn't — failed code preserves the previous `current_shape`.
 - **Library tools without --library:** `search_library` and `load_part` return an error if the server wasn't started with `--library PATH`.

--- a/src/build123d_mcp/quickref.py
+++ b/src/build123d_mcp/quickref.py
@@ -189,6 +189,41 @@ result = p.part""",
     ),
 
     Section(
+        label="joints_rigid",
+        text="""\
+## Joints — assembly relationships
+# Joints express how parts CONNECT, not just where they happen to sit. Move the
+# parent, the child follows. Reach for joints when building assemblies — they
+# scale better than raw .move() because the relationship survives changes.
+from build123d import *
+plate = Box(20, 20, 5)
+RigidJoint("mount", to_part=plate, joint_location=Location((0, 0, 2.5)))
+
+pin = Box(2, 2, 10)
+RigidJoint("base", to_part=pin, joint_location=Location((0, 0, -5)))
+
+# Snap pin's "base" joint to plate's "mount" joint. pin is now positioned
+# so its joint coincides with the plate's. Move plate later → pin follows.
+plate.joints["mount"].connect_to(pin.joints["base"])
+show(plate, "plate")
+show(pin, "pin")""",
+    ),
+
+    Section(
+        text="""\
+## Joint types
+RigidJoint(label, to_part, joint_location)              # fixed (no DOF)
+RevoluteJoint(label, to_part, axis, angular_range)      # hinge (1 rotation)
+LinearJoint(label, to_part, axis, linear_range)         # slider (1 translation)
+CylindricalJoint(label, to_part, axis, ...)             # rotate + translate same axis
+BallJoint(label, to_part, joint_location, angular_range) # 3 rotations, 0 translations
+
+# For movable joints, pass position/angle to connect_to() to set the configuration:
+#   plate.joints["hinge"].connect_to(arm.joints["pivot"], angle=45)
+#   rail.joints["slot"].connect_to(carriage.joints["slide"], position=10)""",
+    ),
+
+    Section(
         text="""\
 ## MCP server conventions
 - Name the final shape 'result' OR call show() — both trigger current_shape auto-detection

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -244,6 +244,20 @@ BUILD123D-MCP WORKFLOW GUIDE
    position, always render by name to avoid Z-fighting (striped colour artifacts).
    STL imports produce a shell (volume=0); render_view and measure work, but interference()
    and boolean operations require a solid.
+
+12. ASSEMBLIES — USE JOINTS, NOT JUST .move()
+   For assemblies of two or more parts that have a real mechanical relationship
+   (mounted on, hinged to, slides along), reach for build123d Joints rather than
+   positioning parts with .move() / Location(). RigidJoint expresses a fixed
+   mount; RevoluteJoint a hinge; LinearJoint a slider; CylindricalJoint
+   rotate-and-slide; BallJoint a 3-axis pivot.
+   The benefit: move the parent later, the child follows. With raw .move() the
+   relationship is lost.
+   Pattern (rigid mount):
+     RigidJoint("mount", to_part=plate, joint_location=Location((0, 0, 2.5)))
+     RigidJoint("base",  to_part=pin,   joint_location=Location((0, 0, -5)))
+     plate.joints["mount"].connect_to(pin.joints["base"])
+   See build123d://quickref for joint type details and movable-joint examples.
 """
 
 
@@ -292,7 +306,10 @@ Workflow:
 5. Use show(shape, "name") to register important intermediate shapes; it prints vol + face count immediately.
 6. Call render_view() only after measure() confirms the geometry is correct.
 7. Call save_snapshot("name") before any experiment you might want to undo.
-8. When complete: export("part", "step,stl").
+8. For assemblies of two or more parts with a mechanical relationship (mounted, hinged, sliding),
+   use Joints (RigidJoint/RevoluteJoint/LinearJoint/CylindricalJoint/BallJoint) rather than raw
+   .move() — the relationship survives later changes. See build123d://quickref for examples.
+9. When complete: export("part", "step,stl").
 
 Read the build123d://quickref resource before writing execute() code — it has accurate API syntax.
 Read the build123d://bd_warehouse resource for fastener/bearing/thread catalogue and usage patterns.


### PR DESCRIPTION
## Summary

Without explicit guidance the LLM defaults to `.move()` / `Location()` for every multi-part assembly, treating geometry placement as the same problem as mechanical relationships. Build123d's Joint types (`RigidJoint`, `RevoluteJoint`, `LinearJoint`, `CylindricalJoint`, `BallJoint`) express the relationship itself — moving a parent updates the child. The server's docs were silent on this, so the LLM never reached for them.

This adds guidance in three places, all docs-only — no new MCP tool, no new dependency. The LLM uses build123d's joint API directly via `execute()`, keeping output code idiomatic and portable outside the MCP.

## Changes

- **`build123d://quickref`** — new "Joints" section with a runnable `RigidJoint` example (verified via `test_quickref`) plus a reference card listing joint types and their constructor signatures, with a note on passing position/angle to `connect_to()` for movable joints.
- **`workflow_hints()`** — new item 12 covering when to use joints vs raw `.move()`.
- **`start-cad-session` prompt** — workflow step 8 nudges toward joints for any assembly with a real mechanical relationship.
- **`llms.md`** — workflow section gains a joints note; common-mistakes section gains a "raw .move() instead of joints" entry.

## Test plan

- [x] All 262 tests pass locally (was 261 — new `joints_rigid` quickref example adds one)
- [x] The new quickref example actually runs and produces a positioned `pin` aligned to the `plate`'s mount joint
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)