### PR TITLE
docs: GD&T drafting helpers + bump pin to >=0.1.7 (v0.3.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.27 — 2026-05-31
+
+### Documentation
+
+- **GD&T drafting recipe**: the drafting cookbook now documents `feature_control_frame()`, `datum_feature()`, and `surface_finish_mark()` (a runnable `gdt_symbols` example), and the "no GD&T symbols" limitation note is removed. The presentation cookbook's "use the heavier path for GD&T" wording is corrected — the drafting helpers cover feature control frames, datum features, and surface-finish marks.
+
+### Dependencies
+
+- **`build123d-drafting-helpers` pin bumped `>=0.1.5` → `>=0.1.7`**, which is the release that adds the GD&T symbol helpers (ISO 1101 feature control frames, ISO 5459 datum features).
+
 ## v0.3.26 — 2026-05-21
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
-    "build123d-drafting-helpers>=0.1.5",
+    "build123d-drafting-helpers>=0.1.7",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/drafting_cookbook.py
+++ b/src/build123d_mcp/drafting_cookbook.py
@@ -484,10 +484,53 @@ show(result, "stacked_dims_demo")""",
     ),
 
     Section(
+        label="gdt_symbols",
+        text="""\
+## GD&T: feature control frames, datum features, surface finish marks
+# build123d.drafting ships no GD&T primitives, and the geometric-characteristic
+# glyphs (⌖ ⊥ ∥ ◎ …) and surface-finish ticks are absent from CAD-safe fonts —
+# so build123d-drafting-helpers (>=0.1.7) draws them geometrically. Each helper
+# builds at the origin; move it into place with .shape.moved(loc), and route
+# .lines / .text to separate SVG layers when you need ISO line/fill colours.
+from build123d import *
+from build123d_drafting import (
+    feature_control_frame, datum_feature, surface_finish_mark,
+)
+
+draft = Draft(font_size=2.5, decimal_precision=2)
+
+# Feature control frame -> | ⌖ | ⌀0.5 Ⓜ | A | B | C |
+# characteristic is one of 14 names ("position", "flatness", "perpendicularity",
+# "concentricity", "circular_runout", ...). diameter=True prepends ⌀;
+# modifier="M"/"L"/"P" = MMC/LMC/projected (None = RFS).
+fcf = feature_control_frame(
+    "position", 0.5, datums=("A", "B", "C"),
+    draft=draft, diameter=True, modifier="M",
+)
+
+# Datum feature symbol (filled triangle + framed letter), tip at the origin.
+datum_a = datum_feature("A", draft=draft)
+
+# Surface finish mark with an Ra value, placed at a point (ISO 1302).
+finish = surface_finish_mark("1.6", position=(60, 0, 0), draft=draft)
+
+# In a real drawing, route .lines and .text to coloured ExportSVG layers; here
+# we just compose .shape for a preview.
+result = Compound(children=[
+    fcf.shape,
+    datum_a.shape.moved(Location((40, 0, 0))),
+    finish.shape,
+])
+show(result, "gdt_demo")""",
+    ),
+
+    Section(
         text="""\
 ## Limitations and gaps in build123d.drafting today
 # - No HoleTable class: roll your own via face_inventory + DimensionLine (see above).
-# - No GD&T symbols: surface finish marks, datum triangles, control frames.
+# - GD&T symbols (feature control frames, datum features, surface finish marks)
+#   and an ISO 7200 title block now live in build123d-drafting-helpers — see the
+#   GD&T recipe above; iso_title_block() covers the title block.
 # - No section-view hatching: clip the part with a plane and project the
 #   result, but cross-hatching the cut surface is manual.
 # - No automatic standards selection (ASME Y14.5 vs ISO): the Draft object

--- a/src/build123d_mcp/presentation_cookbook.py
+++ b/src/build123d_mcp/presentation_cookbook.py
@@ -7,7 +7,8 @@ output you put in a chat, doc, or proposal review.
 
 Differs from build123d://drafting:
   drafting     — engineering drawings for fabrication (DXF handoff, tolerance
-                 dims, GD&T, multi-view sheets). Two-colour output.
+                 dims, GD&T feature control frames / datum / surface-finish
+                 symbols, multi-view sheets). Two-colour output.
   presentation — discussion diagrams (per-group colour, filled features,
                  legends, axes, titles). Multi-colour output via ExportSVG
                  layers, run from a script outside the MCP sandbox.
