### PR TITLE
refactor: delegate the leader lint check; re-purpose SVG check to native-text guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,21 @@
   `find_interferences()`, mapping each `LintIssue.code` to the violation `check`.
   Single source of truth — the duplicated label-vs-measured / overlap / centerline
   logic is gone. New geometry-precise checks (`line_pierces_label`, `redundant_lines`,
-  `labels_overlap`) are now surfaced through the MCP tool for the first time. The leader
-  elbow check and the per-edge page-bounds check stay MCP-native (leader text geometry
-  isn't stored separately); the SVG-export `text_no_fill` check is unchanged.
+  `labels_overlap`) are now surfaced through the MCP tool for the first time. The
+  **leader check is also delegated** — reconstructed from the stored `label_bbox`
+  (which fixes a latent bug: the old whole-leader-bbox check always contained the
+  elbow, so it could false-fire on every leader). Only the per-edge page-bounds check
+  stays MCP-native.
+- **SVG-mode check re-purposed** `text_no_fill` → **`native_svg_text`**: build123d
+  renders text as glyph *paths*, never `<text>`, so any `<text>` in an exported SVG
+  means it won't survive a DXF export / won't scale — flagged regardless of fill.
 
 ### Dependencies
 
-- **`build123d-drafting-helpers` pin bumped `>=0.1.7` → `>=0.1.10`**, picking up the
+- **`build123d-drafting-helpers` pin bumped `>=0.1.7` → `>=0.1.11`**, picking up the
   `surface_finish_mark` ISO-1302 fix, `add_to_layers()` SVG routing, `find_interferences()`
-  geometry-precise collision detection, `draft_preset()`, and `LintIssue.code`.
+  geometry-precise collision detection, `draft_preset()`, `LintIssue.code`, and
+  `LeaderResult.label_bbox`.
 
 ## v0.3.27 — 2026-05-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
