### PR TITLE
feat: STEP exports carry session names as labels

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -159,6 +159,12 @@ Export a shape to a file.
 
 STEP preserves exact geometry for downstream CAD tools. STL is for mesh-based workflows (3D printing, slicers, GitHub preview).
 
+STEP exports carry session names as labels so downstream CAD tools see structured assemblies with named bodies:
+- `export("part.step", object_name="bracket")` — body labelled `bracket`
+- `export("asm.step", object_name="*")` — Compound labelled `assembly` containing each named child (`bracket`, `pin`, etc.)
+
+Labels are set on copies — your session shapes are not mutated.
+
 ---
 
 ### `interference`

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -76,7 +76,7 @@ def cross_sections(object_name: str = "", axis: str = "Z", num_slices: int = 10)
 
 @mcp.tool()
 def export(filename: str, format: str = "step", object_name: str = "") -> str:
-    """Export model. format: step, stl, or comma-separated list e.g. 'step,stl'. object_name: named object from show(), '*' to export all named shapes as a combined assembly (default: current shape)."""
+    """Export model. format: step, stl, or comma-separated list e.g. 'step,stl'. object_name: named object from show(), '*' to export all named shapes as a combined assembly (default: current shape). STEP exports carry the session names as labels — single-object exports use the object_name, '*' exports produce a Compound labelled 'assembly' with each child labelled by its show() name. Downstream CAD tools (FreeCAD, Fusion) will see the structured assembly with named bodies."""
     return _session.export_file(filename, format, object_name)
 
 

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -1,3 +1,4 @@
+import copy
 import struct
 
 from build123d_mcp.tools._paths import safe_output_path
@@ -5,16 +6,26 @@ from build123d_mcp.tools._paths import safe_output_path
 _VALID_FORMATS = ("step", "stl")
 
 
+def _labelled_copy(shape, label: str):
+    """Return a shallow copy of `shape` with `.label` set, preserving any
+    existing color. Used to carry session names through to the exported
+    file without mutating the original shape in session.objects."""
+    c = copy.copy(shape)
+    c.label = label
+    return c
+
+
 def _resolve_shape(session, object_name: str):
     if object_name == "*":
         if not session.objects:
             raise ValueError("No named objects in session. Use show() to register shapes first.")
         from build123d import Compound
-        return Compound(children=list(session.objects.values()))
+        children = [_labelled_copy(s, name) for name, s in session.objects.items()]
+        return Compound(label="assembly", children=children)
     if object_name:
         if object_name not in session.objects:
             raise ValueError(f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}")
-        return session.objects[object_name]
+        return _labelled_copy(session.objects[object_name], object_name)
     if session.current_shape is None:
         raise ValueError("No shape in session. Execute code to create geometry first.")
     return session.current_shape

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -570,6 +570,36 @@ def test_export_to_slash_tmp_allowed(session):
             os.unlink(target)
 
 
+def test_export_step_named_object_carries_label(session, tmp_path, monkeypatch):
+    """A single named object exported to STEP should carry its session name as the label."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'bracket')")
+    export_file(session, "out", "step", object_name="bracket")
+    content = (tmp_path / "out.step").read_text()
+    assert "bracket" in content
+
+
+def test_export_step_star_carries_assembly_and_child_labels(session, tmp_path, monkeypatch):
+    """Exporting * should produce a STEP file with the assembly label and each child name."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'bracket')")
+    execute_code(session, "show(Cylinder(2, 8).move(Location((20, 0, 0))), 'pin')")
+    export_file(session, "out", "step", object_name="*")
+    content = (tmp_path / "out.step").read_text()
+    assert "bracket" in content
+    assert "pin" in content
+    assert "assembly" in content
+
+
+def test_export_step_does_not_mutate_session_shapes(session, tmp_path, monkeypatch):
+    """Setting labels for export must not leak back into session.objects."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'bracket')")
+    original_label = getattr(session.objects["bracket"], "label", None)
+    export_file(session, "out", "step", object_name="bracket")
+    assert getattr(session.objects["bracket"], "label", None) == original_label
+
+
 def test_export_symlink_escape_rejected(session, tmp_path):
     execute_code(session, "result = Box(10, 10, 10)")
     link = tmp_path / "escape.step"


### PR DESCRIPTION
## Summary

STEP exports now carry session names as labels so downstream CAD tools (FreeCAD, Fusion) see structured assemblies with named bodies instead of anonymous "Body 1, Body 2, ...".

- Single-object export uses `object_name` as the body label
- `*` export produces a `Compound` labelled `assembly` with each child labelled by its `show()` name

Verified end-to-end: the resulting STEP file contains the labels as searchable strings.

## Why

Closes the third item in the "more build123d native" plan. The previous behaviour was to dump the geometry into a Compound with no labels, so opening the file in another tool gave you no clue which body was which — even though the LLM had registered them with meaningful names via `show()`. Carrying those names through to the STEP file is what build123d itself encourages and what users would expect.

## Implementation

A small `_labelled_copy` helper sets the label on a shallow copy of each shape rather than mutating the originals in `session.objects`. A regression test guards against label leakage back into session state.

Existing single-object exports without a name (e.g. `export("part.step")` for the bare `current_shape`) are unchanged — no label set.

## Test plan

- [x] All 281 tests pass locally (was 278 — added 3 export label tests)
- [x] `test_export_step_named_object_carries_label` — single-object STEP contains `bracket`
- [x] `test_export_step_star_carries_assembly_and_child_labels` — `*` STEP contains `assembly`, `bracket`, `pin`
- [x] `test_export_step_does_not_mutate_session_shapes` — `session.objects['bracket'].label` unchanged after export
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)