### PR TITLE
ci: auto-publish to MCP registry on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,39 @@ jobs:
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
 
+  publish-mcp-registry:
+    needs: publish-pypi
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # for github-oidc auth to the MCP registry
+      contents: read    # for checkout
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync server.json version with the release tag
+        run: |
+          tag=${{ github.event.release.tag_name }}
+          version=${tag#v}
+          python3 - <<EOF
+          import json
+          with open("server.json") as f:
+              d = json.load(f)
+          d["version"] = "$version"
+          for p in d.get("packages", []):
+              p["version"] = "$version"
+          with open("server.json", "w") as f:
+              json.dump(d, f, indent=2)
+          EOF
+      - name: Install mcp-publisher
+        run: |
+          curl -sL -o mcp-publisher \
+            https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64
+          chmod +x mcp-publisher
+      - name: Login via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP registry
+        run: ./mcp-publisher publish
+
   bump-version:
     needs: publish-pypi
     if: github.event_name == 'release'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.15
+
+### Improvements
+
+- **`execute()` output gains shape deltas and silent-failure warnings** (#81): the diagnostic appended after every `execute()` now shows volume/topology deltas relative to the previous shape (e.g. `volume: 437.2 (-62.8, -12.6%) mm³  |  ... 7f (+1) 15e (+3) 10v (+2)`) and flags two silent failure modes the LLM otherwise sailed past unnoticed — boolean no-ops (cuts that didn't intersect, leaving topology bit-identical) and degenerate results (volume collapsed to ≈ 0). No new MCP tool, no LLM behaviour change required; warnings arrive in the response text the LLM already reads.
+
+### Release process
+
+- **Auto-publish to MCP registry on release** (#82): a new `publish-mcp-registry` job in `publish.yml` mirrors the PyPI publish path. On every `gh release create vX.Y.Z`, after PyPI succeeds, the job authenticates via GitHub OIDC (no stored secret), rewrites `server.json`'s version fields from the release tag, and pushes to `registry.modelcontextprotocol.io`. From this release onward the registry stays in sync with PyPI automatically.
+
+---
+
 ## v0.3.14
 
 This release is "more build123d native" — every change closes a gap where the server was a generic Python sandbox rather than a build123d-aware tool. Five merged PRs:

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/pzfreo/build123d-mcp",
     "source": "github"
   },
-  "version": "0.3.11",
+  "version": "0.3.14",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "build123d-mcp",
-      "version": "0.3.11",
+      "version": "0.3.14",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

The MCP registry currently shows **v0.3.11** (published 2026-05-05) while PyPI is at **v0.3.14**. Three releases worth of features are invisible to anyone discovering the server via registry.modelcontextprotocol.io.

This PR does two things:

1. **Bumps `server.json` to 0.3.14** so the upcoming one-time manual publish reflects current state.
2. **Adds a `publish-mcp-registry` job** to `publish.yml` that fires on the same `release` event PyPI uses, so future releases stay in sync automatically.

## How the registry job works

- **Triggered**: `release: published` event only — same gating as `publish-pypi`. `push` to main publishes to TestPyPI but does not touch the registry.
- **Authentication**: GitHub OIDC. The runner gets a short-lived token proving "this job runs in `pzfreo/build123d-mcp`," which is sufficient to publish under the `io.github.pzfreo/...` namespace. No stored secret, no API key, nothing to rotate.
- **Version source**: extracted from `${{ github.event.release.tag_name }}` (stripping the `v` prefix). The job rewrites both `version` fields in `server.json` (top-level + nested under `packages`) before publishing, so the file's value in main is just a default — what gets published always matches the GitHub Release.
- **Dependency order**: depends on `publish-pypi` so the registry never advertises a version that has no PyPI artifact behind it. Runs in parallel with `bump-version`.
- **Binary install**: downloads the latest `mcp-publisher` from the `modelcontextprotocol/registry` releases on each run.

## What still needs you (one-time, for v0.3.14)

The CI job only fires from v0.3.15 onward (next release). For the current v0.3.14, the manual publish still needs an authenticated local `mcp-publisher`. Once you've run `./mcp-publisher login github`, I can run `./mcp-publisher publish` from here using the updated `server.json` already on this branch (after merge).

## Failure modes

- `mcp-publisher` upstream renames the release asset → curl breaks. Pinned to `latest` for now; can pin to a specific version if it bites.
- Registry publish fails after PyPI succeeds → recoverable by re-running the failed job or invoking `mcp-publisher publish` manually.
- Schema bumps (`server.json` declares `2025-12-11` schema) → unlikely in the next year, but worth knowing.

## Test plan

- [x] YAML parses cleanly
- [ ] CI green on this PR (the new job is gated to release events, so it won't fire on this PR's push)
- [ ] After merge, manual one-time publish for v0.3.14
- [ ] Next release (v0.3.15) verifies the auto-publish path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)