-    "build123d-drafting-helpers>=0.1.10",
+    "build123d-drafting-helpers>=0.1.11",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -172,13 +172,16 @@ def view_axes(viewport_origin: list[float], viewport_up: list[float] = [0.0, 1.0
 def lint_drawing(svg_path: str = "") -> str:
     """Run structural drawing-quality checks and return JSON {violations: [...]}.
 
-    Session mode (default): scans session.objects + drawing_annotations for
-    label-vs-measured-length divergence (>0.5%, likely axis swap) and
-    leader-elbow-inside-label-bbox (line struck through text).
+    Session mode (default): reconstructs the session's annotations and delegates
+    to build123d-drafting-helpers (lint_drawing + find_interferences) — single
+    source of truth. Surfaces label-vs-measured divergence (axis swap), leader
+    line through its own label, annotation/label overlap, a witness/extension
+    line piercing a neighbour's label, redundant collinear lines, and page-bounds
+    overshoot.
 
-    SVG mode (svg_path set): scans an SVG file for layer-level pathologies
-    that only show up at export time — most importantly <text> elements with
-    fill='none' or no fill attribute (glyphs render as illegible thick outlines).
+    SVG mode (svg_path set): scans an SVG file for export-only pathologies — most
+    importantly native <text> elements (build123d renders glyph paths, so any
+    <text> won't DXF-export and won't scale with the model).
 
     Each violation is {severity, check, object, message}. Run this after major
     drawing additions; running it BEFORE rendering catches the bug at the source.

--- a/src/build123d_mcp/tools/lint_drawing.py
+++ b/src/build123d_mcp/tools/lint_drawing.py
@@ -9,8 +9,9 @@ Two modes:
      the stored data: the leader elbow check (leader text geometry isn't stored
      separately) and the per-edge page-bounds check.
 
-  2. SVG mode: scans an exported SVG for layer-level pathologies that only show
-     up at export time (text on a no-fill layer), plus sidecar label checks.
+  2. SVG mode: scans an exported SVG for export-only pathologies — native
+     `<text>` elements (build123d renders glyph paths, so any `<text>` won't
+     DXF-export) — plus sidecar label checks.
 
 The structured violation list is JSON so the LLM can iterate without rendering.
 Each violation's `check` is the helpers' stable `LintIssue.code`.
@@ -20,16 +21,18 @@ import os
 import re
 import xml.etree.ElementTree as ET
 
+from build123d import Compound
 from build123d_drafting import (
     CenterlineResult,
     DimResult,
+    LeaderResult,
     find_interferences,
     lint_drawing as _helper_lint,
 )
 
 # Checks that apply to a single annotation — run per-item so the violation can
 # carry the session object name (the helpers' issues only know the label text).
-_PER_ITEM_CODES = {"label_vs_measured", "dim_inside_part"}
+_PER_ITEM_CODES = {"label_vs_measured", "dim_inside_part", "leader_line_through_text"}
 
 # The MCP elevates these helper "warning"s to "error" in its own contract.
 _SEVERITY_OVERRIDE = {"label_vs_measured": "error"}
@@ -55,10 +58,10 @@ def _pair_object(issue, items) -> str:
 
 
 def _reconstruct(session):
-    """[(name, result)] for each dim/centerline annotation that has geometry.
+    """[(name, result)] for each annotation that can be linted from stored data.
 
-    Leaders are skipped here — their text geometry isn't stored separately, so
-    the leader check stays in `_lint_leaders`.
+    Leaders are reconstructed from the stored `label_bbox` + `elbow` (no live
+    text geometry needed — the helper's leader check prefers `label_bbox`).
     """
     items = []
     for name, meta in session.drawing_annotations.items():
@@ -69,7 +72,13 @@ def _reconstruct(session):
             items.append((name, CenterlineResult(shape=shape,
                                                  label_str=meta.get("label_str", ""))))
         elif meta.get("elbow") is not None:
-            continue  # leader — handled by _lint_leaders
+            items.append((name, LeaderResult(
+                lines=Compound(children=[]), text=Compound(children=[]),
+                label_str=meta.get("label_str", ""),
+                tip=tuple(meta.get("tip") or (0.0, 0.0)),
+                elbow=tuple(meta["elbow"]),
+                label_bbox=meta.get("label_bbox"),
+            )))
         else:
             items.append((name, DimResult(
                 shape=shape,
@@ -100,36 +109,11 @@ def _lint_session(session) -> list[dict]:
     for issue in find_interferences(results):
         violations.append(_violation(issue, _pair_object(issue, items)))
 
-    # MCP-native checks the helpers can't run from the stored data
-    violations += _lint_leaders(session)
+    # the one MCP-native check: per-edge page bounds (more detailed than the
+    # helper's label↔frame check).
     if session.drawing_page:
         violations += _lint_page_bounds(
             session.drawing_annotations, session.objects, session.drawing_page)
-    return violations
-
-
-def _lint_leaders(session) -> list[dict]:
-    """Leader elbow inside the label region — MCP-native because the leader's
-    text geometry isn't stored separately from its lines in the session."""
-    violations: list[dict] = []
-    for name, ann in session.drawing_annotations.items():
-        elbow = ann.get("elbow")
-        if not elbow or name not in session.objects:
-            continue
-        try:
-            bb = session.objects[name].bounding_box()
-            if bb.min.X <= elbow[0] <= bb.max.X and bb.min.Y <= elbow[1] <= bb.max.Y:
-                violations.append({
-                    "severity": "warning",
-                    "check": "leader_elbow_in_label",
-                    "object": name,
-                    "message": (
-                        f"leader elbow ({elbow[0]:.2f}, {elbow[1]:.2f}) "
-                        f"may be inside the label bbox"
-                    ),
-                })
-        except Exception:
-            pass
     return violations
 
 
@@ -171,7 +155,11 @@ _SVG_NS = "{http://www.w3.org/2000/svg}"
 def _lint_svg(svg_path: str) -> list[dict]:
     """Layer-level checks on an exported SVG file, plus sidecar label checks.
 
-    - text on a group with `fill='none'` renders glyphs as illegible outlines;
+    - **native `<text>` elements** — build123d renders text as filled glyph
+      *paths*, never `<text>`. So any `<text>` means the SVG was produced (or
+      post-processed) outside the geometry pipeline: it won't survive a DXF
+      export and won't scale with the model. Flag it (worse still when it also
+      has no fill, where it renders as illegible outlines).
     - label-vs-measured divergence from the `.dims.json` sidecar (no live
       geometry here, so the helper's per-item check is run on shape-less
       reconstructed `DimResult`s).
@@ -188,16 +176,20 @@ def _lint_svg(svg_path: str) -> list[dict]:
         m = re.search(r"fill:\s*([^;]+)", elem.get("style", ""))
         if m:
             fill = m.group(1).strip()
-        if elem.tag.replace(_SVG_NS, "") == "text" and fill in (None, "none", ""):
+        if elem.tag.replace(_SVG_NS, "") == "text":
             layer_id = elem.get("id") or "?"
+            no_fill = fill in (None, "none", "")
+            detail = (" and has no fill (renders as illegible outlines)"
+                      if no_fill else "")
             violations.append({
                 "severity": "error",
-                "check": "text_no_fill",
+                "check": "native_svg_text",
                 "object": layer_id,
                 "message": (
-                    f"<text> element id='{layer_id}' has fill='{fill}'; "
-                    f"glyphs will render as thick outlines, not filled. "
-                    f"Set fill_color on the SVG layer when exporting."
+                    f"native <text> element id='{layer_id}'{detail}. build123d "
+                    f"renders text as filled glyph paths, not <text> — native SVG "
+                    f"text won't export to DXF and won't scale with the model. "
+                    f"Re-export the label from build123d geometry."
                 ),
             })
         for child in elem:

--- a/tests/test_drawing_tooling.py
+++ b/tests/test_drawing_tooling.py
@@ -104,6 +104,18 @@ for i, d in enumerate(dims):
         checks = {v["check"] for v in self._run(session)["violations"]}
         assert "line_pierces_label" in checks
 
+    def test_clean_leader_no_false_violation(self, session):
+        # The leader check is delegated to the helpers via the stored label_bbox.
+        # A correctly-built leader (line stops before the label) must not flag.
+        session.execute("""
+from build123d import *
+from build123d_drafting import leader
+draft = Draft(font_size=2.5, decimal_precision=1)
+ld = leader((0, 0, 0), (20, 12, 0), "Ø5 H7", draft)
+annotate(ld, "callout")
+""")
+        assert self._run(session)["violations"] == []
+
     def test_no_false_overlap_for_separated_dims(self, session):
         # Dims stacked at distinct offsets must not be flagged.
         session.execute("""
@@ -171,7 +183,9 @@ annotate(d, "dim")
 # ---------------------------------------------------------------------------
 
 class TestLintDrawingSvg:
-    def test_flags_text_without_fill(self, tmp_path):
+    def test_flags_native_text(self, tmp_path):
+        # build123d never emits <text> (it renders glyph paths), so any <text>
+        # means native SVG text that won't DXF-export — flagged regardless of fill.
         from build123d_mcp.tools.lint_drawing import lint_drawing
         svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
   <g id="dims" fill="none">
@@ -181,13 +195,14 @@ class TestLintDrawingSvg:
         p = tmp_path / "bad.svg"
         p.write_text(svg)
         out = json.loads(lint_drawing(None, str(p)))
-        assert any(v["check"] == "text_no_fill" for v in out["violations"])
+        assert any(v["check"] == "native_svg_text" for v in out["violations"])
 
     def test_clean_svg_no_violations(self, tmp_path):
+        # A real build123d export uses <path> glyphs, not <text> — clean.
         from build123d_mcp.tools.lint_drawing import lint_drawing
         svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
-  <g id="dims" fill="blue">
-    <text id="label" x="10" y="20" fill="blue">40</text>
+  <g id="dims" fill="black">
+    <path id="glyph" d="M10,10 L20,10 L20,20 Z"/>
   </g>
 </svg>'''
         p = tmp_path / "good.svg"

--- a/uv.lock
+++ b/uv.lock
@@ -99,14 +99,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.1.10"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/ed/4bb4737fa805a874274f35db0aa4f7de4dabea092b6d1bd131e80f1a012b/build123d_drafting_helpers-0.1.10.tar.gz", hash = "sha256:ee179814c9c78c9c513f0aad80baf00aeb46b0391dcbe5c11ad476dc0b4bfa63", size = 41354, upload-time = "2026-06-01T06:48:27.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/4f/fb06b6ad4e996365da8894d4ce7298e6a54543867614ab1ef1948dc3002c/build123d_drafting_helpers-0.1.11.tar.gz", hash = "sha256:b4a2d07a31ddb12feef636c9b9109824bddf1878a1c3d3d9e202a2554c6fc26e", size = 41953, upload-time = "2026-06-01T08:31:33.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/29/4eceaa7fe4b550352f13b5250d749c074c311e0689b60b60de44308b2a2b/build123d_drafting_helpers-0.1.10-py3-none-any.whl", hash = "sha256:9dfef8da9ddcff02b5b8b825663aabe8bd634ca564578ed3213e5985244fd33b", size = 34214, upload-time = "2026-06-01T06:48:25.748Z" },
+    { url = "https://files.pythonhosted.org/packages/17/c3/c7c41901a3de9772bae2103a57a169bef0e1dc7a7ced78d9877514329d92/build123d_drafting_helpers-0.1.11-py3-none-any.whl", hash = "sha256:01afd96570924a9180400710317d4c6bd8f861ad54d931ba318faa3e1d8a30c0", size = 34382, upload-time = "2026-06-01T08:31:32.069Z" },
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ dev = [
 requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.1.10" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.1.11" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]


### PR DESCRIPTION
The two follow-ups from #141, now unblocked by helpers **0.1.11** (`LeaderResult.label_bbox`).

## 1. Leader check delegated
The leader elbow check no longer lives in the MCP. It reconstructs a `LeaderResult` from the stored `label_bbox` + `elbow` and lets the helper's `_lint_leader` run (`leader_line_through_text`). `_lint_leaders` is deleted.

This also **fixes a latent bug**: the old MCP check used the *whole leader* bbox, which always contains the elbow — so it could false-fire on every leader. A correctly built leader now produces **no** violation (new regression test).

After this, the only MCP-native session check is the per-edge **page-bounds** overshoot (more detailed than the helper's `label↔frame`).

## 2. SVG check re-purposed: `text_no_fill` → `native_svg_text`
build123d renders text as filled glyph **paths**, never `<text>`. So *any* `<text>` in an exported SVG means it was produced outside the geometry pipeline — it **won't DXF-export and won't scale** with the model. The check now flags any `<text>` (regardless of fill; worse when also unfilled). SVG tests updated: the "bad" fixture asserts `native_svg_text`; the "clean" fixture uses `<path>` glyphs.

## Verification
- Pin `>=0.1.10` → `>=0.1.11`, `uv.lock` re-locked.
- New tests: clean leader has no violation; native `<text>` flagged; `<path>`-only SVG clean.
- **Full suite: 442 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)