### PR TITLE
fix: render_view honours save_to for DXF in MCP wrapper response (#91)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -30,13 +30,24 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
     )
 
     contents: list = []
+    # Helper: prefer the user-requested save_to path (in result["<fmt>_path"])
+    # over a fresh tempfile. When save_to is set, render_view has already
+    # written the file at the requested path; we just need a path to deliver
+    # via the [SEND:] marker. When save_to is empty, fall back to a tempfile.
+    def _path_for(key: str, suffix: str) -> str:
+        saved = result.get(f"{key}_path")
+        if saved:
+            return saved
+        fd, p = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
+        os.close(fd)
+        with open(p, "wb") as f:
+            f.write(result[key])
+        return p
+
     for key, suffix, mime in (("png", ".png", "image/png"), ("svg", ".svg", "image/svg+xml")):
         if key in result:
             data = result[key]
-            fd, path = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
-            os.close(fd)
-            with open(path, "wb") as f:
-                f.write(data)
+            path = _path_for(key, suffix)
             contents.append(ImageContent(
                 type="image",
                 data=base64.b64encode(data).decode(),
@@ -47,10 +58,7 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
     # DXF is a CAD interchange format, not an image — emit only the file marker
     # so clients deliver the file without the ImageContent base64 round-trip.
     if "dxf" in result:
-        fd, path = tempfile.mkstemp(suffix=".dxf", prefix="build123d_")
-        os.close(fd)
-        with open(path, "wb") as f:
-            f.write(result["dxf"])
+        path = _path_for("dxf", ".dxf")
         contents.append(TextContent(
             type="text",
             text=f"DXF saved: {path}\n[SEND: {path}]",

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -749,8 +749,13 @@ def render_view(
                 save_to = base
             for key, suffix in (("png", ".png"), ("svg", ".svg"), ("dxf", ".dxf")):
                 if key in result:
-                    with open(safe_output_path(save_to + suffix), "wb") as f:
+                    abs_path = safe_output_path(save_to + suffix)
+                    with open(abs_path, "wb") as f:
                         f.write(result[key])
+                    # Record the on-disk path so the MCP wrapper can use it
+                    # for [SEND:] markers instead of writing a duplicate
+                    # tempfile copy.
+                    result[f"{key}_path"] = abs_path
         return result
 
     # Resolve labels up-front so validation errors surface before any rendering work.
@@ -807,14 +812,11 @@ def render_view(
         base, ext = os.path.splitext(save_to)
         if ext.lower() in (".png", ".svg", ".dxf"):
             save_to = base
-        if "png" in result:
-            with open(safe_output_path(save_to + ".png"), "wb") as f:
-                f.write(result["png"])
-        if "svg" in result:
-            with open(safe_output_path(save_to + ".svg"), "wb") as f:
-                f.write(result["svg"])
-        if "dxf" in result:
-            with open(safe_output_path(save_to + ".dxf"), "wb") as f:
-                f.write(result["dxf"])
+        for key, suffix in (("png", ".png"), ("svg", ".svg"), ("dxf", ".dxf")):
+            if key in result:
+                abs_path = safe_output_path(save_to + suffix)
+                with open(abs_path, "wb") as f:
+                    f.write(result[key])
+                result[f"{key}_path"] = abs_path
 
     return result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -501,6 +501,36 @@ def test_render_view_dxf_save_to_writes_dxf_file(session, tmp_path, monkeypatch)
     assert (tmp_path / "part.dxf").stat().st_size > 0
 
 
+def test_render_view_dxf_save_to_records_path_in_result(session, tmp_path, monkeypatch):
+    """Regression for #91: render_view must record the on-disk path for save_to
+    output so the MCP wrapper can use it for [SEND:] markers instead of writing
+    a duplicate tempfile. Without this, the LLM gets a /tmp/<random> path back
+    even when it asked for a specific location."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "result = Box(20, 10, 5)")
+    out = render_view(session, "top", save_to="part", format="dxf")
+    assert "dxf_path" in out
+    assert out["dxf_path"].endswith("part.dxf")
+    assert os.path.exists(out["dxf_path"])
+
+
+def test_render_view_png_save_to_records_path_in_result(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "result = Box(20, 10, 5)")
+    out = render_view(session, "iso", save_to="part", format="png")
+    assert "png_path" in out
+    assert out["png_path"].endswith("part.png")
+
+
+def test_render_view_no_save_to_no_path_in_result(session):
+    """When save_to is empty, no <fmt>_path key is added — the wrapper falls
+    back to writing a tempfile."""
+    execute_code(session, "result = Box(20, 10, 5)")
+    out = render_view(session, "iso", format="png")
+    assert "png" in out
+    assert "png_path" not in out
+
+
 def test_render_view_dxf_save_to_strips_dxf_extension(session, tmp_path, monkeypatch):
     """Passing save_to='part.dxf' should write part.dxf (not part.dxf.dxf)."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Closes #91. The function-level `render_view` always wrote to `save_to` correctly; the bug was in the MCP server wrapper which unconditionally wrote a tempfile copy and reported that path in the `[SEND:]` marker. The LLM saw `/tmp/build123d_<random>.dxf` even when it asked for a specific path. Same anti-pattern existed for PNG/SVG — also tempfile + duplicate write per call.

## Fix

1. `render_view` now records the actual on-disk path under `result["png_path"]` / `result["svg_path"]` / `result["dxf_path"]` when `save_to` is provided. Absent `save_to` leaves these keys absent.
2. The MCP wrapper checks for those keys first; if present, the `[SEND:]` marker uses the user-requested path and no tempfile is written. If absent, falls back to the tempfile path.

## Tests

- `test_render_view_dxf_save_to_records_path_in_result` — direct regression for #91
- `test_render_view_png_save_to_records_path_in_result` — same for PNG
- `test_render_view_no_save_to_no_path_in_result` — empty save_to must not add the path key

337 tests pass locally, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)