### PR TITLE
feat: DXF export from render_view

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -116,7 +116,7 @@ Render one or more shapes and return a file path to the rendered image.
 - `clip_plane` (string, default `""`) — `x`, `y`, or `z`; clips each mesh at its bounding-box midpoint to expose internal geometry (bores, wall thickness)
 - `clip_at` (float, optional) — absolute world coordinate for the clip plane instead of the midpoint
 - `azimuth` / `elevation` (float, default `0.0`) — camera rotation in degrees applied after the direction preset
-- `format` (string, default `"png"`) — `png`, `svg`, or `both`
+- `format` (string, default `"png"`) — `png`, `svg`, `dxf`, or `both` (= png + svg). DXF returns the projected polylines as parseable 2D CAD geometry — use when a downstream tool (matplotlib, ezdxf, FreeCAD) needs the actual geometry rather than a raster image.
 - `save_to` (string, default `""`) — optional path to also write the file(s) to disk
 - `label_objects` (bool, default `False`) — label each named object from `show()` at its centroid in the PNG. Useful for assemblies where the LLM needs to confirm which shape is which by name.
 - `highlights` (list of dict, default `None`) — label specific faces, edges, or vertices in the PNG. Each entry is `{"object": "name", "type": "face"|"edge"|"vertex", "index": int, "label": "text"}` where `index` matches the position in `shape.faces()` / `.edges()` / `.vertices()`. The referenced object must already be registered with `show()` and included in the rendered set; an unregistered object raises an error naming what to register. Use this to verify "edge 5 is the one I want to fillet" before committing to the operation. Labels are PNG-only — SVG output emits a `label_warnings` notice.

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -21,7 +21,7 @@ def execute(code: str) -> str:
 
 @mcp.tool()
 def render_view(direction: str = "iso", objects: str = "", quality: str = "standard", clip_plane: str = "", clip_at: float | None = None, azimuth: float = 0.0, elevation: float = 0.0, save_to: str = "", format: str = "png", label_objects: bool = False, highlights: list[dict] | None = None) -> list:
-    """Render model. format: 'png' (raster, default), 'svg' (HLR line drawing — works without a display, no shading but precise edges), or 'both' (returns the PNG and SVG together — useful when you want shaded depth cues plus crisp edge geometry). If the raster path fails (typically headless host with no display backend) and format='png', the server falls back to SVG automatically. Renders confirm appearance, not geometry — verify boolean operations with measure() before rendering. direction: top, front, side, iso. objects: comma-separated names or name:color pairs e.g. 'u_frame:blue,roller:red' (default: all, auto-coloured). quality: standard, high. clip_plane: x, y, z to slice; clip_at: absolute world coordinate along that axis (default: each mesh's midpoint). azimuth/elevation: camera rotation in degrees applied after the direction preset. save_to: optional file path; for format='both' the PNG and SVG are written as <save_to>.png and <save_to>.svg. label_objects: when true, each named object from show() is labelled at its centroid in the PNG. highlights: optional list of specific entities to label, e.g. [{"object": "bracket", "type": "edge", "index": 5, "label": "hinge_edge"}]; type is 'face', 'edge', or 'vertex' and index matches shape.faces()/edges()/vertices() position. The referenced object must already be registered with show() and included in the rendered set. Labels are PNG-only; SVG output is unlabelled."""
+    """Render model. format: 'png' (raster, default), 'svg' (HLR line drawing — works without a display, no shading but precise edges), 'dxf' (HLR line drawing as DXF — the standard 2D CAD interchange format; use when you need projected polylines as parseable geometry rather than as a raster, e.g. to draw an annotated overlay on top of an accurate base layer instead of redrawing the shape by hand), or 'both' (returns the PNG and SVG together — useful when you want shaded depth cues plus crisp edge geometry). If the raster path fails (typically headless host with no display backend) and format='png', the server falls back to SVG automatically. Renders confirm appearance, not geometry — verify boolean operations with measure() before rendering. direction: top, front, side, iso. objects: comma-separated names or name:color pairs e.g. 'u_frame:blue,roller:red' (default: all, auto-coloured). quality: standard, high. clip_plane: x, y, z to slice; clip_at: absolute world coordinate along that axis (default: each mesh's midpoint). azimuth/elevation: camera rotation in degrees applied after the direction preset. save_to: optional file path; for format='both' the PNG and SVG are written as <save_to>.png and <save_to>.svg. label_objects: when true, each named object from show() is labelled at its centroid in the PNG. highlights: optional list of specific entities to label, e.g. [{"object": "bracket", "type": "edge", "index": 5, "label": "hinge_edge"}]; type is 'face', 'edge', or 'vertex' and index matches shape.faces()/edges()/vertices() position. The referenced object must already be registered with show() and included in the rendered set. Labels are PNG-only; SVG output is unlabelled."""
     result = _session.render_view(
         direction=direction, objects=objects, quality=quality,
         clip_plane=clip_plane, clip_at=clip_at, azimuth=azimuth,
@@ -43,6 +43,18 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
                 mimeType=mime,
             ))
             contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+
