### PR TITLE
fix(install-skill): address post-merge review findings

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -633,8 +633,7 @@ def _cmd_install_skill(argv: list) -> None:
 
     from build123d_mcp.tools.install_skill import _dest_exists
     if not args.force and _dest_exists(args.target):
-        # Print what install_skill would say, then exit non-zero.
-        print(_install(target=args.target, force=False), file=sys.stderr)
+        print(f"Skill already installed for '{args.target}' — use --force to overwrite.", file=sys.stderr)
         sys.exit(1)
     print(_install(target=args.target, force=args.force))
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -470,6 +470,11 @@ BUILD123D-MCP WORKFLOW GUIDE
    default line_width=0.5 and arrow_length=3.0 make witness lines render as
    thick filled rectangles. Override every parameter, not just font_size.
 
+   For a guided multi-view drawing workflow (choose views, scale/page size,
+   annotate, lint, export SVG/DXF/PDF), call install_skill() to write a
+   step-by-step skill file into the current project, or read the skill directly
+   from the build123d://skill/drawing resource.
+
 11. IMPORTING EXTERNAL FILES
    After import_cad_file(), the shape is a named object — use render_view(objects="name")
    to visualise it. If the session also contains the original built shape at the same
@@ -626,11 +631,12 @@ def _cmd_install_skill(argv: list) -> None:
     p.add_argument("--force", action="store_true", help="Overwrite existing installation")
     args = p.parse_args(argv)
 
-    result = _install(target=args.target, force=args.force)
-    if "already" in result.lower() and not args.force:
-        print(result, file=sys.stderr)
+    from build123d_mcp.tools.install_skill import _dest_exists
+    if not args.force and _dest_exists(args.target):
+        # Print what install_skill would say, then exit non-zero.
+        print(_install(target=args.target, force=False), file=sys.stderr)
         sys.exit(1)
-    print(result)
+    print(_install(target=args.target, force=args.force))
 
 
 def main():

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -67,7 +67,11 @@ def _replace_or_append(existing: str, new_section: str) -> str:
 
 
 def _dest_exists(target: str, cwd: Path | None = None) -> bool:
-    """Return True if the skill is already installed for *target*."""
+    """Return True if the skill is already installed for *target*.
+
+    NOTE: the file-path logic here must stay in sync with install_skill() below.
+    If you change a target's destination path, update both functions.
+    """
     base = cwd or Path.cwd()
     if target == "claude":
         return (base / ".claude" / "skills" / "b123d-drawing" / "SKILL.md").exists()

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -44,9 +44,7 @@ def _cursor_frontmatter() -> str:
     return (
         "---\n"
         "description: Engineering drawing workflow for build123d geometry using the build123d-mcp MCP server\n"
-        "globs:\n"
-        "  - scripts/drawings/**\n"
-        "  - drawings/**\n"
+        'globs: "scripts/drawings/**, drawings/**"\n'
         "alwaysApply: false\n"
         "---\n\n"
     )
@@ -66,6 +64,22 @@ def _replace_or_append(existing: str, new_section: str) -> str:
     if pattern.search(existing):
         return pattern.sub(new_section.rstrip(), existing, count=1)
     return existing.rstrip() + "\n\n" + new_section
+
+
+def _dest_exists(target: str, cwd: Path | None = None) -> bool:
+    """Return True if the skill is already installed for *target*."""
+    base = cwd or Path.cwd()
+    if target == "claude":
+        return (base / ".claude" / "skills" / "b123d-drawing" / "SKILL.md").exists()
+    if target == "agents-md":
+        f = base / "AGENTS.md"
+        return f.exists() and _START in f.read_text(encoding="utf-8")
+    if target == "cursor":
+        return (base / ".cursor" / "rules" / "b123d-drawing.mdc").exists()
+    if target == "windsurf":
+        f = base / ".windsurfrules"
+        return f.exists() and _START in f.read_text(encoding="utf-8")
+    return False
 
 
 def install_skill(target: str = "claude", force: bool = False, cwd: Path | None = None) -> str:

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -1,14 +1,12 @@
 """Tests for the install_skill tool (all four targets)."""
 
-import re
 from pathlib import Path
-
-import pytest
 
 from build123d_mcp.tools.install_skill import (
     TARGETS,
     _END,
     _START,
+    _dest_exists,
     _load_raw,
     _strip_claude_markers,
     install_skill,
@@ -145,6 +143,9 @@ def test_install_cursor_creates_mdc(tmp_path):
     assert "Engineering Drawing" in content
     assert "[SEND:" not in content
     assert "Installed" in result
+    # globs must be a quoted string, not a YAML block list
+    assert 'globs: "' in content
+    assert "  - " not in content.split("---")[1]  # no YAML list items in frontmatter
 
 
 def test_install_cursor_no_overwrite(tmp_path):
@@ -187,6 +188,25 @@ def test_install_windsurf_force_replaces_section(tmp_path):
     install_skill(target="windsurf", force=True, cwd=tmp_path)
     content = _read(tmp_path / ".windsurfrules")
     assert content.count(_START) == 1
+
+
+# ---------------------------------------------------------------------------
+# _dest_exists
+# ---------------------------------------------------------------------------
+
+def test_dest_exists_false_before_install(tmp_path):
+    for target in TARGETS:
+        assert not _dest_exists(target, cwd=tmp_path)
+
+
+def test_dest_exists_true_after_install(tmp_path):
+    for target in TARGETS:
+        install_skill(target=target, cwd=tmp_path)
+        assert _dest_exists(target, cwd=tmp_path)
+
+
+def test_dest_exists_unknown_target():
+    assert not _dest_exists("unknown")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Five fixes from post-merge review of #156:

| # | Issue | Fix |
|---|-------|-----|
| 1 | Cursor `.mdc` `globs` used YAML block list — invalid in Cursor frontmatter, silently breaks path scoping | Changed to quoted string `"scripts/drawings/**, drawings/**"` |
| 2 | CLI exit detection used `"already" in result.lower()` — fragile if message wording changes | Added `_dest_exists(target, cwd)` helper; CLI now pre-checks before calling install |
| 3 | `pytest` unused import in test file | Removed |
| 4 | `install_skill` not mentioned in `workflow_hints()` — agents asking about drawing setup wouldn't discover it | Added pointer in the 2D drawings section |
| 5 | `re` unused import in test file | Removed |

## Test plan
- [ ] 22 passing (3 new `_dest_exists` tests added)
- [ ] Full suite clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)