### PR TITLE
refactor: lint_drawing delegates geometry checks to the helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## v0.3.28 — 2026-06-01
 
+### Changed
+
+- **`lint_drawing` (session mode) now delegates to the helpers** instead of
+  reimplementing the geometry checks. It reconstructs `DimResult`/`CenterlineResult`
+  from the session and calls `build123d_drafting.lint_drawing()` +
+  `find_interferences()`, mapping each `LintIssue.code` to the violation `check`.
+  Single source of truth — the duplicated label-vs-measured / overlap / centerline
+  logic is gone. New geometry-precise checks (`line_pierces_label`, `redundant_lines`,
+  `labels_overlap`) are now surfaced through the MCP tool for the first time. The leader
+  elbow check and the per-edge page-bounds check stay MCP-native (leader text geometry
+  isn't stored separately); the SVG-export `text_no_fill` check is unchanged.
+
 ### Dependencies
 
-- **`build123d-drafting-helpers` pin bumped `>=0.1.7` → `>=0.1.9`**, picking up the
+- **`build123d-drafting-helpers` pin bumped `>=0.1.7` → `>=0.1.10`**, picking up the
   `surface_finish_mark` ISO-1302 fix, `add_to_layers()` SVG routing, `find_interferences()`
-  geometry-precise collision detection, and `draft_preset()`.
+  geometry-precise collision detection, `draft_preset()`, and `LintIssue.code`.
 
 ## v0.3.27 — 2026-05-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
-    "build123d-drafting-helpers>=0.1.9",
+    "build123d-drafting-helpers>=0.1.10",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/tools/lint_drawing.py
+++ b/src/build123d_mcp/tools/lint_drawing.py
@@ -1,190 +1,136 @@
-"""lint_drawing — standalone structural checks on a 2D drawing.
+"""lint_drawing — structural checks on a 2D drawing.
 
 Two modes:
 
-  1. Session mode: scans session.objects + session.drawing_annotations and runs
-     the same checks inspect_drawing reports inline (label-vs-measured-length
-     divergence, leader elbow inside the label bbox).
+  1. Session mode: reconstructs the session's annotations as build123d_drafting
+     result objects and **delegates the geometry checks to the helpers**
+     (`lint_drawing` + `find_interferences`) — single source of truth, no
+     duplicated check logic. The MCP keeps only what the helpers can't do from
+     the stored data: the leader elbow check (leader text geometry isn't stored
+     separately) and the per-edge page-bounds check.
 
-  2. SVG mode: scans an SVG file on disk for layer-level pathologies that only
-     show up at export time — most importantly text on a layer with no fill
-     (renders as illegible thick outlines).
+  2. SVG mode: scans an exported SVG for layer-level pathologies that only show
+     up at export time (text on a no-fill layer), plus sidecar label checks.
 
-The structured violation list is JSON so the LLM can iterate on a drawing
-without rendering it.
+The structured violation list is JSON so the LLM can iterate without rendering.
+Each violation's `check` is the helpers' stable `LintIssue.code`.
 """
 import json
+import os
 import re
 import xml.etree.ElementTree as ET
 
+from build123d_drafting import (
+    CenterlineResult,
+    DimResult,
+    find_interferences,
+    lint_drawing as _helper_lint,
+)
 
-def _lint_annotations(annotations: dict, objects: dict | None = None) -> list[dict]:
-    """Run label-vs-measured and leader checks against an annotations dict.
+# Checks that apply to a single annotation — run per-item so the violation can
+# carry the session object name (the helpers' issues only know the label text).
+_PER_ITEM_CODES = {"label_vs_measured", "dim_inside_part"}
 
-    Args:
-        annotations: mapping of name → annotation metadata dict.
-        objects: optional session.objects for leader elbow bbox check (unavailable
-            in SVG mode — the geometry isn't loaded).
+# The MCP elevates these helper "warning"s to "error" in its own contract.
+_SEVERITY_OVERRIDE = {"label_vs_measured": "error"}
+
+
+def _violation(issue, obj: str) -> dict:
+    return {
+        "severity": _SEVERITY_OVERRIDE.get(issue.code, issue.severity),
+        "check": issue.code or "lint",
+        "object": obj,
+        "message": issue.message,
+    }
+
+
+def _pair_object(issue, items) -> str:
+    """Best-effort: session names whose label text appears in a pairwise message."""
+    names = []
+    for name, res in items:
+        label = getattr(res, "label_str", "")
+        if label and (f'"{label}"' in issue.message or f"'{label}'" in issue.message):
+            names.append(name)
+    return "+".join(dict.fromkeys(names))
+
+
+def _reconstruct(session):
+    """[(name, result)] for each dim/centerline annotation that has geometry.
+
+    Leaders are skipped here — their text geometry isn't stored separately, so
+    the leader check stays in `_lint_leaders`.
     """
+    items = []
+    for name, meta in session.drawing_annotations.items():
+        if name not in session.objects:
+            continue
+        shape = session.objects[name]
+        if meta.get("type") == "centerline":
+            items.append((name, CenterlineResult(shape=shape,
+                                                 label_str=meta.get("label_str", ""))))
+        elif meta.get("elbow") is not None:
+            continue  # leader — handled by _lint_leaders
+        else:
+            items.append((name, DimResult(
+                shape=shape,
+                label_str=meta.get("label_str", ""),
+                measured_length=meta.get("measured_length") or 0.0,
+                dim_level_y=meta.get("dim_level_y"),
+                label_bbox=meta.get("label_bbox"),
+            )))
+    return items
+
+
+def _lint_session(session) -> list[dict]:
+    items = _reconstruct(session)
+    results = [r for _, r in items]
     violations: list[dict] = []
 
-    for name, ann in annotations.items():
-        label = ann.get("label_str", "")
-        measured = ann.get("measured_length")
-        if label and measured and measured > 1e-6:
-            nums = re.findall(
-                r"\d+\.?\d*",
-                label.split("±")[0].split("+")[0].lstrip("ø⌀Rr"),
-            )
-            if nums:
-                try:
-                    label_val = float(nums[0])
-                    ratio = abs(label_val - measured) / measured
-                    if ratio > 0.005:
-                        violations.append({
-                            "severity": "error",
-                            "check": "label_vs_measured",
-                            "object": name,
-                            "message": (
-                                f"label '{label}' value {label_val:.3f} differs from "
-                                f"measured length {measured:.3f} by {ratio*100:.1f}% "
-                                f"— possible axis swap"
-                            ),
-                        })
-                except ValueError:
-                    pass
+    # per-item checks (carry the session name)
+    for name, res in items:
+        for issue in _helper_lint([res]):
+            if issue.code in _PER_ITEM_CODES:
+                violations.append(_violation(issue, name))
 
+    # pairwise checks + geometry-precise interference over the whole set
+    if len(results) >= 2:
+        for issue in _helper_lint(results):
+            if issue.code not in _PER_ITEM_CODES:
+                violations.append(_violation(issue, _pair_object(issue, items)))
+    for issue in find_interferences(results):
+        violations.append(_violation(issue, _pair_object(issue, items)))
+
+    # MCP-native checks the helpers can't run from the stored data
+    violations += _lint_leaders(session)
+    if session.drawing_page:
+        violations += _lint_page_bounds(
+            session.drawing_annotations, session.objects, session.drawing_page)
+    return violations
+
+
+def _lint_leaders(session) -> list[dict]:
+    """Leader elbow inside the label region — MCP-native because the leader's
+    text geometry isn't stored separately from its lines in the session."""
+    violations: list[dict] = []
+    for name, ann in session.drawing_annotations.items():
         elbow = ann.get("elbow")
-        if elbow and objects is not None and name in objects:
-            try:
-                bb = objects[name].bounding_box()
-                if (bb.min.X <= elbow[0] <= bb.max.X
-                        and bb.min.Y <= elbow[1] <= bb.max.Y):
-                    violations.append({
-                        "severity": "warning",
-                        "check": "leader_elbow_in_label",
-                        "object": name,
-                        "message": (
-                            f"leader elbow ({elbow[0]:.2f}, {elbow[1]:.2f}) "
-                            f"may be inside the label bbox"
-                        ),
-                    })
-            except Exception:
-                pass
-
+        if not elbow or name not in session.objects:
+            continue
+        try:
+            bb = session.objects[name].bounding_box()
+            if bb.min.X <= elbow[0] <= bb.max.X and bb.min.Y <= elbow[1] <= bb.max.Y:
+                violations.append({
+                    "severity": "warning",
+                    "check": "leader_elbow_in_label",
+                    "object": name,
+                    "message": (
+                        f"leader elbow ({elbow[0]:.2f}, {elbow[1]:.2f}) "
+                        f"may be inside the label bbox"
+                    ),
+                })
+        except Exception:
+            pass
     return violations
-
-
-def _lint_overlap(annotations: dict, objects: dict) -> list[dict]:
-    """Check every pair of annotations for bounding-box overlap.
-
-    Uses dim_level_y (stored by annotate()) to skip stacked dims whose
-    extension lines share the same X range but occupy different Y levels.
-
-    Handles centerline objects specially:
-    - centerline-vs-centerline pairs are skipped.
-    - dim-vs-centerline pairs use the dim's label_bbox for precision.
-    """
-    violations: list[dict] = []
-    names = [n for n in annotations if n in objects]
-    for i, name_a in enumerate(names):
-        for name_b in names[i + 1:]:
-            try:
-                is_cl_a = annotations[name_a].get("type") == "centerline"
-                is_cl_b = annotations[name_b].get("type") == "centerline"
-
-                # Skip centerline-vs-centerline
-                if is_cl_a and is_cl_b:
-                    continue
-
-                # Centerline-vs-dim: use label_bbox for precision
-                if is_cl_a or is_cl_b:
-                    dim_name = name_b if is_cl_a else name_a
-                    cl_name = name_a if is_cl_a else name_b
-                    v = _lint_centerline_label_overlap(
-                        dim_name, annotations[dim_name], objects[dim_name],
-                        cl_name, objects[cl_name],
-                    )
-                    if v:
-                        violations.append(v)
-                    continue
-
-                level_a = annotations[name_a].get("dim_level_y")
-                level_b = annotations[name_b].get("dim_level_y")
-                if (level_a is not None and level_b is not None
-                        and abs(level_a - level_b) > 3.0):
-                    continue  # different Y levels → stacked, not colliding
-                ba = objects[name_a].bounding_box()
-                bb = objects[name_b].bounding_box()
-                ox = max(0.0, min(ba.max.X, bb.max.X) - max(ba.min.X, bb.min.X))
-                oy = max(0.0, min(ba.max.Y, bb.max.Y) - max(ba.min.Y, bb.min.Y))
-                if ox > 0.5 and oy > 0.5:
-                    violations.append({
-                        "severity": "warning",
-                        "check": "annotation_overlap",
-                        "object": f"{name_a}+{name_b}",
-                        "message": (
-                            f"annotations '{name_a}' and '{name_b}' overlap by "
-                            f"{ox:.1f}×{oy:.1f} mm — increase offset or spacing"
-                        ),
-                    })
-            except Exception:
-                pass
-    return violations
-
-
-def _lint_centerline_label_overlap(
-    dim_name: str,
-    dim_ann: dict,
-    dim_obj,
-    cl_name: str,
-    cl_obj,
-) -> dict | None:
-    """Return a violation dict if the dim's label overlaps the centerline, else None."""
-    try:
-        cl_bb = cl_obj.bounding_box()
-
-        # Use stored label_bbox when available; fall back to full object bbox
-        label_bbox = dim_ann.get("label_bbox")
-        if label_bbox is not None:
-            lmin_x, lmin_y, lmax_x, lmax_y = label_bbox
-        else:
-            db = dim_obj.bounding_box()
-            lmin_x, lmin_y = db.min.X, db.min.Y
-            lmax_x, lmax_y = db.max.X, db.max.Y
-
-        cl_w = cl_bb.max.X - cl_bb.min.X
-        cl_h = cl_bb.max.Y - cl_bb.min.Y
-
-        if cl_w < 0.1:
-            # Vertical centerline: check if its X falls inside label X range
-            cl_x = (cl_bb.min.X + cl_bb.max.X) / 2.0
-            ox = min(cl_x - lmin_x, lmax_x - cl_x) if lmin_x < cl_x < lmax_x else 0.0
-        else:
-            ox = max(0.0, min(lmax_x, cl_bb.max.X) - max(lmin_x, cl_bb.min.X))
-
-        if cl_h < 0.1:
-            # Horizontal centerline: check if its Y falls inside label Y range
-            cl_y = (cl_bb.min.Y + cl_bb.max.Y) / 2.0
-            oy = min(cl_y - lmin_y, lmax_y - cl_y) if lmin_y < cl_y < lmax_y else 0.0
-        else:
-            oy = max(0.0, min(lmax_y, cl_bb.max.Y) - max(lmin_y, cl_bb.min.Y))
-
-        if ox > 0.5 and oy > 0.5:
-            dim_label = dim_ann.get("label_str", dim_name)
-            return {
-                "severity": "warning",
-                "check": "label_centerline_overlap",
-                "object": f"{dim_name}+{cl_name}",
-                "message": (
-                    f"label '{dim_label}' overlaps centerline '{cl_name}' by "
-                    f"{ox:.1f}×{oy:.1f} mm — use label_offset_x to shift the label "
-                    f"or increase the dim offset to clear the centerline"
-                ),
-            }
-    except Exception:
-        pass
-    return None
 
 
 def _lint_page_bounds(annotations: dict, objects: dict, page: dict) -> list[dict]:
@@ -219,30 +165,17 @@ def _lint_page_bounds(annotations: dict, objects: dict, page: dict) -> list[dict
     return violations
 
 
-def _lint_session(session) -> list[dict]:
-    """Run structural lint on session-registered annotations."""
-    violations = _lint_annotations(session.drawing_annotations, objects=session.objects)
-    violations += _lint_overlap(session.drawing_annotations, session.objects)
-    if session.drawing_page:
-        violations += _lint_page_bounds(
-            session.drawing_annotations, session.objects, session.drawing_page
-        )
-    return violations
-
-
 _SVG_NS = "{http://www.w3.org/2000/svg}"
 
 
 def _lint_svg(svg_path: str) -> list[dict]:
-    """Layer-level checks on an SVG file, plus sidecar annotation checks.
+    """Layer-level checks on an exported SVG file, plus sidecar label checks.
 
-    Catches:
-    - text elements on a group with fill='none' or no fill attribute, which
-      renders glyphs as outlines rather than filled shapes.
-    - label-vs-measured divergence from the .dims.json sidecar (written by
-      save_drawing_annotations()) — same axis-swap check as session mode.
+    - text on a group with `fill='none'` renders glyphs as illegible outlines;
+    - label-vs-measured divergence from the `.dims.json` sidecar (no live
+      geometry here, so the helper's per-item check is run on shape-less
+      reconstructed `DimResult`s).
     """
-    import os, json as _json
     violations: list[dict] = []
     try:
         tree = ET.parse(svg_path)
@@ -250,42 +183,42 @@ def _lint_svg(svg_path: str) -> list[dict]:
         return [{"severity": "error", "check": "svg_parse",
                  "object": svg_path, "message": str(e)}]
 
-    root = tree.getroot()
-
     def walk(elem, inherited_fill):
         fill = elem.get("fill", inherited_fill)
-        style = elem.get("style", "")
-        m = re.search(r"fill:\s*([^;]+)", style)
+        m = re.search(r"fill:\s*([^;]+)", elem.get("style", ""))
         if m:
             fill = m.group(1).strip()
-
-        tag = elem.tag.replace(_SVG_NS, "")
-        if tag == "text":
-            if fill in (None, "none", ""):
-                layer_id = elem.get("id") or "?"
-                violations.append({
-                    "severity": "error",
-                    "check": "text_no_fill",
-                    "object": layer_id,
-                    "message": (
-                        f"<text> element id='{layer_id}' has fill='{fill}'; "
-                        f"glyphs will render as thick outlines, not filled. "
-                        f"Set fill_color on the SVG layer when exporting."
-                    ),
-                })
-
+        if elem.tag.replace(_SVG_NS, "") == "text" and fill in (None, "none", ""):
+            layer_id = elem.get("id") or "?"
+            violations.append({
+                "severity": "error",
+                "check": "text_no_fill",
+                "object": layer_id,
+                "message": (
+                    f"<text> element id='{layer_id}' has fill='{fill}'; "
+                    f"glyphs will render as thick outlines, not filled. "
+                    f"Set fill_color on the SVG layer when exporting."
+                ),
+            })
         for child in elem:
             walk(child, fill)
 
-    walk(root, None)
+    walk(tree.getroot(), None)
 
-    # Sidecar annotation checks (label-vs-measured, leader-strikethrough).
     sidecar = os.path.splitext(svg_path)[0] + ".dims.json"
     if os.path.isfile(sidecar):
         try:
             with open(sidecar) as f:
-                annotations = _json.load(f)
-            violations.extend(_lint_annotations(annotations, objects=None))
+                annotations = json.load(f)
+            for name, meta in annotations.items():
+                dim = DimResult(
+                    shape=None,
+                    label_str=meta.get("label_str", ""),
+                    measured_length=meta.get("measured_length") or 0.0,
+                )
+                for issue in _helper_lint([dim]):
+                    if issue.code == "label_vs_measured":
+                        violations.append(_violation(issue, name))
         except Exception as exc:
             violations.append({
                 "severity": "warning",
@@ -307,8 +240,5 @@ def lint_drawing(session, svg_path: str = "") -> str:
     Returns:
         JSON: {"violations": [{severity, check, object, message}, ...]}
     """
-    if svg_path:
-        violations = _lint_svg(svg_path)
-    else:
-        violations = _lint_session(session)
+    violations = _lint_svg(svg_path) if svg_path else _lint_session(session)
     return json.dumps({"violations": violations}, indent=2)

--- a/tests/test_drawing_tooling.py
+++ b/tests/test_drawing_tooling.py
@@ -87,6 +87,23 @@ annotate(b, "dim_b")
         out = self._run(session)
         assert any(v["check"] == "annotation_overlap" for v in out["violations"])
 
+    def test_surfaces_geometry_precise_interference(self, session):
+        # find_interferences checks are now exposed through the MCP tool: a
+        # stacked dim whose extension line spears a neighbour's label.
+        session.execute("""
+from build123d import *
+from build123d_drafting import place_dims
+draft = Draft(font_size=2.5, decimal_precision=1)
+dims = place_dims([
+    ((-18, -10, 0), (18, -10, 0), "below", "36"),
+    ((-18, -10, 0), (0, -10, 0), "below", "18"),
+], draft, base_distance=6)
+for i, d in enumerate(dims):
+    annotate(d, f"dim_{i}")
+""")
+        checks = {v["check"] for v in self._run(session)["violations"]}
+        assert "line_pierces_label" in checks
+
     def test_no_false_overlap_for_separated_dims(self, session):
         # Dims stacked at distinct offsets must not be flagged.
         session.execute("""

--- a/uv.lock
+++ b/uv.lock
@@ -99,14 +99,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.1.9"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/6b/d3086c5a29fcb993ca45387a9c42d6c870130a9841c7340c0747ba2874c8/build123d_drafting_helpers-0.1.9.tar.gz", hash = "sha256:846ee0bdec636d1ccd8e248bdfbd30a6845fe7e9fc04308926be8c238b514f79", size = 40822, upload-time = "2026-06-01T05:56:29.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/ed/4bb4737fa805a874274f35db0aa4f7de4dabea092b6d1bd131e80f1a012b/build123d_drafting_helpers-0.1.10.tar.gz", hash = "sha256:ee179814c9c78c9c513f0aad80baf00aeb46b0391dcbe5c11ad476dc0b4bfa63", size = 41354, upload-time = "2026-06-01T06:48:27.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/6d/35f76c6706e0deb9f72920e35e8cbd9f8c540395a2fe3f4673a89ac91216/build123d_drafting_helpers-0.1.9-py3-none-any.whl", hash = "sha256:f7513f52c61262c031fc6b4a788b2673e9c3da6c937ce7032d60ebc850f0b570", size = 34000, upload-time = "2026-06-01T05:56:28.733Z" },
+    { url = "https://files.pythonhosted.org/packages/af/29/4eceaa7fe4b550352f13b5250d749c074c311e0689b60b60de44308b2a2b/build123d_drafting_helpers-0.1.10-py3-none-any.whl", hash = "sha256:9dfef8da9ddcff02b5b8b825663aabe8bd634ca564578ed3213e5985244fd33b", size = 34214, upload-time = "2026-06-01T06:48:25.748Z" },
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ dev = [
 requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.1.9" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.1.10" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]


### PR DESCRIPTION
Makes the MCP `lint_drawing` tool **reuse** the drafting helpers instead of maintaining a second copy of the geometry-check logic — the consolidation discussed in review.

## What changed
Session-mode lint now:
1. reconstructs `DimResult` / `CenterlineResult` from `session.drawing_annotations` + `session.objects`;
2. calls `build123d_drafting.lint_drawing()` + `find_interferences()`;
3. maps each `LintIssue.code` → the violation `check`.

The duplicated **label-vs-measured / annotation-overlap / centerline** logic is **deleted**. As a bonus, the geometry-precise checks the MCP never had — **`line_pierces_label`, `redundant_lines`, `labels_overlap`** — now surface through the tool.

## Contract preserved
- Per-item checks are run one annotation at a time so the violation keeps the **session object name** (`object == "wrong_dim"`).
- The MCP elevates `label_vs_measured` to **severity `error`** in its own mapping.
- `check` codes are unchanged (the helper codes were named to match).

## Kept MCP-native (the helpers can't run these from stored data)
- **Leader elbow check** — the leader's *text* geometry isn't stored separately from its lines in the session, so the helper's text-bbox check can't be reconstructed. Documented; a clean follow-up is to add `LeaderResult.label_bbox` upstream.
- **Per-edge page-bounds check** — more detailed than the helper's `label_out_of_frame`.
- **SVG-export `text_no_fill`** — inspects the exported artifact, not the model; stays here (a separate follow-up will re-purpose it to the native-`<text>` guard).

## Verification
- Pin bumped `>=0.1.9` → `>=0.1.10` (for `LintIssue.code`); `uv.lock` re-locked.
- New test asserts the interference checks now surface via the MCP tool.
- **Full suite: 442 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)