### PR TITLE
feat: execute() output gains shape deltas and silent-failure warnings

### DIFF
--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -63,21 +63,91 @@ class Session:
 
         self.namespace["named_face"] = named_face
 
-    def _quick_diagnostics(self, shape) -> str:
+    def _shape_summary(self, shape) -> dict | None:
+        """Pull volume/bbox/topology from a shape; None if anything errors."""
         try:
             bb = shape.bounding_box()
-            vol = shape.volume
-            faces = len(shape.faces())
-            edges = len(shape.edges())
-            verts = len(shape.vertices())
-            return (
-                f"--- current_shape ---\n"
-                f"volume: {vol:.4g} mm³  |  "
-                f"bbox: {bb.size.X:.4g}×{bb.size.Y:.4g}×{bb.size.Z:.4g} mm  |  "
-                f"{faces}f {edges}e {verts}v"
-            )
+            return {
+                "vol": shape.volume,
+                "size_x": bb.size.X, "size_y": bb.size.Y, "size_z": bb.size.Z,
+                "center_x": bb.center().X, "center_y": bb.center().Y, "center_z": bb.center().Z,
+                "faces": len(shape.faces()),
+                "edges": len(shape.edges()),
+                "verts": len(shape.vertices()),
+            }
         except Exception:
-            return ""
+            return None
+
+    def _diagnose_change(self, shape, before) -> tuple[str, list[str]]:
+        """Format the current_shape diagnostic line, with deltas vs `before`
+        when available, plus warnings for two specific silent-failure modes:
+        boolean no-op and degenerate (zero-volume) result."""
+        after = self._shape_summary(shape)
+        if after is None:
+            return "", []
+
+        before_summary = self._shape_summary(before) if before is not None else None
+
+        if before_summary is None:
+            diag = (
+                f"--- current_shape ---\n"
+                f"volume: {after['vol']:.4g} mm³  |  "
+                f"bbox: {after['size_x']:.4g}×{after['size_y']:.4g}×{after['size_z']:.4g} mm  |  "
+                f"{after['faces']}f {after['edges']}e {after['verts']}v"
+            )
+            return diag, []
+
+        b = before_summary
+        a = after
+        dvol = a["vol"] - b["vol"]
+        dpct = (dvol / b["vol"] * 100) if abs(b["vol"]) > 1e-9 else None
+
+        def fmt_int_delta(d: int) -> str:
+            return "" if d == 0 else f" ({d:+d})"
+
+        def fmt_vol_delta(d: float, pct: float | None) -> str:
+            if abs(d) < 1e-9:
+                return ""
+            if pct is None:
+                return f" ({d:+.3g})"
+            return f" ({d:+.3g}, {pct:+.1f}%)"
+
+        diag = (
+            f"--- current_shape ---\n"
+            f"volume: {a['vol']:.4g}{fmt_vol_delta(dvol, dpct)} mm³  |  "
+            f"bbox: {a['size_x']:.4g}×{a['size_y']:.4g}×{a['size_z']:.4g} mm  |  "
+            f"{a['faces']}f{fmt_int_delta(a['faces'] - b['faces'])} "
+            f"{a['edges']}e{fmt_int_delta(a['edges'] - b['edges'])} "
+            f"{a['verts']}v{fmt_int_delta(a['verts'] - b['verts'])}"
+        )
+
+        warnings: list[str] = []
+
+        # Boolean no-op: shape was rebound (different object) but every
+        # measurable property is bit-identical. Likely the boolean missed.
+        identical = (
+            shape is not before
+            and a["vol"] == b["vol"]
+            and a["faces"] == b["faces"]
+            and a["edges"] == b["edges"]
+            and a["verts"] == b["verts"]
+            and a["size_x"] == b["size_x"] and a["size_y"] == b["size_y"] and a["size_z"] == b["size_z"]
+            and a["center_x"] == b["center_x"] and a["center_y"] == b["center_y"] and a["center_z"] == b["center_z"]
+        )
+        if identical:
+            warnings.append(
+                "Warning: shape was rebound but volume/topology/bbox unchanged "
+                "— boolean may have missed (no intersection?)"
+            )
+
+        # Degenerate: previously had volume, now ≈ 0. Failed loft/extrude/intersection.
+        if b["vol"] > 1e-9 and a["vol"] < 1e-9:
+            warnings.append(
+                "Warning: resulting shape has volume ≈ 0 — degenerate "
+                "(failed loft/extrude/intersection?)"
+            )
+
+        return diag, warnings
 
     def execute(self, code: str) -> str:
         # Layer 1: AST check before anything runs
@@ -163,9 +233,11 @@ class Session:
 
         output = buf.getvalue() or "OK"
         if self.current_shape is not None and self.current_shape is not shape_before:
-            diag = self._quick_diagnostics(self.current_shape)
+            diag, warnings = self._diagnose_change(self.current_shape, shape_before)
             if diag:
                 output = output.rstrip("\n") + "\n" + diag
