### PR TITLE
feat: expose install_skill as MCP tool + resource, add multi-agent targets

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -541,6 +541,32 @@ def build123d_bd_warehouse() -> str:
     return build_bd_warehouse_text()
 
 
+@mcp.resource("build123d://skill/drawing", mime_type="text/plain",
+              description="The b123d-drawing engineering workflow skill: step-by-step guide for creating multi-view engineering drawings from build123d geometry (views, scale, annotation, lint, SVG/DXF/PDF export).")
+def build123d_drawing_skill() -> str:
+    """b123d-drawing engineering workflow skill."""
+    from build123d_mcp.tools.install_skill import _load_raw
+    return _load_raw()
+
+
+@mcp.tool()
+def install_skill(target: str = "claude", force: bool = False) -> str:
+    """Copy the b123d-drawing engineering drawing skill into the current project.
+
+    Writes the appropriate config file for the requested agent so the
+    step-by-step drawing workflow is available in future sessions.
+
+    target: one of "claude" (default), "agents-md", "cursor", "windsurf"
+      - claude     → .claude/skills/b123d-drawing/SKILL.md  (Claude Code)
+      - agents-md  → AGENTS.md  (Codex CLI, Antigravity, GitHub Copilot, Cline)
+      - cursor     → .cursor/rules/b123d-drawing.mdc
+      - windsurf   → .windsurfrules
+    force: overwrite existing installation (default False)
+    """
+    from build123d_mcp.tools.install_skill import install_skill as _install
+    return _install(target=target, force=force)
+
+
 @mcp.prompt(
     name="start-cad-session",
     description="Prime a new CAD design session with the task description and workflow reminders.",
@@ -585,28 +611,26 @@ Call workflow_hints() if unsure which tool to use next.
 def _cmd_install_skill(argv: list) -> None:
     import argparse
     import sys
-    from importlib.resources import files
-    from pathlib import Path
+    from build123d_mcp.tools.install_skill import TARGETS, install_skill as _install
 
     p = argparse.ArgumentParser(
         prog="build123d-mcp install-skill",
-        description="Copy the b123d-drawing Claude Code skill into .claude/skills/ of the current directory.",
+        description="Copy the b123d-drawing skill into the current project for the specified agent.",
     )
-    p.add_argument("--force", action="store_true", help="Overwrite existing skill files without prompting")
+    p.add_argument(
+        "--target",
+        choices=TARGETS,
+        default="claude",
+        help="Agent to install for (default: claude)",
+    )
+    p.add_argument("--force", action="store_true", help="Overwrite existing installation")
     args = p.parse_args(argv)
 
-    dest = Path.cwd() / ".claude" / "skills" / "b123d-drawing"
-    if dest.exists() and not args.force:
-        print(f"Skill already installed at {dest}\nUse --force to overwrite.", file=sys.stderr)
+    result = _install(target=args.target, force=args.force)
+    if "already" in result.lower() and not args.force:
+        print(result, file=sys.stderr)
         sys.exit(1)
-
-    skill_pkg = files("build123d_mcp") / "skills" / "b123d-drawing"
-    dest.mkdir(parents=True, exist_ok=True)
-    for fname in ["SKILL.md"]:
-        content = (skill_pkg / fname).read_text(encoding="utf-8")
-        (dest / fname).write_text(content, encoding="utf-8")
-
-    print(f"Installed b123d-drawing skill → {dest}")
+    print(result)
 
 
 def main():

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -1,0 +1,124 @@
+"""install_skill — write the b123d-drawing workflow to a project's agent config.
+
+Supports four targets:
+  claude     → .claude/skills/b123d-drawing/SKILL.md
+  agents-md  → AGENTS.md  (Codex CLI, Antigravity, GitHub Copilot, Cline)
+  cursor     → .cursor/rules/b123d-drawing.mdc
+  windsurf   → .windsurfrules
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.resources import files
+from pathlib import Path
+
+TARGETS = ("claude", "agents-md", "cursor", "windsurf")
+
+# Delimiters used when appending to shared files (AGENTS.md, .windsurfrules)
+_START = "<!-- b123d-drawing:start -->"
+_END   = "<!-- b123d-drawing:end -->"
+
+
+def _load_raw() -> str:
+    return (files("build123d_mcp") / "skills" / "b123d-drawing" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _strip_claude_markers(text: str) -> str:
+    """Remove Claude Code-specific inline markers that other agents don't understand."""
+    # [SEND: /tmp/foo.png]  →  show the rendered image at /tmp/foo.png to the user
+    text = re.sub(
+        r'\[SEND:\s*([^\]]+)\]',
+        r'(show the rendered image at \1 to the user)',
+        text,
+    )
+    # [ASK: question | opt1 | opt2]  →  ask the user: question (opt1 / opt2)
+    def _ask_replace(m: re.Match) -> str:
+        parts = [p.strip() for p in m.group(1).split("|")]
+        return f"(ask the user: {parts[0]}" + (f" — options: {', '.join(parts[1:])}" if len(parts) > 1 else "") + ")"
+    text = re.sub(r'\[ASK:\s*([^\]]+)\]', _ask_replace, text)
+    return text
+
+
+def _cursor_frontmatter() -> str:
+    return (
+        "---\n"
+        "description: Engineering drawing workflow for build123d geometry using the build123d-mcp MCP server\n"
+        "globs:\n"
+        "  - scripts/drawings/**\n"
+        "  - drawings/**\n"
+        "alwaysApply: false\n"
+        "---\n\n"
+    )
+
+
+def _wrap_section(content: str) -> str:
+    """Wrap content in delimiters for safe replacement in shared files."""
+    return f"{_START}\n{content.strip()}\n{_END}\n"
+
+
+def _replace_or_append(existing: str, new_section: str) -> str:
+    """Replace delimited section if present, else append."""
+    pattern = re.compile(
+        re.escape(_START) + r".*?" + re.escape(_END),
+        re.DOTALL,
+    )
+    if pattern.search(existing):
+        return pattern.sub(new_section.rstrip(), existing, count=1)
+    return existing.rstrip() + "\n\n" + new_section
+
+
+def install_skill(target: str = "claude", force: bool = False, cwd: Path | None = None) -> str:
+    """Install the b123d-drawing skill into the current project for *target*.
+
+    Returns a human-readable status string.
+    """
+    if target not in TARGETS:
+        return f"Unknown target '{target}'. Supported targets: {', '.join(TARGETS)}"
+
+    base = cwd or Path.cwd()
+    raw = _load_raw()
+    adapted = _strip_claude_markers(raw)
+
+    if target == "claude":
+        dest_dir = base / ".claude" / "skills" / "b123d-drawing"
+        dest_file = dest_dir / "SKILL.md"
+        if dest_file.exists() and not force:
+            return f"Already installed at {dest_file} — use force=True to overwrite."
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_file.write_text(raw, encoding="utf-8")
+        return f"Installed b123d-drawing skill for Claude Code → {dest_file}"
+
+    if target == "agents-md":
+        dest_file = base / "AGENTS.md"
+        section = _wrap_section(adapted)
+        if dest_file.exists():
+            existing = dest_file.read_text(encoding="utf-8")
+            if _START in existing and not force:
+                return f"b123d-drawing section already present in {dest_file} — use force=True to overwrite."
+            dest_file.write_text(_replace_or_append(existing, section), encoding="utf-8")
+        else:
+            dest_file.write_text(section, encoding="utf-8")
+        return f"Installed b123d-drawing skill into {dest_file} (Codex / Antigravity / Copilot / Cline)"
+
+    if target == "cursor":
+        dest_file = base / ".cursor" / "rules" / "b123d-drawing.mdc"
+        if dest_file.exists() and not force:
+            return f"Already installed at {dest_file} — use force=True to overwrite."
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        dest_file.write_text(_cursor_frontmatter() + adapted, encoding="utf-8")
+        return f"Installed b123d-drawing rule for Cursor → {dest_file}"
+
+    if target == "windsurf":
+        dest_file = base / ".windsurfrules"
+        section = _wrap_section(adapted)
+        if dest_file.exists():
+            existing = dest_file.read_text(encoding="utf-8")
+            if _START in existing and not force:
+                return f"b123d-drawing section already present in {dest_file} — use force=True to overwrite."
+            dest_file.write_text(_replace_or_append(existing, section), encoding="utf-8")
+        else:
+            dest_file.write_text(section, encoding="utf-8")
+        return f"Installed b123d-drawing skill into {dest_file} (Windsurf)"
+
+    return "Unreachable"  # mypy

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,0 +1,199 @@
+"""Tests for the install_skill tool (all four targets)."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from build123d_mcp.tools.install_skill import (
+    TARGETS,
+    _END,
+    _START,
+    _load_raw,
+    _strip_claude_markers,
+    install_skill,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _load_raw
+# ---------------------------------------------------------------------------
+
+def test_load_raw_returns_skill_content():
+    content = _load_raw()
+    assert "Engineering Drawing" in content
+    assert len(content) > 1000
+
+
+# ---------------------------------------------------------------------------
+# _strip_claude_markers
+# ---------------------------------------------------------------------------
+
+def test_strip_send_marker():
+    out = _strip_claude_markers("See [SEND: /tmp/foo.png] for the result.")
+    assert "[SEND:" not in out
+    assert "/tmp/foo.png" in out
+
+
+def test_strip_ask_marker_with_options():
+    out = _strip_claude_markers("[ASK: Which size? | A4 | A3]")
+    assert "[ASK:" not in out
+    assert "Which size?" in out
+    assert "A4" in out
+
+
+def test_strip_ask_marker_no_options():
+    out = _strip_claude_markers("[ASK: Ready to proceed?]")
+    assert "[ASK:" not in out
+    assert "Ready to proceed?" in out
+
+
+# ---------------------------------------------------------------------------
+# target: claude
+# ---------------------------------------------------------------------------
+
+def test_install_claude(tmp_path):
+    result = install_skill(target="claude", cwd=tmp_path)
+    dest = tmp_path / ".claude" / "skills" / "b123d-drawing" / "SKILL.md"
+    assert dest.exists()
+    assert "Engineering Drawing" in _read(dest)
+    assert "Installed" in result
+
+
+def test_install_claude_no_overwrite(tmp_path):
+    install_skill(target="claude", cwd=tmp_path)
+    result = install_skill(target="claude", cwd=tmp_path)
+    assert "already" in result.lower()
+
+
+def test_install_claude_force(tmp_path):
+    install_skill(target="claude", cwd=tmp_path)
+    result = install_skill(target="claude", force=True, cwd=tmp_path)
+    assert "Installed" in result
+
+
+def test_install_claude_preserves_claude_markers(tmp_path):
+    install_skill(target="claude", cwd=tmp_path)
+    dest = tmp_path / ".claude" / "skills" / "b123d-drawing" / "SKILL.md"
+    # Claude target keeps [SEND:] / [ASK:] markers intact
+    raw = _load_raw()
+    assert _read(dest) == raw
+
+
+# ---------------------------------------------------------------------------
+# target: agents-md
+# ---------------------------------------------------------------------------
+
+def test_install_agents_md_creates_file(tmp_path):
+    result = install_skill(target="agents-md", cwd=tmp_path)
+    dest = tmp_path / "AGENTS.md"
+    assert dest.exists()
+    assert _START in _read(dest)
+    assert _END in _read(dest)
+    assert "[SEND:" not in _read(dest)
+    assert "Installed" in result
+
+
+def test_install_agents_md_appends_to_existing(tmp_path):
+    existing = "# My project\n\nSome existing instructions.\n"
+    (tmp_path / "AGENTS.md").write_text(existing, encoding="utf-8")
+    install_skill(target="agents-md", cwd=tmp_path)
+    content = _read(tmp_path / "AGENTS.md")
+    assert "Some existing instructions." in content
+    assert _START in content
+
+
+def test_install_agents_md_no_overwrite(tmp_path):
+    install_skill(target="agents-md", cwd=tmp_path)
+    result = install_skill(target="agents-md", cwd=tmp_path)
+    assert "already" in result.lower()
+
+
+def test_install_agents_md_force_replaces_section(tmp_path):
+    install_skill(target="agents-md", cwd=tmp_path)
+    (tmp_path / "AGENTS.md").write_text(
+        _read(tmp_path / "AGENTS.md").replace("Engineering Drawing", "OLD CONTENT"),
+        encoding="utf-8",
+    )
+    install_skill(target="agents-md", force=True, cwd=tmp_path)
+    content = _read(tmp_path / "AGENTS.md")
+    assert "OLD CONTENT" not in content
+    assert "Engineering Drawing" in content
+    # Only one copy of the section
+    assert content.count(_START) == 1
+
+
+# ---------------------------------------------------------------------------
+# target: cursor
+# ---------------------------------------------------------------------------
+
+def test_install_cursor_creates_mdc(tmp_path):
+    result = install_skill(target="cursor", cwd=tmp_path)
+    dest = tmp_path / ".cursor" / "rules" / "b123d-drawing.mdc"
+    assert dest.exists()
+    content = _read(dest)
+    assert "alwaysApply: false" in content
+    assert "description:" in content
+    assert "Engineering Drawing" in content
+    assert "[SEND:" not in content
+    assert "Installed" in result
+
+
+def test_install_cursor_no_overwrite(tmp_path):
+    install_skill(target="cursor", cwd=tmp_path)
+    result = install_skill(target="cursor", cwd=tmp_path)
+    assert "already" in result.lower()
+
+
+def test_install_cursor_force(tmp_path):
+    install_skill(target="cursor", cwd=tmp_path)
+    result = install_skill(target="cursor", force=True, cwd=tmp_path)
+    assert "Installed" in result
+
+
+# ---------------------------------------------------------------------------
+# target: windsurf
+# ---------------------------------------------------------------------------
+
+def test_install_windsurf_creates_file(tmp_path):
+    result = install_skill(target="windsurf", cwd=tmp_path)
+    dest = tmp_path / ".windsurfrules"
+    assert dest.exists()
+    content = _read(dest)
+    assert _START in content
+    assert "[SEND:" not in content
+    assert "Installed" in result
+
+
+def test_install_windsurf_appends_to_existing(tmp_path):
+    existing = "# existing windsurf rules\n\nUse tabs.\n"
+    (tmp_path / ".windsurfrules").write_text(existing, encoding="utf-8")
+    install_skill(target="windsurf", cwd=tmp_path)
+    content = _read(tmp_path / ".windsurfrules")
+    assert "Use tabs." in content
+    assert _START in content
+
+
+def test_install_windsurf_force_replaces_section(tmp_path):
+    install_skill(target="windsurf", cwd=tmp_path)
+    install_skill(target="windsurf", force=True, cwd=tmp_path)
+    content = _read(tmp_path / ".windsurfrules")
+    assert content.count(_START) == 1
+
+
+# ---------------------------------------------------------------------------
+# unknown target
+# ---------------------------------------------------------------------------
+
+def test_unknown_target_returns_error():
+    result = install_skill(target="unknown-agent")
+    assert "Unknown target" in result
+    assert "unknown-agent" in result

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -584,7 +584,7 @@ def test_mcp_lists_all_tools():
                      "version", "last_error", "shape_compare", "repair_hints",
                      "import_cad_file", "cross_sections", "clearance", "inspect_drawing",
                      "view_axes", "lint_drawing", "render_drawing", "save_drawing_annotations",
-                     "align_check", "resolve", "script"}
+                     "align_check", "resolve", "script", "install_skill"}
 
 
 @_skip_mcp_on_win


### PR DESCRIPTION
## Summary

- Adds `install_skill(target, force=False)` as an **MCP tool** — any MCP-supporting agent (Claude Code, Codex CLI, Antigravity, Cursor, Windsurf) can call it to install the b123d-drawing workflow into the current project without a human running a CLI command
- Adds `build123d://skill/drawing` as an **MCP resource** — agents can read the full workflow without installing it
- CLI `install-skill` gains `--target` flag (defaults to `claude`, fully backward-compatible)

## Targets

| Target | File written | Agents |
|--------|-------------|--------|
| `claude` | `.claude/skills/b123d-drawing/SKILL.md` | Claude Code |
| `agents-md` | `AGENTS.md` | Codex CLI, Antigravity, GitHub Copilot, Cline |
| `cursor` | `.cursor/rules/b123d-drawing.mdc` | Cursor |
| `windsurf` | `.windsurfrules` | Windsurf |

Claude-specific markers (`[SEND:]`, `[ASK:]`) are stripped for non-Claude targets. Shared files use HTML comment delimiters for safe section replacement.

## Test plan
- [ ] 19 new unit tests covering all four targets, force/no-force, append, replace, marker stripping
- [ ] `test_mcp_lists_all_tools` updated for new tool
- [ ] Full suite: 472 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)