### PR TITLE
fix: _LibraryIndex._last_scan tracks max indexed mtime (#99)

### DIFF
--- a/src/build123d_mcp/tools/library.py
+++ b/src/build123d_mcp/tools/library.py
@@ -45,7 +45,17 @@ class _LibraryIndex:
 
     def _scan(self):
         new_index = {}
+        # Track the largest mtime we observe so _last_scan is provably >=
+        # everything we just indexed. Without this, Windows file-mtime
+        # granularity (NTFS rounds mtime up; time.time() returns the raw
+        # clock) can leave dir mtimes > time.time() at scan completion,
+        # making _needs_rescan() return True on the very next call. See #99.
+        max_mtime = 0.0
         for dirpath, _, filenames in os.walk(self.library_path):
+            try:
+                max_mtime = max(max_mtime, os.path.getmtime(dirpath))
+            except OSError:
+                pass
             for filename in sorted(filenames):
                 if not filename.endswith(".py"):
                     continue
@@ -60,17 +70,19 @@ class _LibraryIndex:
                     info = _extract_part_info(source)
                 except Exception as e:
                     info = {"description": f"Error reading part: {e}", "tags": [], "parameters": {}}
+                file_mtime = os.path.getmtime(filepath)
+                max_mtime = max(max_mtime, file_mtime)
                 new_index[name] = {
                     "name": name,
                     "category": category,
                     "path": filepath,
-                    "mtime": os.path.getmtime(filepath),
+                    "mtime": file_mtime,
                     "description": info.get("description", ""),
                     "tags": info.get("tags", []),
                     "parameters": info.get("parameters", {}),
                 }
         self._index = new_index
-        self._last_scan = time.time()
+        self._last_scan = max(time.time(), max_mtime)
 
     def search(self, query: str) -> list:
         self.ensure_fresh()


### PR DESCRIPTION
## Summary

The Windows-flaky `test_no_rescan_when_nothing_changed` was the symptom; the cause was a real bug in `_scan()` exposed by NTFS file-mtime granularity.

## Root cause

```python
self._last_scan = time.time()
```

After the scan, `_last_scan` was set to the current wall-clock time. But the directory and file mtimes the OS had stamped *during* the scan were sometimes in the future relative to that wall-clock value (NTFS rounds mtime up to a coarser granularity than `time.time()` returns). The very next `_needs_rescan()` call would see a dir mtime `> _last_scan` and return True, triggering a spurious second scan.

On macOS/Linux the granularity is finer so the race rarely fires. On Windows it fires ~1 in 3 CI runs and was forcing manual re-runs on every release PR.

## Fix

Walk the tree once during the scan, tracking the largest mtime observed (dirs + .py files). Set `_last_scan = max(time.time(), max_observed_mtime)`. This guarantees the post-scan invariant: nothing currently on disk has an mtime `> _last_scan`, so `_needs_rescan()` returns False until something actually changes.

## Why this is the right fix (vs tolerating in the test)

The test (`assert idx._last_scan == scan_time`) was correct in spirit — it's checking that no rescan happened. The underlying logic was flaky in production too (Windows users could easily see double-scans on every search call when their library had recent files). Fixing the root cause makes both the test and real Windows usage deterministic.

## Test plan

- [x] All 348 tests pass locally
- [x] mypy clean
- [ ] CI green on all three platforms (this PR is its own regression test for the Windows flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)