@@ -45,7 +46,8 @@ SECTIONS: list[Section] = [
         "\n"
         "When to reach for build123d://drafting instead:\n"
         "  - Output is an engineering drawing for fabrication.\n"
-        "  - You need tolerance dims, GD&T, title block, multi-view sheets.\n"
+        "  - You need tolerance dims, GD&T symbols, title block, multi-view\n"
+        "    sheets (the drafting helpers cover all of these).\n"
         "  - Two-colour (black part + blue dims) is enough.\n"
         "\n"
         "Pipeline:\n"

--- a/uv.lock
+++ b/uv.lock
@@ -99,14 +99,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.1.5"
+version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/93/6bd204cf7bfda73e3b54168b5eb6dbd7507d0cecf90f515a4b0310ae3ba2/build123d_drafting_helpers-0.1.5.tar.gz", hash = "sha256:968cefb0f5b3d9008bf933938a9f85d2695240e20879e0a24bc10c4d050da621", size = 26781, upload-time = "2026-05-25T09:01:34.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/a9/42519cc5a019f3ed027feabc95f1b809fa9ebe32a1643db79ce3f38b7fae/build123d_drafting_helpers-0.1.7.tar.gz", hash = "sha256:06de68f8b722b011bda75ddb3e0dabc9e3ce7af4b54f202061116c1185a00bf3", size = 34016, upload-time = "2026-05-31T17:00:32.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/78/5f5199d468f9215ce889e7df8a5b5f70f72d41ecb30f1df274c9fb7f6cd3/build123d_drafting_helpers-0.1.5-py3-none-any.whl", hash = "sha256:10fa930306bc3f7ec9eb5248f8186a83b7bb102967ddfed49746d57874c127b4", size = 24444, upload-time = "2026-05-25T09:01:33.746Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/44/e330838f77f2d072718ed4389394401998b6622681630b80cff2e0f1efa9/build123d_drafting_helpers-0.1.7-py3-none-any.whl", hash = "sha256:01a1201b9e3cc7315dce34b8bd1a80ce8bbdd3dfb950b126e7fe0d4c74c01c47", size = 29828, upload-time = "2026-05-31T17:00:30.929Z" },
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ dev = [
 requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.1.5" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.1.7" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]


### PR DESCRIPTION
Surfaces the GD&T support that landed in `build123d-drafting-helpers` 0.1.7 (#11 there) and pins the version that provides it. Prep for cutting **v0.3.27**.

## Changes
- **`drafting_cookbook.py`**: new runnable `gdt_symbols` example covering `feature_control_frame()`, `datum_feature()`, and `surface_finish_mark()`; removed the stale "No GD&T symbols" limitation bullet (and noted `iso_title_block()` for the title block).
- **`presentation_cookbook.py`**: corrected the "reach for the heavier presentation path for GD&T" wording — the drafting helpers now cover feature control frames, datum features, and surface-finish marks.
- **`pyproject.toml`**: bump `build123d-drafting-helpers` `>=0.1.5` → `>=0.1.7`; `uv.lock` re-locked to 0.1.7.
- **`CHANGELOG.md`**: 0.3.27 entry.

## Verification
- `uv run pytest` — **441 passed**. The new `gdt_symbols` cookbook section is executed by `test_drafting_cookbook.py`, so the documented API calls are validated, not just prose.

## Notes
- Depends on `build123d-drafting-helpers` 0.1.7, now live on PyPI.
- `pyproject.toml` project version left at `0.3.27.dev0` — the release tag drives the published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)