### PR TITLE
docs: snapshot+restore as the proposal-evaluation pattern

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -341,6 +341,21 @@ Clear the session back to empty state, including all snapshots.
 
 For assemblies of two or more parts with a mechanical relationship (mounted, hinged, sliding), use build123d Joints (`RigidJoint`/`RevoluteJoint`/`LinearJoint`/`CylindricalJoint`/`BallJoint`) rather than positioning parts with `.move()`. The relationship survives later changes to the parent. See `build123d://quickref` for examples.
 
+### Proposals — evaluating "what if?" without touching the canonical model
+
+When asked to evaluate a possible modification ("would adding a hole here weaken the wall?", "what if we widened this slot to 6mm?"), use snapshots as a scratch layer. Don't redraw the geometry in matplotlib to evaluate it — that's lossy and disagrees with the model.
+
+```
+save_snapshot("before")            # cheap; geometry-only
+execute("plate = plate - Cylinder(2, 5).move(Location((10, 0, 0)))")
+clearance("hole_proxy", "plate")   # check wall thickness, piercing, etc.
+cross_sections(plate, axis="Z")    # see internal voids at each Z
+render_view(format="dxf")          # geometry as parseable polylines, not a redraw
+restore_snapshot("before")          # canonical model untouched
+```
+
+The 3D mutation + 3D analysis loop is faster, more accurate, and uses the same primitives as the rest of the workflow.
+
 ---
 
 ---

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -219,10 +219,20 @@ BUILD123D-MCP WORKFLOW GUIDE
    Call session_state() for a full JSON view of all active shapes, objects, and snapshots.
    session_state() includes the named-object list — no separate list_objects() call needed.
 
-6. CHECKPOINT BEFORE EXPERIMENTS
+6. CHECKPOINT BEFORE EXPERIMENTS — AND PROPOSALS
    Call save_snapshot("name") before any operation you might want to undo.
    Snapshots are instant. restore_snapshot("name") reverts geometry without re-running code.
    Use diff_snapshot("name") to see what changed; pass format="json" for structured output.
+
+   "What if?" proposals: when asked to evaluate a possible modification (add a hole here,
+   widen this slot, swap this part), the right pattern is:
+       save_snapshot("before")   # cheap; geometry-only
+       <apply the proposed change via execute()>
+       <run analyses: measure(), clearance(), cross_sections(), render_view()>
+       restore_snapshot("before")  # canonical model untouched
+   Use this instead of redrawing the geometry in matplotlib or editing the source file.
+   The 3D mutation + 3D analysis loop is cheaper than re-deriving geometry by hand,
+   and the restore guarantees the canonical model isn't accidentally touched.
 
 7. CROSS-SECTIONS FOR INTERNAL GEOMETRY
    render_view with clip_plane + clip_at reveals interior features.
@@ -326,6 +336,9 @@ Workflow:
 5. Use show(shape, "name") to register important intermediate shapes; it prints vol + face count immediately.
 6. Call render_view() only after measure() confirms the geometry is correct.
 7. Call save_snapshot("name") before any experiment you might want to undo.
+   For "what if?" proposals (add a hole, modify a feature) use the snapshot+restore loop:
+   save_snapshot → mutate via execute → run analyses (measure/clearance/render_view) → restore_snapshot.
+   This is cheaper and more accurate than redrawing geometry in matplotlib to evaluate a change.
 8. For assemblies of two or more parts with a mechanical relationship (mounted, hinged, sliding),
    use Joints (RigidJoint/RevoluteJoint/LinearJoint/CylindricalJoint/BallJoint) rather than raw
    .move() — the relationship survives later changes. See build123d://quickref for examples.


### PR DESCRIPTION
## Summary

Adds explicit guidance pushing the LLM toward `save_snapshot` → mutate → analyse → `restore_snapshot` for any "what if?" question, instead of redrawing the geometry in matplotlib to evaluate it.

The recent insert-pierces-wall bug had this as a contributing cause: the LLM went straight to a 2D matplotlib sketch to propose the modification, bypassing the MCP entirely and missing the chance for `measure()` / `clearance()` / `cross_sections()` to catch the problem before it rendered.

## Three places updated

- **`workflow_hints` item 6** (CHECKPOINT BEFORE EXPERIMENTS) — now also covers proposals, with the explicit snapshot → mutate → analyse → restore loop spelled out.
- **`start-cad-session` step 7** — nudges toward the same pattern: cheaper than redrawing geometry by hand, and the restore guarantees the canonical model isn't touched.
- **`llms.md` "Recommended workflow"** — new "Proposals" subsection with a concrete code example showing `save_snapshot` + cylinder cut + `clearance` + `cross_sections` + `render_view(format="dxf")` + `restore_snapshot`.

## Why it's docs-only

The tooling already supported this pattern — snapshots have been there since v0.3.0. The gap was behavioural: the LLM didn't reach for snapshots when given a proposal-style request, so the prompt needed to make the pattern visible.

## Test plan

- [x] All 304 tests pass locally (no code change, count unchanged from baseline)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)