+            for w in warnings:
+                output += "\n" + w
         return output
 
     def _rollback_namespace(self, values_before: dict[str, Any]) -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -80,6 +80,71 @@ def test_execute_detects_buildpart(session):
     assert session.current_shape is not None
 
 
+# --- execute() diagnostics: deltas + anomaly warnings ---
+
+def test_execute_first_shape_shows_absolutes_no_warnings(session):
+    """First shape ever: no previous to diff against, so no delta and no warnings."""
+    out = execute_code(session, "result = Box(10, 10, 5)")
+    assert "current_shape" in out
+    assert "500" in out  # volume
+    assert "Warning:" not in out
+    # No delta markers
+    assert "(+" not in out and "(-" not in out
+
+
+def test_execute_real_cut_shows_deltas(session):
+    """A successful boolean cut shows the volume and topology deltas inline."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    out = execute_code(session, "result = result - Cylinder(2, 5)")
+    # Volume dropped, faces increased — delta markers should appear
+    assert "(-" in out  # volume decreased
+    assert "(+" in out  # faces increased
+    assert "%" in out   # percentage delta on volume
+    assert "Warning:" not in out
+
+
+def test_execute_warns_on_boolean_noop(session):
+    """A boolean that produces no change (cylinder placed far away) triggers the
+    no-op warning so the LLM can't silently sail past a failed cut."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    out = execute_code(
+        session,
+        "result = result - Cylinder(2, 5).move(Location((100, 100, 100)))",
+    )
+    assert "Warning:" in out
+    assert "boolean may have missed" in out
+
+
+def test_execute_warns_on_degenerate(session):
+    """Intersection that produces an empty result triggers the degenerate warning."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    out = execute_code(
+        session,
+        "result = result & Cylinder(1, 1).move(Location((100, 100, 100)))",
+    )
+    assert "Warning:" in out
+    assert "volume" in out and "0" in out
+    assert "degenerate" in out
+
+
+def test_execute_move_does_not_warn(session):
+    """A pure translation changes bbox center, not size/topology/volume — must
+    not trigger the no-op warning."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    out = execute_code(session, "result = result.move(Location((50, 0, 0)))")
+    assert "Warning:" not in out
+
+
+def test_execute_no_warnings_when_shape_unchanged(session):
+    """If execute doesn't change current_shape (e.g. just printing), no
+    diagnostic block at all — no warnings, no deltas."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    out = execute_code(session, "print('inspecting')")
+    assert "current_shape" not in out
+    assert "Warning:" not in out
+    assert "inspecting" in out
+
+
 # --- security ---
 
 def test_show_objects_persist_across_execute_calls(session):


### PR DESCRIPTION
## Summary

The `current_shape` diagnostic appended after every `execute()` now shows **deltas relative to the previous shape**, and flags **two silent failure modes** the LLM otherwise sails past unnoticed.

No new MCP tool, no API surface change. Information arrives in the response text the LLM already reads, so this benefits every `execute()` call without any prompt or behaviour change.

## What it looks like

Before:
```
--- current_shape ---
volume: 437.2 mm³  |  bbox: 10×10×5 mm  |  7f 15e 10v
```

After (when there's a previous shape):
```
--- current_shape ---
volume: 437.2 (-62.8, -12.6%) mm³  |  bbox: 10×10×5 mm  |  7f (+1) 15e (+3) 10v (+2)
```

After (when a boolean missed):
```
--- current_shape ---
volume: 437.2 mm³  |  bbox: 10×10×5 mm  |  7f 15e 10v
Warning: shape was rebound but volume/topology/bbox unchanged — boolean may have missed (no intersection?)
```

After (when result collapsed):
```
--- current_shape ---
volume: 0 (-437, -100.0%) mm³  |  bbox: 0×0×0 mm  |  0f (-7) 0e (-15) 0v (-10)
Warning: resulting shape has volume ≈ 0 — degenerate (failed loft/extrude/intersection?)
```

## Two anomaly detectors

1. **Boolean no-op** — `current_shape` was rebound to a new object, but every measurable property (volume, face/edge/vertex counts, bbox size + center) is bit-identical. Most common cause: a cut/intersect placed where it doesn't intersect the part.
2. **Degenerate result** — previous shape had volume, current is ≈ 0. Catches collapsed lofts, failed extrusions, empty intersections.

## Why bit-identical comparison

The check uses exact equality (no tolerance) and **includes bbox center**, so a pure `.move()` is correctly NOT flagged as a no-op. The comparison is conservative — false positives are rare and the warning text says "may have" rather than "did".

## Test plan

- [x] All 295 tests pass locally (was 289 — six new tests)
- [x] First shape: absolutes only, no deltas, no warnings
- [x] Real cut: deltas appear with sign + percentage
- [x] No-op cut (cylinder placed far away): warning fires
- [x] Degenerate intersection (no overlap): warning fires
- [x] Pure `.move()`: no warning (bbox center catches it)
- [x] No diagnostic block at all when execute doesn't change `current_shape`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)