### PR TITLE
fix: download mcp-publisher tarball correctly in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,9 +87,16 @@ jobs:
           EOF
       - name: Install mcp-publisher
         run: |
-          curl -sL -o mcp-publisher \
-            https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64
+          # Resolve the latest release tag via the API rather than the
+          # /releases/latest/download/ shortcut, which has been observed to
+          # 502 intermittently. -f makes curl fail on non-2xx responses.
+          tag=$(curl -sLf https://api.github.com/repos/modelcontextprotocol/registry/releases/latest \
+                  | python3 -c "import json, sys; print(json.load(sys.stdin)['tag_name'])")
+          curl -sLf -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/$tag/mcp-publisher_linux_amd64.tar.gz"
+          tar xzf mcp-publisher.tar.gz mcp-publisher
           chmod +x mcp-publisher
+          ./mcp-publisher --help > /dev/null   # fail loudly if the binary's broken
       - name: Login via GitHub OIDC
         run: ./mcp-publisher login github-oidc
       - name: Publish to MCP registry


### PR DESCRIPTION
## Summary

First real registry-publish run (just now, on the v0.3.15 release) failed at the install step because the workflow tried to fetch the asset name as a raw binary, but upstream actually ships a tarball.

**The exact failure**: original curl had no `-f` flag → silently saved the GitHub 404 page as `mcp-publisher` → `chmod +x` made it executable → bash ran "Not Found" → "Not: command not found", exit 127.

## Two changes

1. **Resolve the latest release tag via the API** instead of the `/releases/latest/download/` shortcut. That shortcut was returning 502 intermittently from GitHub when this PR was written — the API path is more reliable.
2. **Download the `.tar.gz`, extract, smoke-test** with `--help`. Add `-f` to every curl so any 4xx/5xx fails the step loudly instead of silently producing a broken binary.

## Tested

End-to-end install pipeline tested locally against the live `modelcontextprotocol/registry` latest release (v1.7.8) before push.

## Recovery for v0.3.15

The hot-fix gets future releases publishing automatically. For v0.3.15 specifically, I'll publish manually using the local `mcp-publisher` binary (after you `./mcp-publisher login github`) — re-running the failed job in CI would still execute the broken YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)