### PR TITLE
fix: improve allow-imports guidance + PYTHONPATH package test (closes #150)

### DIFF
--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -249,8 +249,12 @@ def _check_module(dotted_name: str) -> None:
             f"This blocks filesystem (os, pathlib, shutil), network (socket, urllib, "
             f"requests), and shell access (subprocess). "
             f"Permitted: {permitted}. "
-            f"To allow project-local packages add their top-level name to "
-            f"--allow-imports or the BUILD123D_ALLOW_IMPORTS env var."
+            f"To allow project-local packages, add their top-level name to the "
+            f"server's --allow-imports flag or BUILD123D_ALLOW_IMPORTS env var "
+            f"(e.g. --allow-imports my_package). The package must be on PYTHONPATH "
+            f"or installed in the server's environment. Transitive dependencies of "
+            f"the allowed package also need to be on the allowlist or in the stdlib "
+            f"safe list above."
         )
 
 

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -248,7 +248,9 @@ def _check_module(dotted_name: str) -> None:
             f"Import of '{dotted_name}' is not allowed. "
             f"This blocks filesystem (os, pathlib, shutil), network (socket, urllib, "
             f"requests), and shell access (subprocess). "
-            f"Permitted: {permitted}"
+            f"Permitted: {permitted}. "
+            f"To allow project-local packages add their top-level name to "
+            f"--allow-imports or the BUILD123D_ALLOW_IMPORTS env var."
         )
 
 
@@ -292,7 +294,13 @@ def make_restricted_builtins() -> dict[str, Any]:
             permitted = sorted(IMPORT_ALLOWLIST | EXTRA_ALLOWED_IMPORTS)
             raise ImportError(
                 f"Import of '{name}' is not allowed. "
-                f"Permitted: {permitted}"
+                f"Permitted: {permitted}. "
+                f"To allow project-local packages, add their top-level name to the "
+                f"server's --allow-imports flag or BUILD123D_ALLOW_IMPORTS env var "
+                f"(e.g. --allow-imports my_package). The package must be on PYTHONPATH "
+                f"or installed in the server's environment. Transitive dependencies of "
+                f"the allowed package also need to be on the allowlist or in the stdlib "
+                f"safe list above."
             )
         return _original_import(name, *args, **kwargs)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -256,7 +256,6 @@ def test_pythonpath_package_importable_when_allowlisted(monkeypatch, tmp_path):
     Regression for issue #150: the runtime __import__ wrapper should honour
     EXTRA_ALLOWED_IMPORTS and let _original_import resolve the package from
     sys.path (which includes PYTHONPATH)."""
-    import sys
     import build123d_mcp.security as _sec
 
     # Create a minimal package in a temp directory (not installed).
@@ -278,16 +277,24 @@ def test_pythonpath_package_importable_when_allowlisted(monkeypatch, tmp_path):
     assert "not allowed" not in result.lower()
 
 
-def test_blocked_import_error_message_mentions_allow_imports(monkeypatch):
-    """The ImportError message for a blocked module should tell the user how
-    to add it to the allowlist via --allow-imports / BUILD123D_ALLOW_IMPORTS."""
-    import build123d_mcp.security as _sec
-    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+def test_blocked_import_error_message_mentions_allow_imports():
+    """The Layer-1 AST error message for a blocked module should tell the user
+    how to add it to the allowlist via --allow-imports / BUILD123D_ALLOW_IMPORTS."""
     s = Session()
     result = s.execute("import subprocess")
     assert "--allow-imports" in result or "BUILD123D_ALLOW_IMPORTS" in result, (
         "error message should mention how to add the module to the allowlist"
     )
+
+
+def test_runtime_blocked_import_message_mentions_allow_imports():
+    """The Layer-2 _safe_import error message should also mention --allow-imports.
+    Exercises _safe_import directly, bypassing the AST check (Layer 1)."""
+    from build123d_mcp.security import make_restricted_builtins
+    builtins = make_restricted_builtins()
+    safe_import = builtins["__import__"]
+    with pytest.raises(ImportError, match="--allow-imports|BUILD123D_ALLOW_IMPORTS"):
+        safe_import("subprocess")
 
 
 def test_dir_allowed(session):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -250,6 +250,46 @@ def test_extras_message_lists_added_modules(monkeypatch):
     assert "'os'" in result
 
 
+def test_pythonpath_package_importable_when_allowlisted(monkeypatch, tmp_path):
+    """A package on PYTHONPATH (not installed) becomes importable when its
+    root name is added to the allowlist via --allow-imports / EXTRA_ALLOWED_IMPORTS.
+    Regression for issue #150: the runtime __import__ wrapper should honour
+    EXTRA_ALLOWED_IMPORTS and let _original_import resolve the package from
+    sys.path (which includes PYTHONPATH)."""
+    import sys
+    import build123d_mcp.security as _sec
+
+    # Create a minimal package in a temp directory (not installed).
+    pkg_dir = tmp_path / "my_test_parts"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("VALUE = 42\n")
+
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    _sec.EXTRA_ALLOWED_IMPORTS.add("my_test_parts")
+    # Add the tmp_path to sys.path so Python can find the package.
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    s = Session()
+    result = s.execute(
+        "from my_test_parts import VALUE\n"
+        "assert VALUE == 42, f'expected 42, got {VALUE}'"
+    )
+    assert "Error" not in result, f"PYTHONPATH package import failed: {result}"
+    assert "not allowed" not in result.lower()
+
+
+def test_blocked_import_error_message_mentions_allow_imports(monkeypatch):
+    """The ImportError message for a blocked module should tell the user how
+    to add it to the allowlist via --allow-imports / BUILD123D_ALLOW_IMPORTS."""
+    import build123d_mcp.security as _sec
+    monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
+    s = Session()
+    result = s.execute("import subprocess")
+    assert "--allow-imports" in result or "BUILD123D_ALLOW_IMPORTS" in result, (
+        "error message should mention how to add the module to the allowlist"
+    )
+
+
 def test_dir_allowed(session):
     result = execute_code(session, "attrs = dir([])")
     assert "Error" not in result


### PR DESCRIPTION
Closes #150.

## What was wrong
The `--allow-imports` / `BUILD123D_ALLOW_IMPORTS` mechanism for project-local packages **already worked correctly** end-to-end. The `AST` check and the runtime `__import__` wrapper both honour `EXTRA_ALLOWED_IMPORTS`, and `spawn`-mode worker processes inherit `sys.path` (including `PYTHONPATH`) from the parent. The bug was a **discoverability problem**: neither error message told the user how to add a package to the allowlist.

## Changes
- **`SecurityError` (AST check) message**: now mentions `--allow-imports` and `BUILD123D_ALLOW_IMPORTS`.
- **`ImportError` (runtime check) message**: same, plus a note about transitive dependencies and PYTHONPATH.
- **`test_pythonpath_package_importable_when_allowlisted`**: creates a minimal package in `tmp_path` (not installed), adds it to `EXTRA_ALLOWED_IMPORTS`, prepends to `sys.path`, and confirms `from my_test_parts import VALUE` works inside `execute()` — proves the end-to-end path.
- **`test_blocked_import_error_message_mentions_allow_imports`**: verifies the error message contains the how-to-fix guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)