### PR TITLE
fix: launch via uv tool run --upgrade (.mcp.json pointed at stale sibling checkout)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,7 @@
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["run", "build123d-mcp"],
-      "cwd": "/app/workspaces/pzfreo/build123-mcp"
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ The server runs over stdio — the client launches it as a subprocess using `uv 
 
 > **Note on Python version.** All examples below pass `--python 3.12`. VTK and cadquery-ocp do not yet ship wheels for Python 3.13+, so pinning to 3.12 is required. uv will auto-download a managed Python 3.12 if you don't already have one.
 
+> **Note on `--upgrade`.** The examples pass `--upgrade` so each launch re-resolves to the latest published `build123d-mcp` instead of reusing uv's cached environment — without it, the client can stay pinned to whatever version uv first cached and silently miss releases. The trade-off is a short dependency-resolution step at every startup (and it needs network access to check for updates). Drop `--upgrade` if you prefer faster, offline-capable starts and update manually with `uv tool upgrade build123d-mcp`.
+
 ### Claude Code
 
 Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
@@ -176,7 +178,7 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -193,7 +195,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -210,7 +212,7 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   }
 }
@@ -226,7 +228,7 @@ For **Continue** extension, add to `.continue/config.json`:
     {
       "name": "build123d-mcp",
       "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   ]
 }
@@ -240,7 +242,7 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
     "build123d-mcp": {
       "type": "stdio",
       "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
     }
   }
 }


### PR DESCRIPTION
## What

`.mcp.json` was launching the server with:

```json
"args": ["run", "build123d-mcp"],
"cwd": "/app/workspaces/pzfreo/build123-mcp"
```

That `cwd` points at a **different sibling checkout** — `build123-mcp` (missing the "d") — which is a separate, abandoned repo stuck at **v0.1.0**. So `uv run` resolved and launched the *old* server from there, not this one.

Consequence: the running server lacked everything added since v0.1.0 — the 2D-drawing render path, the expanded `render_view` signature, `render_mode` detection, etc. Flat 2D artwork (e.g. a GD&T feature control frame) hit the 3D mesher and failed with `3mf mesh is invalid` purely because of this misconfiguration — not a code bug.

## Fix

- **`.mcp.json`**: launch with `uv tool run --upgrade --python 3.12 build123d-mcp`. This resolves the published package from PyPI (no `cwd`), and `--upgrade` re-resolves to the latest release on every launch so it can't silently rot again.
- **README**: add `--upgrade` to all five client-config examples (Claude Code, Claude Desktop, Cursor, Continue, VS Code/Copilot) and a note explaining the flag and its trade-off (a short resolve step at startup + needs network; drop it and run `uv tool upgrade build123d-mcp` manually if you prefer faster/offline starts).

## Notes
- Config + docs only; no code changes.
- Requires an MCP-client restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)