### PR TITLE
fix: don't send SVG as ImageContent (fixes 400 Could not process image)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -45,16 +45,18 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
             f.write(result[key])
         return p
 
-    for key, suffix, mime in (("png", ".png", "image/png"), ("svg", ".svg", "image/svg+xml")):
-        if key in result:
-            data = result[key]
-            path = _path_for(key, suffix)
-            contents.append(ImageContent(
-                type="image",
-                data=base64.b64encode(data).decode(),
-                mimeType=mime,
-            ))
-            contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+    if "png" in result:
+        path = _path_for("png", ".png")
+        contents.append(ImageContent(
+            type="image",
+            data=base64.b64encode(result["png"]).decode(),
+            mimeType="image/png",
+        ))
+        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+
+    if "svg" in result:
+        path = _path_for("svg", ".svg")
+        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
 
     # DXF is a CAD interchange format, not an image — emit only the file marker
     # so clients deliver the file without the ImageContent base64 round-trip.


### PR DESCRIPTION
## Summary

- SVG output was being returned as `ImageContent(mimeType="image/svg+xml")`, but the Claude API only accepts `image/png`, `image/jpeg`, `image/gif`, and `image/webp` as inline image content
- Once an SVG ImageContent landed in conversation history, every subsequent API call — including simple messages like "hi" — replayed that history and failed with `400 Could not process image`, making the session unusable
- SVGs are now delivered only via the `[SEND: path]` text marker, matching how DXF output was already handled; PNGs continue to use `ImageContent` as before

## Test plan

- [ ] All 348 existing tests pass (`uv run pytest tests/`)
- [ ] Request `format='svg'` render — verify it returns a `[SEND:]` path marker without an `ImageContent` entry
- [ ] Request `format='png'` render — verify it still returns an inline `ImageContent` as before
- [ ] Request `format='both'` render — verify PNG is inline, SVG is file-only
- [ ] Confirm a new conversation after the fix is not broken by prior history

🤖 Generated with [Claude Code](https://claude.com/claude-code)