### PR TITLE
feat: --allow-imports flag + surface the sandbox in README and llms.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,38 @@ bd_warehouse is a full fastener system, not just a thread library. Always:
 
 See `build123d://bd_warehouse` (MCP resource) for the full catalogue and usage patterns.
 
+## Security
+
+Unlike CAD MCP servers that simply `exec()` user code, build123d-mcp ships with **defence-in-depth sandboxing** so the server is reasonable to expose to LLM-generated and untrusted prompts. Three layers, all applied before user code runs:
+
+1. **AST inspection** — rejects imports of anything outside the allowlist (`build123d`, `bd_warehouse`, `math`, `numpy`, `inspect`, plus the rest of the safe stdlib subset and a curated set of geometric OCP submodules), blocks `eval`/`exec`/`compile`/`open`, and refuses dunder attribute access (the most common Python sandbox-escape route).
+2. **Restricted builtins** — the `__builtins__` exposed to user code has the dangerous functions removed and `__import__` rewrapped to enforce the same allowlist at runtime, so a payload that bypasses the AST check still hits the wall on import.
+3. **Execution timeout** — wall-clock limit (default 120 s, `--exec-timeout N` to override) enforced via SIGALRM, with the worker process restarted on breach so a hung script can't hold the session forever.
+
+Filesystem I/O modules (`os`, `pathlib`, `shutil`), networking (`socket`, `urllib`, `requests`), shell access (`subprocess`), and the OCP file-I/O submodules (`STEPControl`, `IGESControl`, `OSD`, …) are **all blocked**. Path traversal is rejected for `export()` and `render_view(save_to=)`.
+
+This is not a perfect sandbox — memory exhaustion isn't bounded, and Python introspection chains via build123d internals could in principle escape — but it raises the bar significantly against realistic prompt-injection payloads.
+
+### Extending or relaxing the sandbox
+
+Two CLI flags let you adjust the import policy without giving up the rest of the layers:
+
+- `--allow-imports scipy,pandas` — extend the allowlist with named modules. Each entry permits the named root and all its submodules. Use for CAD scripts that need extra packages.
+- `--allow-all-imports` — disable the import allowlist entirely. The other layers (restricted builtins for `open`/`eval`/etc, exec timeout, dunder-attribute block) still apply. **Use only in trusted environments or under OS-level isolation** (see below).
+
+Both flags also accept their values via env var (`BUILD123D_ALLOW_IMPORTS`, `BUILD123D_ALLOW_ALL_IMPORTS`).
+
+### Stronger isolation: OS-level sandboxing
+
+For deployments that need stronger guarantees than Python-level checks (e.g. exposing the server to truly untrusted input, or running with `--allow-all-imports`), wrap the whole MCP server in an OS-level sandbox:
+
+- **[`@anthropic-ai/sandbox-runtime`](https://github.com/anthropic-experimental/sandbox-runtime)** — Anthropic's official sandbox runtime, designed exactly for this. The Claude Code docs explicitly call out wrapping MCP servers: `npx @anthropic-ai/sandbox-runtime <command-to-sandbox>`.
+- **Docker / containers** — generic approach; many community MCP-sandbox wrappers exist (e.g. [`pottekkat/sandbox-mcp`](https://github.com/pottekkat/sandbox-mcp), [`Automata-Labs-team/code-sandbox-mcp`](https://github.com/Automata-Labs-team/code-sandbox-mcp)). Run build123d-mcp inside a minimal container with no host filesystem mounts and no network egress.
+- **Claude Code's sandbox** (`/sandbox` command, macOS Seatbelt or Linux bubblewrap) — if you're running build123d-mcp under Claude Code, the host's sandbox already restricts what subprocesses can touch.
+- **Cursor / IDE dev containers** — Cursor doesn't ship MCP-specific sandboxing, but you can run the server inside a dev container that the IDE attaches to.
+
+Inside any of these, **`--allow-all-imports` becomes a reasonable default**: the OS-level isolation handles the security, and the Python-level allowlist becomes redundant friction. The recommended high-security recipe is `sandbox-runtime` (or a container) + `--allow-all-imports` + a strict exec timeout.
+
 ## Requirements
 
 - [uv](https://github.com/astral-sh/uv)

--- a/llms.md
+++ b/llms.md
@@ -2,6 +2,28 @@
 
 build123d-mcp is an MCP server that wraps the [build123d](https://github.com/gumyr/build123d) Python CAD library. It gives you tools to build 3D geometry incrementally, render views, measure dimensions, export files, snapshot state, inspect session state, and verify dependencies.
 
+## Sandbox — what your `execute()` code can and can't do
+
+This server enforces a Python-level sandbox on every `execute()` call. Three layers run before your code:
+
+1. **Import allowlist** — only `build123d`, `bd_warehouse`, `math`, `numpy`, `inspect`, the safe stdlib subset (collections, itertools, functools, copy, typing, dataclasses, enum, re, json, base64, hashlib, …), and curated geometric OCP submodules are importable. Filesystem (`os`, `pathlib`, `shutil`), networking (`socket`, `urllib`, `requests`), and shell access (`subprocess`) are blocked. The full allowlist is in the error message of any blocked import.
+2. **Restricted builtins** — `open`, `eval`, `exec`, `compile`, `breakpoint`, `input`, and the introspection helpers `getattr`/`vars`/`hasattr` are removed (the last three because string arguments would let you bypass the dunder-attribute block).
+3. **Execution timeout** — wall-clock limit (default 120 s).
+
+If a script truly needs an extra package (e.g. `scipy.optimize` to size a parametric part), the server operator can extend the allowlist via `--allow-imports scipy,pandas` — the LLM doesn't control this, but a blocked-import error message names the attempted module so the user can decide whether to add it.
+
+Practical implications for your code:
+
+- Never `import os`, `import pathlib`, `import subprocess`, `import socket`, `import urllib`, `import requests` — all blocked.
+- Never call `eval()`, `exec()`, `open()` — blocked at the builtin level.
+- Never write `obj.__class__.__bases__[0]` or similar dunder-attribute access — AST-blocked.
+- Use `inspect.signature(ClassName)` and `inspect.getdoc()` for API discovery; both are allowed.
+- File I/O happens through MCP tools (`export`, `import_cad_file`, `render_view(save_to=)`) — never directly.
+
+If you see "Import of 'X' is not allowed" or "Call to 'Y' is not allowed", the user code hit a sandbox layer; don't try to bypass it, just use the MCP tools or change approach.
+
+---
+
 ## Key concept: persistent session
 
 All tool calls share a single Python namespace. Variables and shapes you create with `execute` persist across subsequent calls. Use this to build geometry step by step, checking your work after each step.

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -150,6 +150,15 @@ OCP_ALLOWLIST = frozenset({
 # When True, import checks are skipped entirely.  Set via --allow-all-imports.
 ALLOW_ALL_IMPORTS: bool = False
 
+# Extra root modules added to the allowlist by the user, on top of IMPORT_ALLOWLIST.
+# Set via --allow-imports. Each entry is a top-level module name; submodules of an
+# allowed root are permitted (e.g. allowing "scipy" lets "scipy.optimize" through).
+EXTRA_ALLOWED_IMPORTS: set[str] = set()
+
+
+def _is_root_allowed(root: str) -> bool:
+    return root in IMPORT_ALLOWLIST or root in EXTRA_ALLOWED_IMPORTS
+
 # Builtins that are dangerous even without an import.
 _BLOCKED_BUILTINS = frozenset({
     "eval", "exec", "compile", "open", "breakpoint", "input",
@@ -224,12 +233,13 @@ def _check_module(dotted_name: str) -> None:
                     f"Permitted OCP modules: {sorted(OCP_ALLOWLIST)}"
                 )
         return  # bare 'OCP' or allowed sub-module
-    if root not in IMPORT_ALLOWLIST:
+    if not _is_root_allowed(root):
+        permitted = sorted(IMPORT_ALLOWLIST | EXTRA_ALLOWED_IMPORTS)
         raise ValueError(
             f"Import of '{dotted_name}' is not allowed. "
             f"This blocks filesystem (os, pathlib, shutil), network (socket, urllib, "
             f"requests), and shell access (subprocess). "
-            f"Permitted: {sorted(IMPORT_ALLOWLIST)}"
+            f"Permitted: {permitted}"
         )
 
 
@@ -269,10 +279,11 @@ def make_restricted_builtins() -> dict[str, Any]:
                         f"This OCP sub-module is blocked (potential file I/O or OS access). "
                         f"Permitted OCP modules: {sorted(OCP_ALLOWLIST)}"
                     )
-        elif root not in IMPORT_ALLOWLIST:
+        elif not _is_root_allowed(root):
+            permitted = sorted(IMPORT_ALLOWLIST | EXTRA_ALLOWED_IMPORTS)
             raise ImportError(
                 f"Import of '{name}' is not allowed. "
-                f"Permitted: {sorted(IMPORT_ALLOWLIST)}"
+                f"Permitted: {permitted}"
             )
         return _original_import(name, *args, **kwargs)
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -394,6 +394,15 @@ Part library file format (Python, any .py file under --library path):
              "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
     )
     parser.add_argument(
+        "--allow-imports", metavar="MODULES",
+        default=os.environ.get("BUILD123D_ALLOW_IMPORTS", ""),
+        help="Comma-separated extra modules added to the import allowlist on top of "
+             "the defaults (e.g. --allow-imports scipy,pandas). Each entry permits the "
+             "named module and all its submodules. Use this for CAD scripts that need "
+             "extra packages without disabling the sandbox via --allow-all-imports. "
+             "Overrides BUILD123D_ALLOW_IMPORTS env var.",
+    )
+    parser.add_argument(
         "--exec-timeout", metavar="SECONDS", type=int,
         default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT", "120")),
         help="Execution time limit in seconds for user code (default: 120). "
@@ -404,13 +413,25 @@ Part library file format (Python, any .py file under --library path):
     if args.library and not os.path.isdir(args.library):
         parser.error(f"Library path is not a directory: {args.library}")
 
-    if args.allow_all_imports:
+    extra_imports = tuple(
+        m.strip() for m in args.allow_imports.split(",") if m.strip()
+    )
+
+    if args.allow_all_imports or extra_imports:
         import build123d_mcp.security as _sec
-        _sec.ALLOW_ALL_IMPORTS = True
+        if args.allow_all_imports:
+            _sec.ALLOW_ALL_IMPORTS = True
+        if extra_imports:
+            _sec.EXTRA_ALLOWED_IMPORTS.update(extra_imports)
 
     global _session, _has_library
     _has_library = bool(args.library)
-    _session = WorkerSession(library_path=args.library, allow_all_imports=args.allow_all_imports, exec_timeout=args.exec_timeout)
+    _session = WorkerSession(
+        library_path=args.library,
+        allow_all_imports=args.allow_all_imports,
+        extra_allowed_imports=extra_imports,
+        exec_timeout=args.exec_timeout,
+    )
 
     mcp.run()
 

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -20,14 +20,23 @@ from typing import Any
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
 
-def worker_main(conn: Any, library_path: str = "", exec_timeout: int = 120, allow_all_imports: bool = False) -> None:
+def worker_main(
+    conn: Any,
+    library_path: str = "",
+    exec_timeout: int = 120,
+    allow_all_imports: bool = False,
+    extra_allowed_imports: tuple[str, ...] = (),
+) -> None:
     """Entry point run in the worker subprocess.
 
     Loops receiving requests until the parent closes the connection.
     """
-    if allow_all_imports:
+    if allow_all_imports or extra_allowed_imports:
         import build123d_mcp.security as _sec
-        _sec.ALLOW_ALL_IMPORTS = True
+        if allow_all_imports:
+            _sec.ALLOW_ALL_IMPORTS = True
+        if extra_allowed_imports:
+            _sec.EXTRA_ALLOWED_IMPORTS.update(extra_allowed_imports)
 
     from build123d_mcp.session import Session
 
@@ -156,10 +165,17 @@ class WorkerSession:
     _INTERFERENCE_TIMEOUT = 30
     _SHORT_TIMEOUT = 10
 
-    def __init__(self, exec_timeout: int = 120, library_path: str = "", allow_all_imports: bool = False) -> None:
+    def __init__(
+        self,
+        exec_timeout: int = 120,
+        library_path: str = "",
+        allow_all_imports: bool = False,
+        extra_allowed_imports: tuple[str, ...] = (),
+    ) -> None:
         self._exec_timeout = exec_timeout
         self._library_path = library_path
         self._allow_all_imports = allow_all_imports
+        self._extra_allowed_imports = tuple(extra_allowed_imports)
         self._conn: Any = None
         self._proc: Any = None
         self._start_worker()
@@ -169,7 +185,13 @@ class WorkerSession:
         parent_conn, child_conn = ctx.Pipe()
         self._proc = ctx.Process(
             target=worker_main,
-            args=(child_conn, self._library_path, self._exec_timeout, self._allow_all_imports),
+            args=(
+                child_conn,
+                self._library_path,
+                self._exec_timeout,
+                self._allow_all_imports,
+                self._extra_allowed_imports,
+            ),
             daemon=True,
         )
         self._proc.start()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -202,6 +202,54 @@ def test_open_removed_from_builtins(session):
     assert "open" not in session.namespace.get("__builtins__", {})
 
 
+# --- --allow-imports flag (granular allowlist extension) ---
+
+def test_extra_allowed_import_permits_specified_module(monkeypatch):
+    """Modules added via --allow-imports become importable (using a stdlib
+    module that's normally blocked, so the test doesn't depend on optional
+    third-party packages being installed)."""
+    import build123d_mcp.security as _sec
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    _sec.EXTRA_ALLOWED_IMPORTS.add("os")
+    s = Session()
+    result = s.execute("import os")
+    assert "not allowed" not in result.lower()
+    assert "Error" not in result
+
+
+def test_extra_allowed_import_permits_submodules(monkeypatch):
+    """Allowing a root module also permits its submodules (e.g. allowing
+    'os' lets 'os.path' through)."""
+    import build123d_mcp.security as _sec
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    _sec.EXTRA_ALLOWED_IMPORTS.add("os")
+    s = Session()
+    result = s.execute("import os.path")
+    assert "not allowed" not in result.lower()
+    assert "Error" not in result
+
+
+def test_unspecified_module_still_blocked_when_extras_used(monkeypatch):
+    """Adding 'foo' to extras must NOT allow 'bar'."""
+    import build123d_mcp.security as _sec
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    _sec.EXTRA_ALLOWED_IMPORTS.add("os")
+    s = Session()
+    result = s.execute("import subprocess")
+    assert "not allowed" in result.lower()
+
+
+def test_extras_message_lists_added_modules(monkeypatch):
+    """Error message for blocked imports should include user-added extras
+    in the 'Permitted' list so the LLM sees the current state."""
+    import build123d_mcp.security as _sec
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    _sec.EXTRA_ALLOWED_IMPORTS.add("os")
+    s = Session()
+    result = s.execute("import subprocess")
+    assert "'os'" in result
+
+
 def test_dir_allowed(session):
     result = execute_code(session, "attrs = dir([])")
     assert "Error" not in result


### PR DESCRIPTION
## Why

ChatGPT summarising this project missed the sandbox entirely — neither README nor llms.md mentioned security, sandbox, or safety, despite the three-layer defence-in-depth model being a real differentiator over CAD MCP servers that just `exec()` user code.

Two related changes in one PR.

## 1. Granular allowlist via `--allow-imports`

Today the import policy is binary: strict allowlist (default) or `--allow-all-imports` (full bypass). For unusual cases — `scipy.optimize` for parametric sizing, `pandas` to drive parts from a CSV — the only escape was to throw away the whole allowlist.

```
--allow-imports scipy,pandas
```

extends the allowlist with the named modules (and their submodules), keeping the rest of the sandbox intact. Plumbed through:

- CLI flag in `server.py` (with `BUILD123D_ALLOW_IMPORTS` env var)
- `WorkerSession` constructor → child-process args → `worker_main` initializer
- `security.py` exposes `EXTRA_ALLOWED_IMPORTS: set[str]` and a `_is_root_allowed()` helper that both AST inspection (Layer 1) and `__import__` wrapper (Layer 2) consult

Four tests cover: allowed module imports succeed; allowed root permits submodules; unspecified modules still blocked when extras are set; error messages include the user-added extras in the `Permitted:` list.

## 2. Sandbox visibility in README and llms.md

**README** gains a "Security" section covering:
- The three layers (AST inspection, restricted builtins, exec timeout)
- Explicit blocklist categories (filesystem, networking, shell access, OCP file-I/O submodules)
- The two relaxation flags (`--allow-imports`, `--allow-all-imports`)
- A "Stronger isolation: OS-level sandboxing" subsection pointing at:
  - `@anthropic-ai/sandbox-runtime` (Anthropic's official tool, designed exactly for wrapping MCP servers)
  - Community Docker-based MCP-server wrappers: `pottekkat/sandbox-mcp`, `Automata-Labs-team/code-sandbox-mcp`
  - Claude Code's `/sandbox` (Seatbelt / bubblewrap)
  - Cursor / IDE dev containers
- The recommended high-security recipe: OS-level sandbox + `--allow-all-imports` + strict exec timeout

**llms.md** gains a "Sandbox" section near the top so the LLM picks it up early — short version focused on what user code can and can't do, with explicit "don't try to bypass these" guidance for blocked-import errors.

## Test plan

- [x] All 299 tests pass locally (was 295 — added 4 `--allow-imports` tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)