### PR TITLE
fix: annotate() accepts vanilla ExtensionLine/DimensionLine (#107)

### DIFF
--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -34,19 +34,54 @@ class Session:
         session_ref = self
         drawing_annotations = self.drawing_annotations
 
-        def annotate(result: Any, name: str | None = None) -> None:
-            """Register a build123d_drafting DimResult/LeaderResult for inspect_drawing.
+        def annotate(
+            result: Any,
+            name: str | None = None,
+            label: str | None = None,
+        ) -> None:
+            """Register a drawing annotation for inspect_drawing.
 
-            Stores annotation metadata (label, measured length, tip/elbow coords)
-            and also calls show() so the shape is visible to render_view.
+            Accepts two flavours of input:
+
+            1. build123d_drafting DimResult / LeaderResult — extracted by
+               attribute: label_str, measured_length, tip, elbow.
+            2. Vanilla build123d.ExtensionLine / DimensionLine — measured
+               length is read from the .dimension attribute that build123d
+               sets during construction. The label string is NOT stored on
+               the constructed object by build123d, so pass it explicitly
+               via label="..." to have it captured.
+
+            Stores annotation metadata and also calls show() so the shape
+            is visible to render_view.
+
+            Args:
+                result: a DimResult, LeaderResult, ExtensionLine,
+                    DimensionLine, or any shape — anything else is registered
+                    without annotation metadata.
+                name: object name for the session registry. Defaults to
+                    label_str (when available) or "annotation".
+                label: explicit label string. Use this with vanilla
+                    ExtensionLine/DimensionLine — they consume the label
+                    constructor argument without exposing it on the shape.
+                    Ignored if result already exposes label_str.
             """
             if name is None:
                 name = getattr(result, "label_str", None) or "annotation"
             meta: dict[str, Any] = {"type": type(result).__name__}
+            # Helper-library duck-typed extraction.
             for attr in ("label_str", "measured_length", "tip", "elbow"):
                 val = getattr(result, attr, None)
                 if val is not None:
                     meta[attr] = val
+            # Vanilla build123d fallback: ExtensionLine/DimensionLine set
+            # .dimension to the measured path length but do not store the
+            # label string anywhere.
+            if "measured_length" not in meta:
+                dim = getattr(result, "dimension", None)
+                if dim is not None:
+                    meta["measured_length"] = dim
+            if label is not None and "label_str" not in meta:
+                meta["label_str"] = label
             drawing_annotations[name] = meta
             shape = getattr(result, "shape", result)
             objects[name] = shape

--- a/tests/test_inspect_drawing.py
+++ b/tests/test_inspect_drawing.py
@@ -81,6 +81,68 @@ annotate(w, "width")
         # annotation from first execute must still be there (only the bad exec rolls back)
         assert "width" in session.drawing_annotations
 
+    # -----------------------------------------------------------------------
+    # Vanilla build123d primitives — annotate() must extract measured_length
+    # from .dimension and accept an explicit label= kwarg (issue #107).
+    # The old behaviour was: empty metadata block, label and length lost.
+    # -----------------------------------------------------------------------
+
+    def test_annotate_vanilla_extension_line_captures_dimension(self, session):
+        session.execute("""
+from build123d import ExtensionLine, Draft
+draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
+w = ExtensionLine(border=[(-20, 10, 0), (20, 10, 0)], offset=6, draft=draft, label="40")
+annotate(w, "width_dim", label="40")
+""")
+        ann = session.drawing_annotations.get("width_dim")
+        assert ann is not None
+        assert ann["label_str"] == "40"
+        assert abs(ann["measured_length"] - 40.0) < 0.01
+        assert ann["type"] == "ExtensionLine"
+
+    def test_annotate_vanilla_dimension_line_captures_dimension(self, session):
+        session.execute("""
+from build123d import DimensionLine, Draft
+draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
+d = DimensionLine(path=[(0, 0, 0), (25, 0, 0)], draft=draft, label="25")
+annotate(d, "len_dim", label="25")
+""")
+        ann = session.drawing_annotations.get("len_dim")
+        assert ann is not None
+        assert ann["label_str"] == "25"
+        assert abs(ann["measured_length"] - 25.0) < 0.01
+        assert ann["type"] == "DimensionLine"
+
+    def test_annotate_vanilla_extension_line_without_label_still_captures_length(self, session):
+        """Without an explicit label= kwarg, measured_length should still be
+        captured from .dimension (label_str just won't be present)."""
+        session.execute("""
+from build123d import ExtensionLine, Draft
+draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
+w = ExtensionLine(border=[(-15, 0, 0), (15, 0, 0)], offset=5, draft=draft)
+annotate(w, "no_label_dim")
+""")
+        ann = session.drawing_annotations.get("no_label_dim")
+        assert ann is not None
+        assert "measured_length" in ann
+        assert abs(ann["measured_length"] - 30.0) < 0.01
+        assert "label_str" not in ann
+
+    def test_annotate_label_kwarg_ignored_when_result_has_label_str(self, session):
+        """For DimResult (which already exposes label_str), an explicit
+        label= kwarg should not overwrite the helper's value."""
+        session.execute("""
+from build123d import *
+from build123d import Draft
+from build123d_drafting import dim_linear
+draft = Draft(font_size=2.5, decimal_precision=1)
+w = dim_linear((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
+annotate(w, "width", label="WRONG")
+""")
+        ann = session.drawing_annotations.get("width")
+        assert ann is not None
+        assert ann["label_str"] == "20"
+
 
 # ---------------------------------------------------------------------------
 # inspect_drawing tool


### PR DESCRIPTION
## Summary

Fixes #107. \`annotate()\` previously did pure duck-typing on attribute names that exist on \`DimResult\`/\`LeaderResult\` but not on vanilla \`build123d.ExtensionLine\`/\`DimensionLine\`. Real drafting codebases (the gramel project the issue cites, ~600 lines of \`ExtensionLine\`-based code) ended up with empty metadata blocks and couldn't use \`inspect_drawing\` without a rewrite.

## Important finding from the source

The issue's suggested fix says "pull \`label\` from the build123d API". After reading \`build123d/drafting.py\`: **build123d does NOT store the constructor \`label\` argument as an attribute on the constructed shape.** It's consumed into a local during \`__init__\` (\`DimensionLine\` line 389, \`ExtensionLine\` line 544) and never persisted. There's no way to recover it after the fact.

What *is* exposed: \`self.dimension\` (the measured path length) on both classes. So measured_length is free; the label needs a different mechanism.

## Fix shape

Additive, no breaking changes:

- Read \`measured_length\` from \`.dimension\` when the helper-library attribute is absent — free for every existing call site that uses vanilla primitives.
- Add an optional \`label=\"...\"\` kwarg to \`annotate()\` so users can pass the label through explicitly. This is the honest workaround given build123d's API.
- Helper-library \`DimResult\`/\`LeaderResult\` flows unchanged. An explicit \`label=\` kwarg is **ignored** when the result already exposes \`label_str\` (helper's value wins).

## Usage

\`\`\`python
# Vanilla build123d — pass label explicitly:
w = ExtensionLine(border=[(-20, 10, 0), (20, 10, 0)], offset=6, draft=draft, label=\"40\")
annotate(w, \"width_dim\", label=\"40\")
# → meta: {type: \"ExtensionLine\", measured_length: 40.0, label_str: \"40\"}

# build123d-drafting-helpers — unchanged:
w = dim_linear((-20, -10, 0), (20, -10, 0), \"below\", 8, draft, label=\"40\")
annotate(w, \"width_dim\")
# → meta: {type: \"DimResult\", measured_length: 40.0, label_str: \"40\"}
\`\`\`

## Test plan

- [x] \`uv run pytest tests/\` — 369 passed (was 365; +4 vanilla-primitive regression tests)
- [x] Each new test covers a distinct case: \`ExtensionLine\` with explicit label, \`DimensionLine\` with explicit label, \`ExtensionLine\` without label (length still captured), helper-library result with conflicting kwarg (helper wins)
- [ ] Manual verify against the issue's exact reproducer

Scope: \`Session.annotate()\` only. No \`inspect_drawing\` changes — its metadata consumer is format-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)