### PR TITLE
fix(execute): append var summary so repeated similar calls produce distinct output

### DIFF
--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -497,13 +497,17 @@ class Session:
         Shapes, functions, modules, and private names are excluded — shapes are
         already reported by the shape diagnostic.
         """
+        _SCALAR = (bool, int, float, complex, str, bytes)
         _sentinel = object()
         changed = []
         for k in sorted(self.namespace):
             if k in _INJECTED or k.startswith("_"):
                 continue
             v = self.namespace[k]
-            if not isinstance(v, (bool, int, float, complex, str, bytes, tuple)):
+            if isinstance(v, tuple):
+                if not all(isinstance(e, _SCALAR) for e in v):
+                    continue
+            elif not isinstance(v, _SCALAR):
                 continue
             old = before.get(k, _sentinel)
             try:

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -393,6 +393,15 @@ class Session:
                 output = output.rstrip("\n") + "\n" + diag
             for w in warnings:
                 output += "\n" + w
+
+        # Append a summary of new/changed scalar variables so the caller can verify
+        # that assignments took effect. This makes each execution's output distinct
+        # even when the code structure is similar, preventing stale context references
+        # from being silently mistaken for a successful re-run with updated values.
+        var_summary = self._summarise_var_changes(values_before)
+        if var_summary:
+            output = output.rstrip("\n") + "\n# vars: " + var_summary
+
         return output
 
     def _rollback_namespace(self, values_before: dict[str, Any]) -> None:
@@ -480,6 +489,33 @@ class Session:
         self.current_shape = snap["current_shape"]
         self.objects.clear()
         self.objects.update(snap["objects"])
+
+    def _summarise_var_changes(self, before: dict) -> str:
+        """Return a compact summary of scalar variables added or changed since *before*.
+
+        Only covers simple value types (bool, int, float, complex, str, tuple).
+        Shapes, functions, modules, and private names are excluded — shapes are
+        already reported by the shape diagnostic.
+        """
+        _sentinel = object()
+        changed = []
+        for k in sorted(self.namespace):
+            if k in _INJECTED or k.startswith("_"):
+                continue
+            v = self.namespace[k]
+            if not isinstance(v, (bool, int, float, complex, str, bytes, tuple)):
+                continue
+            old = before.get(k, _sentinel)
+            try:
+                same = old is not _sentinel and old == v
+            except Exception:
+                same = False
+            if not same:
+                r = repr(v)
+                if len(r) > 60:
+                    r = r[:57] + "..."
+                changed.append(f"{k}={r}")
+        return ", ".join(changed)
 
     def reset(self) -> None:
         self.namespace.clear()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -114,6 +114,24 @@ def test_execute_var_summary_absent_on_error(session):
     assert "# vars:" not in result
 
 
+def test_execute_var_summary_tuple_of_scalars_included(session):
+    result = execute_code(session, "pt = (1.0, 2.0, 3.0)")
+    assert "pt=(1.0, 2.0, 3.0)" in result
+
+
+def test_execute_var_summary_tuple_of_shapes_excluded(session):
+    result = execute_code(session, "from build123d import *\nt = (Box(1,1,1), Box(2,2,2))")
+    var_line = next((l for l in result.splitlines() if l.startswith("# vars:")), "")
+    assert "t=" not in var_line
+
+
+def test_execute_var_summary_long_repr_truncated(session):
+    result = execute_code(session, "s = 'x' * 100")
+    var_line = next((l for l in result.splitlines() if l.startswith("# vars:")), "")
+    assert "..." in var_line
+    assert len(var_line) < 200
+
+
 def test_execute_creates_shape(session):
     execute_code(session, "result = Box(10, 10, 10)")
     assert session.current_shape is not None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -70,6 +70,50 @@ def test_execute_success_has_no_hint(session):
     assert "Hint:" not in result
 
 
+# --- var summary ---
+
+def test_execute_var_summary_shows_new_scalar(session):
+    result = execute_code(session, "FV_Y = 35.0")
+    assert "# vars:" in result
+    assert "FV_Y=35.0" in result
+
+
+def test_execute_var_summary_distinct_for_different_values(session):
+    r1 = execute_code(session, "FV_Y = 35.0")
+    r2 = execute_code(session, "FV_Y = 47.0")
+    assert r1 != r2
+    assert "FV_Y=47.0" in r2
+
+
+def test_execute_var_summary_unchanged_var_not_repeated(session):
+    execute_code(session, "x = 1")
+    result = execute_code(session, "x = 1")
+    assert "x=" not in result
+
+
+def test_execute_var_summary_multiple_vars(session):
+    result = execute_code(session, "SCALE = 2.0\nPAGE_W = 297.0")
+    assert "SCALE=2.0" in result
+    assert "PAGE_W=297.0" in result
+
+
+def test_execute_var_summary_skips_shapes(session):
+    result = execute_code(session, "result = Box(1, 1, 1)")
+    # shapes are reported in the shape diagnostic, not the var summary line
+    var_line = next((l for l in result.splitlines() if l.startswith("# vars:")), "")
+    assert "Box" not in var_line
+
+
+def test_execute_var_summary_skips_private_names(session):
+    result = execute_code(session, "_hidden = 99")
+    assert "_hidden=" not in result
+
+
+def test_execute_var_summary_absent_on_error(session):
+    result = execute_code(session, "bad syntax !!!")
+    assert "# vars:" not in result
+
+
 def test_execute_creates_shape(session):
     execute_code(session, "result = Box(10, 10, 10)")
     assert session.current_shape is not None


### PR DESCRIPTION
## Summary

Fixes #161.

**Root cause:** `execute()` returned `"OK"` for any successful variable-assignment block. Structurally-similar runs (e.g. `FV_Y=35.0` then `FV_Y=47.0`) produced identical output. Claude Code's context compression collapses repeated identical tool results into a `<<ccr:...>>` reference — the LLM cannot tell which value is actually in the session.

**Fix:** After each successful execution, append `# vars: key=val, ...` listing every scalar variable that was added or changed.

```
FV_Y = 35.0  →  "OK\n# vars: FV_Y=35.0"
FV_Y = 47.0  →  "OK\n# vars: FV_Y=47.0"   ← now distinct
```

**Scope:** `bool`, `int`, `float`, `complex`, `str`, `bytes`, `tuple`. Shapes (already covered by the shape diagnostic), functions, modules, and private names are excluded. Unchanged variables are not repeated.

## Test plan
- [ ] 7 new unit tests covering new/changed vars, unchanged suppression, shape exclusion, private exclusion, error suppression
- [ ] Full suite: 482 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)