+    # DXF is a CAD interchange format, not an image — emit only the file marker
+    # so clients deliver the file without the ImageContent base64 round-trip.
+    if "dxf" in result:
+        fd, path = tempfile.mkstemp(suffix=".dxf", prefix="build123d_")
+        os.close(fd)
+        with open(path, "wb") as f:
+            f.write(result["dxf"])
+        contents.append(TextContent(
+            type="text",
+            text=f"DXF saved: {path}\n[SEND: {path}]",
+        ))
     if result.get("fallback"):
         contents.append(TextContent(type="text", text=result["fallback"]))
     if result.get("png_error"):

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -65,7 +65,7 @@ _QUALITY = {
     "high":     {"linear_deflection": 0.0005, "angular_deflection": 0.02},
 }
 
-_VALID_FORMATS = ("png", "svg", "both")
+_VALID_FORMATS = ("png", "svg", "dxf", "both")
 
 
 def _resolve_shapes(session, objects: str):
@@ -466,6 +466,66 @@ def _do_render_svg(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
             return f.read()
 
 
+def _do_render_dxf(shapes, direction, clip_plane, clip_at, azimuth, elevation) -> bytes:
+    """Produce a DXF via build123d's HLR projection.
+
+    DXF is the standard 2D CAD interchange format. Use it when the LLM (or a
+    downstream tool) needs the projected geometry as parseable polylines
+    rather than as a raster — e.g. building a matplotlib annotation overlay
+    on top of a faithful base layer instead of redrawing the shape by hand.
+
+    Each input shape becomes two layers: <name>_visible (solid) and
+    <name>_hidden (dashed). Clip-plane handling mirrors the SVG path.
+    """
+    import tempfile
+    from build123d import ExportDXF, LineType, Plane, Vector
+
+    clipped_shapes = []
+    if clip_plane:
+        for name, shape, color in shapes:
+            if clip_at is not None:
+                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
+            else:
+                c = shape.center()
+                origin = {"x": (c.X, 0, 0), "y": (0, c.Y, 0), "z": (0, 0, c.Z)}[clip_plane]
+            normal = {"x": (1, 0, 0), "y": (0, 1, 0), "z": (0, 0, 1)}[clip_plane]
+            plane = Plane(origin=Vector(*origin), z_dir=Vector(*normal))
+            try:
+                halves = shape.split(plane, keep=None)
+                kept = halves[0] if isinstance(halves, tuple) else halves
+            except Exception:
+                kept = shape
+            clipped_shapes.append((name, kept, color))
+    else:
+        clipped_shapes = list(shapes)
+
+    origin, up, look_at = _viewport_origin_for(direction, clipped_shapes, azimuth, elevation)
+
+    exporter = ExportDXF()
+    for i, (name, shape, _obj_color) in enumerate(clipped_shapes):
+        try:
+            visible, hidden = shape.project_to_viewport(
+                viewport_origin=origin, viewport_up=up, look_at=look_at,
+            )
+        except Exception:
+            continue
+
+        layer_visible = f"{name or f'shape_{i}'}_visible"
+        layer_hidden = f"{name or f'shape_{i}'}_hidden"
+        exporter.add_layer(layer_visible)
+        exporter.add_layer(layer_hidden, line_type=LineType.HIDDEN)
+        if visible:
+            exporter.add_shape(visible, layer=layer_visible)
+        if hidden:
+            exporter.add_shape(hidden, layer=layer_hidden)
+
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        dxf_path = os.path.join(tmpdir, "render.dxf")
+        exporter.write(dxf_path)
+        with open(dxf_path, "rb") as f:
+            return f.read()
+
+
 def render_view(
     session,
     direction: str = "iso",
@@ -504,7 +564,7 @@ def render_view(
 
     format = format.lower()
     if format not in _VALID_FORMATS:
-        raise ValueError(f"Unknown format '{format}'. Use: png, svg, both")
+        raise ValueError(f"Unknown format '{format}'. Use: png, svg, dxf, both")
 
     shapes = _resolve_shapes(session, objects)
     tess = _QUALITY[quality]
@@ -517,9 +577,9 @@ def render_view(
 
     result: dict = {}
 
-    if (label_objects or highlights) and format in ("svg", "both"):
+    if (label_objects or highlights) and format in ("svg", "dxf", "both"):
         result["label_warnings"] = [
-            "Labels are only rendered in PNG output; SVG output is unlabelled."
+            "Labels are only rendered in PNG output; SVG/DXF output is unlabelled."
         ]
 
     if format in ("png", "both"):
@@ -554,11 +614,16 @@ def render_view(
             shapes, direction, clip_plane, clip_at, azimuth, elevation,
         )
 
+    if format == "dxf":
+        result["dxf"] = _do_render_dxf(
+            shapes, direction, clip_plane, clip_at, azimuth, elevation,
+        )
+
     if save_to:
         from build123d_mcp.tools._paths import safe_output_path
         # Strip a known extension so format='both' produces consistent <base>.png and <base>.svg
         base, ext = os.path.splitext(save_to)
-        if ext.lower() in (".png", ".svg"):
+        if ext.lower() in (".png", ".svg", ".dxf"):
             save_to = base
         if "png" in result:
             with open(safe_output_path(save_to + ".png"), "wb") as f:
@@ -566,5 +631,8 @@ def render_view(
         if "svg" in result:
             with open(safe_output_path(save_to + ".svg"), "wb") as f:
                 f.write(result["svg"])
+        if "dxf" in result:
+            with open(safe_output_path(save_to + ".dxf"), "wb") as f:
+                f.write(result["dxf"])
 
     return result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -473,6 +473,49 @@ def test_render_view_save_to_both_writes_two_files(session, tmp_path, monkeypatc
     assert (tmp_path / "multi.svg").exists()
 
 
+# --- render_view DXF ---
+
+def test_render_view_dxf_returns_dxf_bytes(session):
+    execute_code(session, "result = Box(20, 10, 5)")
+    out = render_view(session, "top", format="dxf")
+    assert "dxf" in out and "png" not in out and "svg" not in out
+    # DXF magic: file starts with "  0\nSECTION\n  2\nHEADER" and contains $ACADVER
+    assert b"SECTION" in out["dxf"]
+    assert b"$ACADVER" in out["dxf"]
+
+
+def test_render_view_dxf_contains_named_layers(session):
+    """Each named shape should produce visible + hidden layers in the DXF."""
+    execute_code(session, "show(Box(20, 10, 5), 'plate')")
+    out = render_view(session, "top", format="dxf")
+    text = out["dxf"].decode("utf-8", errors="ignore")
+    assert "plate_visible" in text
+    assert "plate_hidden" in text
+
+
+def test_render_view_dxf_save_to_writes_dxf_file(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "result = Box(20, 10, 5)")
+    render_view(session, "top", save_to="part", format="dxf")
+    assert (tmp_path / "part.dxf").exists()
+    assert (tmp_path / "part.dxf").stat().st_size > 0
+
+
+def test_render_view_dxf_save_to_strips_dxf_extension(session, tmp_path, monkeypatch):
+    """Passing save_to='part.dxf' should write part.dxf (not part.dxf.dxf)."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "result = Box(20, 10, 5)")
+    render_view(session, "top", save_to="part.dxf", format="dxf")
+    assert (tmp_path / "part.dxf").exists()
+    assert not (tmp_path / "part.dxf.dxf").exists()
+
+
+def test_render_view_dxf_invalid_format_message_lists_dxf(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="dxf"):
+        render_view(session, "iso", format="jpeg")
+
+
 # --- render_view labels ---
 
 def test_render_view_label_objects_renders(session):


### PR DESCRIPTION
## Summary

Adds `format="dxf"` to `render_view`, returning the projected geometry as a DXF (the standard 2D CAD interchange format) rather than as a raster. This eliminates the **LLM-redraws-shapes-in-matplotlib** failure mode: the LLM can now load the DXF as the geometry layer and only contribute notation on top.

## Why this is small

Most of the heavy lifting is done by build123d itself — the same `project_to_viewport` HLR projection used for SVG output, piped into `ExportDXF` (the parallel exporter to `ExportSVG`). Net change ~80 lines.

## Changes

- **`_do_render_dxf`** in `tools/render.py` mirrors `_do_render_svg`, swapping `ExportSVG` → `ExportDXF` and using `LineType.HIDDEN` for hidden edges
- **`'dxf'`** added to `_VALID_FORMATS`; `render_view` dispatches it; `save_to` recognises and strips `.dxf` in the same pattern as `.png` / `.svg`
- **`server.py`** emits DXF as a `TextContent + [SEND: path]` marker rather than as `ImageContent` — DXF isn't an image and most MCP clients reject `ImageContent` with a non-image MIME type
- **`llms.md`** updated to mention `dxf` as a format option with the use case spelled out

## What this is and isn't

- **Is**: foundation for any future engineering-drawing workflow. The geometry layer is now accurate and parseable by matplotlib + ezdxf or any other downstream tool.
- **Isn't**: a drafting tool. Dimensions, hole tables, title blocks, line conventions are all out of scope here — those would belong in a separate drafting MCP if we ever build one. This PR deliberately stops at "geometry, accurately, in a standard format."

## Test plan

- [x] All 304 tests pass locally (was 299 — 5 new DXF tests)
- [x] DXF magic (`SECTION HEADER $ACADVER AC1027`) present in output
- [x] Named layers (`<name>_visible`, `<name>_hidden`) appear in the file
- [x] `save_to="part.dxf"` writes `part.dxf`, not `part.dxf.dxf`
- [x] Manual smoke test on a Box-with-hole renders to a valid 17 KB DXF file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)