### PR TITLE
fix: annotate() no longer auto-derives label_str, preventing false-negative lint (#119)

### DIFF
--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -60,13 +60,12 @@ class Session:
                     without annotation metadata.
                 name: object name for the session registry. Defaults to
                     label_str (when available) or "annotation".
-                label: explicit label string override. Use when the dim has a
-                    custom label that differs from the measured length (e.g.
-                    ExtensionLine(..., label="40") on a 20 mm segment). If
-                    omitted for vanilla ExtensionLine/DimensionLine, the label
-                    is auto-derived from the measured dimension length. To
-                    avoid manual duplication use dim_linear() from
-                    build123d_drafting, which stores the exact label.
+                label: explicit label string. Required for lint to check
+                    axis swaps on vanilla ExtensionLine/DimensionLine — pass
+                    the same string you gave to the ExtensionLine constructor
+                    (e.g. label="40"). Omit only when you don't need lint
+                    coverage. For automatic label capture without duplication
+                    use dim_linear() from build123d_drafting instead.
             """
             if name is None:
                 name = getattr(result, "label_str", None) or "annotation"
@@ -86,11 +85,15 @@ class Session:
             if "label_str" not in meta:
                 if label is not None:
                     meta["label_str"] = label
-                elif "measured_length" in meta:
-                    # build123d does not expose the constructor label after
-                    # construction (.label is always ''); derive from length.
-                    # Use dim_linear() from build123d_drafting for custom labels.
-                    meta["label_str"] = str(round(meta["measured_length"], 1))
+                # Do NOT auto-derive label_str from measured_length.
+                # build123d doesn't expose the constructor label after
+                # construction, so we can't distinguish ExtensionLine(label="99")
+                # (axis-swap bug) from one built without a label. Deriving
+                # label_str from measured_length makes lint always see
+                # label==measured → silent false negatives. Leave label_str
+                # absent so lint skips the check rather than falsely approving
+                # a potentially wrong drawing. Pass label= explicitly or use
+                # dim_linear() from build123d_drafting to enable lint.
             drawing_annotations[name] = meta
             shape = getattr(result, "shape", result)
             objects[name] = shape

--- a/tests/test_inspect_drawing.py
+++ b/tests/test_inspect_drawing.py
@@ -113,10 +113,12 @@ annotate(d, "len_dim", label="25")
         assert abs(ann["measured_length"] - 25.0) < 0.01
         assert ann["type"] == "DimensionLine"
 
-    def test_annotate_vanilla_extension_line_without_label_auto_derives_from_length(self, session):
-        """Without an explicit label= kwarg, label_str is auto-derived from
-        the measured dimension length (build123d doesn't expose the constructor
-        label on the shape object)."""
+    def test_annotate_vanilla_extension_line_without_label_has_no_label_str(self, session):
+        """Without an explicit label= kwarg, label_str is absent.
+        build123d doesn't expose the constructor label after construction, so
+        we can't distinguish a correctly-labelled dim from an axis-swap bug.
+        Leaving label_str absent means lint skips the check rather than
+        producing a false negative."""
         session.execute("""
 from build123d import ExtensionLine, Draft
 draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
@@ -127,8 +129,36 @@ annotate(w, "no_label_dim")
         assert ann is not None
         assert "measured_length" in ann
         assert abs(ann["measured_length"] - 30.0) < 0.01
-        # Auto-derived label from measured_length rounded to 1 decimal place
-        assert ann["label_str"] == "30.0"
+        assert "label_str" not in ann
+
+    def test_annotate_vanilla_el_with_wrong_label_fires_lint(self, session):
+        """Regression for #119: annotate(el, name, label="99") on a 30mm path
+        must produce a lint violation, not a false negative."""
+        session.execute("""
+from build123d import ExtensionLine, Draft
+draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
+bad = ExtensionLine(border=[(-15, -30, 0), (15, -30, 0)], offset=-6, draft=draft, label="99")
+annotate(bad, "axis_swap_bug", label="99")
+""")
+        from build123d_mcp.tools.lint_drawing import lint_drawing
+        import json
+        out = json.loads(lint_drawing(session))
+        assert any(v["check"] == "label_vs_measured" for v in out["violations"]), (
+            "lint must flag 99 vs 30mm mismatch when label= is passed explicitly"
+        )
+
+    def test_annotate_vanilla_el_without_label_no_false_negative(self, session):
+        """Regression for #119: annotate(el, name) without label= on a 30mm
+        path labelled '99' must NOT produce a false-clean lint result."""
+        session.execute("""
+from build123d import ExtensionLine, Draft
+draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0.1)
+bad = ExtensionLine(border=[(-15, -30, 0), (15, -30, 0)], offset=-6, draft=draft, label="99")
+annotate(bad, "axis_swap_bug")   # no label= kwarg
+""")
+        ann = session.drawing_annotations.get("axis_swap_bug")
+        # label_str must be absent — lint cannot fire a false negative
+        assert "label_str" not in ann
 
     def test_annotate_label_kwarg_ignored_when_result_has_label_str(self, session):
         """For DimResult (which already exposes label_str), an explicit
@@ -294,7 +324,9 @@ annotate(w, "width")
 # ---------------------------------------------------------------------------
 
 class TestAnnotateLabelFallback:
-    def test_vanilla_extension_line_gets_auto_label(self, session):
+    def test_vanilla_extension_line_without_kwarg_has_no_label_str(self, session):
+        """Without label= kwarg, label_str is absent — not derived from measured_length.
+        Auto-derive was removed because it caused false-negative lint results (#119)."""
         session.execute("""
 from build123d import *
 from build123d import Draft, ExtensionLine, Mode
@@ -304,9 +336,7 @@ annotate(el, "dim")
 """)
         ann = session.drawing_annotations.get("dim")
         assert ann is not None
-        assert "label_str" in ann
-        # Auto-derived from measured length (20.0), not the custom "20" label
-        assert ann["label_str"] == "20.0"
+        assert "label_str" not in ann
         assert abs(ann["measured_length"] - 20.0) < 0.01
 
     def test_explicit_label_kwarg_wins(self, session):


### PR DESCRIPTION
## Summary

- `annotate(el, "name")` without `label=` was setting `label_str = str(round(measured_length, 1))`, making lint always see label == measured → silent false negatives for axis-swap bugs
- Fix: remove the auto-derive; leave `label_str` absent when we can't extract the actual label
- Lint now skips the check (rather than falsely approving) when called without `label=`
- Callers who need lint coverage must pass `label=` explicitly or use `dim_linear()`

## Root cause

build123d doesn't expose the `ExtensionLine` constructor's `label=` argument after construction. So if a user built `ExtensionLine(..., label="99")` on a 30mm path and called `annotate(el, "name")`, the stored `label_str` was `"30.0"` — lint saw 30.0 == 30.0 → no violation. The actual bug (99 vs 30mm) was invisible.

## Test plan
- [ ] `test_annotate_vanilla_extension_line_without_label_has_no_label_str` — label_str absent without kwarg
- [ ] `test_annotate_vanilla_el_with_wrong_label_fires_lint` — lint fires with explicit `label="99"` on 30mm path
- [ ] `test_annotate_vanilla_el_without_label_no_false_negative` — label_str absent when kwarg omitted
- [ ] `TestAnnotateLabelFallback.test_vanilla_extension_line_without_kwarg_has_no_label_str` — updated from old auto-derive expectation
- [ ] All 396 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)