### PR TITLE
deps: bump build123d-drafting-helpers to >=0.1.13 (v0.3.29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.29 — 2026-06-01
+
+### Dependencies
+
+- **`build123d-drafting-helpers` pin bumped `>=0.1.11` → `>=0.1.13`**, picking up the
+  GD&T completions: basic (theoretically-exact) dimensions (`dim_linear(basic=True)`),
+  datum targets (`datum_target`), composite feature control frames
+  (`composite_feature_control_frame`), hole callouts (`hole_callout` — ⌀ ⌴ ⌵ ↧),
+  all-around / all-over leaders (`leader(all_around=…)`), and the
+  `find_interferences(obstacles=…)` label-over-geometry check with the vertical-dim
+  `label_bbox` fix. Drawing scripts run via `execute` can now use these directly.
+
 ## v0.3.28 — 2026-06-01
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
-    "build123d-drafting-helpers>=0.1.11",
+    "build123d-drafting-helpers>=0.1.13",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -99,14 +99,14 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.1.11"
+version = "0.1.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/4f/fb06b6ad4e996365da8894d4ce7298e6a54543867614ab1ef1948dc3002c/build123d_drafting_helpers-0.1.11.tar.gz", hash = "sha256:b4a2d07a31ddb12feef636c9b9109824bddf1878a1c3d3d9e202a2554c6fc26e", size = 41953, upload-time = "2026-06-01T08:31:33.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/ad/25359a28efaa52b1e902282d5be2528b2dcdf4025b168d592fccb59dbd31/build123d_drafting_helpers-0.1.13.tar.gz", hash = "sha256:bbdb9880ec6050162a2b4c2ac22107b94ab70a82a4f8e766932702ab96a59f9e", size = 50197, upload-time = "2026-06-01T13:22:54.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/c3/c7c41901a3de9772bae2103a57a169bef0e1dc7a7ced78d9877514329d92/build123d_drafting_helpers-0.1.11-py3-none-any.whl", hash = "sha256:01afd96570924a9180400710317d4c6bd8f861ad54d931ba318faa3e1d8a30c0", size = 34382, upload-time = "2026-06-01T08:31:32.069Z" },
+    { url = "https://files.pythonhosted.org/packages/33/4b/099d3d6fa0cf61f5fb27dbfa4084c034df888bd8c0e58f5ffccab1318264/build123d_drafting_helpers-0.1.13-py3-none-any.whl", hash = "sha256:87f0b61c45e0dea9c80e0f14dc21b7e6579dcc74e89a2d62e4a7f4d9ce943f97", size = 39087, upload-time = "2026-06-01T13:22:52.778Z" },
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ dev = [
 requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.1.11" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.1.13" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]


### PR DESCRIPTION
Bumps the helpers pin `>=0.1.11` → `>=0.1.13` so the server ships with the completed GD&T helper set.

### Picks up (helpers 0.1.13)
- Basic (theoretically-exact) dimensions — `dim_linear(basic=True)`
- Datum targets — `datum_target`
- Composite feature control frames — `composite_feature_control_frame`
- Hole callouts — `hole_callout` (⌀ ⌴ ⌵ ↧)
- All-around / all-over leaders — `leader(all_around=…)`
- `find_interferences(obstacles=…)` + vertical-dim `label_bbox` fix

Drawing scripts run via `execute` can use these directly. `uv.lock` updated to resolve 0.1.13; CHANGELOG entry added for **v0.3.29**.

Full MCP suite **443 passing** against 0.1.13. After merge: `gh release create v0.3.29 --generate-notes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)