### PR TITLE
fix: route inspect_drawing through WorkerSession IPC (#105)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -138,8 +138,7 @@ def inspect_drawing(objects: str = "") -> str:
 
     objects: comma-separated object names (default: all registered objects).
     """
-    from build123d_mcp.tools.inspect_drawing import inspect_drawing as _inspect
-    return _inspect(_session, objects)
+    return _session.inspect_drawing(objects)
 
 
 @mcp.tool()

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -151,6 +151,10 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.import_step import import_cad_file
         return import_cad_file(session, args["path"], args.get("name", ""))
 
+    if op == "inspect_drawing":
+        from build123d_mcp.tools.inspect_drawing import inspect_drawing
+        return inspect_drawing(session, args.get("objects", ""))
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -350,6 +354,9 @@ class WorkerSession:
 
     def import_cad_file(self, path: str, name: str = "") -> str:
         return self._call("import_cad_file", {"path": path, "name": name}, self._EXPORT_TIMEOUT)
+
+    def inspect_drawing(self, objects: str = "") -> str:
+        return self._call("inspect_drawing", {"objects": objects}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_inspect_drawing.py
+++ b/tests/test_inspect_drawing.py
@@ -192,3 +192,34 @@ annotate(w, "width")
 """)
         result = self._run(session)
         assert result["lint"] == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: inspect_drawing must work through WorkerSession (issue #105).
+# The bare-Session tests above can't catch a routing bug because the in-process
+# Session has .objects/.drawing_annotations directly; the production server
+# uses WorkerSession, a parent-side IPC proxy whose state lives in a subprocess.
+# ---------------------------------------------------------------------------
+
+class TestInspectDrawingViaWorker:
+    def test_inspect_drawing_through_worker(self):
+        from build123d_mcp.worker import WorkerSession
+
+        ws = WorkerSession(exec_timeout=30)
+        try:
+            ws.execute("""
+from build123d import *
+from build123d import Draft
+from build123d_drafting import dim_linear
+draft = Draft(font_size=2.5, decimal_precision=1)
+w = dim_linear((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+annotate(w, "width")
+""")
+            payload = json.loads(ws.inspect_drawing())
+            assert "error" not in payload, payload
+            assert "width" in payload["objects"]
+            ann = payload["objects"]["width"]["annotation"]
+            assert ann is not None
+            assert ann["label_str"] == "20"
+        finally:
+            ws._kill_worker()


### PR DESCRIPTION
## Summary

Fixes #105 — `inspect_drawing` was reaching for `.objects` / `.drawing_annotations` on a `WorkerSession`, which is the parent-side IPC proxy. The real `Session` (with those attrs) lives in the worker subprocess, so every call crashed with `'WorkerSession' object has no attribute 'objects'`.

- Add `inspect_drawing` op to `worker._dispatch`
- Add `WorkerSession.inspect_drawing(objects)` proxy method
- Update `server.inspect_drawing` to call the proxy instead of importing the tool function directly
- Regression test routes through `WorkerSession` (existing tests use bare `Session`, which had the attrs directly and therefore couldn't catch this class of routing bug)

Scope: one-tool routing fix only — no worker-architecture changes.

## Test plan

- [x] `uv run pytest tests/` — 363 passed
- [x] New test `TestInspectDrawingViaWorker::test_inspect_drawing_through_worker` exercises the full IPC path
- [ ] Manual verify against a real MCP client: `from build123d import *` → `from build123d_drafting import dim_linear, Draft` → `annotate()` → `inspect_drawing()` returns structured JSON instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)