### PR TITLE
fix: bundle build123d-drafting-helpers as runtime dep (#106)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dependencies = [
     # resvg-py ships pre-built Rust wheels for all platforms with no native
     # library dependencies — works out-of-the-box on Linux/macOS/Windows.
     "resvg-py",
+    # Drawing-annotation helpers (dim_linear, leader, view_axes, lint_drawing).
+    # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
+    # build123d://drafting cookbook — actually work out of the box.
+    # Import name remains `build123d_drafting` (install name ≠ import name).
+    "build123d-drafting-helpers>=0.1.0",
 ]
 
 [project.urls]
@@ -45,11 +50,7 @@ dev = [
     "pytest-timeout",
     "mypy",
     "pytest-cov>=7.1.0",
-    "build123d-drafting>=0.1.0",
 ]
-
-[tool.uv.sources]
-build123d-drafting = { git = "https://github.com/pzfreo/build123d-drafting-helpers.git" }
 
 [tool.mypy]
 files = ["src"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,43 @@
+"""Packaging-level regression tests.
+
+These tests guard against changes that would break installation or runtime
+behaviour for end users without surfacing in the in-process tests.
+"""
+from importlib.metadata import requires
+
+
+def test_build123d_drafting_helpers_is_runtime_dependency():
+    """build123d-drafting-helpers must ship as a runtime dependency (issue #106).
+
+    The `inspect_drawing` tool's docstring and the `build123d://drafting` cookbook
+    both instruct users to `from build123d_drafting import dim_linear, Draft`.
+    That promise only holds if the helper package is installed alongside the
+    server in a runtime install (`uv tool run build123d-mcp`, `pip install
+    build123d-mcp`). Moving it back to a dev-only dep would silently break the
+    advertised workflow.
+    """
+    deps = requires("build123d-mcp") or []
+    # Each entry is a PEP 508 requirement string. Match by leading name segment
+    # so version markers and extras don't break this.
+    runtime_deps = {req.split()[0].split(";")[0].split(">")[0].split("<")[0].split("=")[0].split("[")[0].strip() for req in deps if "extra ==" not in req}
+    assert "build123d-drafting-helpers" in runtime_deps, (
+        f"build123d-drafting-helpers must be in runtime dependencies "
+        f"(issue #106). Got: {sorted(runtime_deps)}"
+    )
+
+
+def test_build123d_drafting_importable_in_sandbox():
+    """The sandbox must accept `from build123d_drafting import ...` without
+    the user having to install anything extra."""
+    from build123d_mcp.worker import WorkerSession
+
+    ws = WorkerSession(exec_timeout=30)
+    try:
+        out = ws.execute(
+            "from build123d_drafting import dim_linear, leader, view_axes, lint_drawing\n"
+            "print('imports OK')"
+        )
+        assert "imports OK" in out, out
+        assert "Error" not in out, out
+    finally:
+        ws._kill_worker()

--- a/uv.lock
+++ b/uv.lock
@@ -98,11 +98,15 @@ wheels = [
 ]
 
 [[package]]
-name = "build123d-drafting"
+name = "build123d-drafting-helpers"
 version = "0.1.0"
-source = { git = "https://github.com/pzfreo/build123d-drafting-helpers.git#fb2e203ef3c91ef241bb026d739ec3c067b5f4a6" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/1f/d546fd7b8bcbf4e54001de5d5e4012901c4bfbe4c5eba9273990b996e5e6/build123d_drafting_helpers-0.1.0.tar.gz", hash = "sha256:1ca8dd4ffa31ac2252a4a96864ca25d283b774f3142818bd9484cef612030c4a", size = 18713, upload-time = "2026-05-19T15:11:53.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/4a/7a4206dab6cc1a3e8a911e616e499eecec366dba99634868442f34329677/build123d_drafting_helpers-0.1.0-py3-none-any.whl", hash = "sha256:8f00fe691510a0b09c8d063138aa0bebd8c095d33aeefacad396cde4e28ffb57", size = 19408, upload-time = "2026-05-19T15:11:52.285Z" },
 ]
 
 [[package]]
@@ -112,13 +116,13 @@ source = { editable = "." }
 dependencies = [
     { name = "bd-warehouse" },
     { name = "build123d" },
+    { name = "build123d-drafting-helpers" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "build123d-drafting" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -129,13 +133,13 @@ dev = [
 requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.1.0" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "build123d-drafting", git = "https://github.com/pzfreo/build123d-drafting-helpers.git" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary

Fixes #106 — the \`inspect_drawing\` docstring and the \`build123d://drafting\` cookbook both instructed users to \`from build123d_drafting import dim_linear, Draft\`, but the package wasn't installed in a runtime install of build123d-mcp (it was a dev-only git-URL dep). This makes the advertised workflow actually run.

Depends on https://pypi.org/project/build123d-drafting-helpers/0.1.0/ — published earlier today from [pzfreo/build123d-drafting-helpers#3](https://github.com/pzfreo/build123d-drafting-helpers/pull/3).

## Changes

- \`pyproject.toml\`: \`build123d-drafting-helpers>=0.1.0\` added to \`[project.dependencies]\`. Removed the old \`[dependency-groups].dev\` entry and the \`[tool.uv.sources]\` git URL pointer.
- Install name is \`build123d-drafting-helpers\`; import name remains \`build123d_drafting\` (install name ≠ import name). No call sites change — existing \`from build123d_drafting import …\` lines still work.
- \`tests/test_packaging.py\`: two regression tests.
  1. Asserts \`build123d-drafting-helpers\` is in the installed-package runtime metadata via \`importlib.metadata.requires('build123d-mcp')\` — catches a future move back to dev-only.
  2. Runs an import through \`WorkerSession\` to confirm the sandbox actually accepts the module end-to-end.

## Test plan

- [x] \`uv run pytest tests/\` — 365 passed (was 363; +2 for the new packaging tests)
- [x] \`uv sync\` resolves \`build123d-drafting-helpers==0.1.0\` from PyPI (no git URL needed)
- [ ] Manual verify in a fresh \`uv tool install build123d-mcp\` once this lands: \`uv tool run build123d-mcp\` and run an \`inspect_drawing\` flow that imports from \`build123d_drafting\`

Scope: dependency change only. No code changes to the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)