### PR TITLE
feat(view_axes): add look_at_offset and helper_snippet to response

### DIFF
--- a/src/build123d_mcp/tools/view_axes.py
+++ b/src/build123d_mcp/tools/view_axes.py
@@ -26,21 +26,37 @@ def _norm3(v):
     return (v[0]/mag, v[1]/mag, v[2]/mag) if mag > 1e-10 else (0.0, 0.0, 0.0)
 
 
+def _helper_expr(param: str, view_var: str, offset: float, sign: float) -> str:
+    """Build a compact coordinate-helper expression string."""
+    if offset == 0.0:
+        inner = param
+    elif offset < 0:
+        inner = f"({param} + {-offset})"
+    else:
+        inner = f"({param} - {offset})"
+    return f"{view_var} + {inner} * SCALE" if sign == 1.0 else f"{view_var} - {inner} * SCALE"
+
+
 def view_axes(
     viewport_origin: tuple,
     viewport_up: tuple = (0.0, 1.0, 0.0),
     look_at: tuple = (0.0, 0.0, 0.0),
 ) -> str:
-    """Return JSON {world_X, world_Y, world_Z: [page_axis, sign]}.
+    """Return the world→page axis mapping plus the look_at offset and helper snippet.
 
-    Computes the world→page axis mapping analytically. Useful BEFORE calling
-    project_to_viewport to confirm which world axis maps to which page axis
-    and with what sign — catches bottom-view/side-view axis swaps before they
-    show up in the render.
+    project_to_viewport centres the projected compound at look_at. When that
+    compound is .locate()-d at (VIEW_X, VIEW_Y), the look_at point maps to
+    exactly (VIEW_X, VIEW_Y). The correct coordinate helper must subtract the
+    look_at component along each active world axis — omitting this term shifts
+    every annotation by look_at_component × SCALE mm.
 
-    Returns JSON like {"world_X": ["page_X", -1.0], "world_Y": ["page_Y", 1.0],
-    "world_Z": ["depth", 0.0]} — for a bottom-view origin (0,0,-100), world-X
-    flips to negative page-X.
+    Returns JSON with four fields:
+      world_X/Y/Z : [page_axis, sign]   — existing axis mapping
+      look_at_offset : {page_X, page_Y} — look_at world component projected onto
+                                          each page axis (multiply by SCALE to get
+                                          the page-space offset to subtract)
+      helper_snippet : str              — ready-to-paste Python coordinate helpers
+                                          (replace VIEW_X/VIEW_Y/SCALE with your values)
 
     Args:
         viewport_origin: camera position, same arg as project_to_viewport.
@@ -55,7 +71,8 @@ def view_axes(
     page_y = _norm3(_sub3(vu, _scale3(_dot3(vu, view_dir), view_dir)))
     page_x = _cross3(view_dir, page_y)
 
-    result = {}
+    axis_map = {}
+    la_world = {"world_X": la[0], "world_Y": la[1], "world_Z": la[2]}
     for name, world_v in [
         ("world_X", (1.0, 0.0, 0.0)),
         ("world_Y", (0.0, 1.0, 0.0)),
@@ -64,13 +81,49 @@ def view_axes(
         px = _dot3(world_v, page_x)
         py = _dot3(world_v, page_y)
         if abs(px) < 1e-9 and abs(py) < 1e-9:
-            result[name] = ("depth", 0.0)
+            axis_map[name] = ("depth", 0.0)
         elif abs(px) >= abs(py):
-            result[name] = ("page_X", float(round(px / abs(px), 1)))
+            axis_map[name] = ("page_X", float(round(px / abs(px), 1)))
         else:
-            result[name] = ("page_Y", float(round(py / abs(py), 1)))
+            axis_map[name] = ("page_Y", float(round(py / abs(py), 1)))
+
+    # look_at offset: for each page axis, the look_at world component from the dominant
+    # world axis (highest projection magnitude). A slightly tilted view can map two world
+    # axes to the same page axis; use the one with the larger |dot product|, not the first.
+    # Correct helper formula: page_coord = VIEW + (world - offset) * SCALE * sign
+    _world_vecs = {
+        "world_X": (1.0, 0.0, 0.0),
+        "world_Y": (0.0, 1.0, 0.0),
+        "world_Z": (0.0, 0.0, 1.0),
+    }
+    la_offset: dict[str, float] = {"page_X": 0.0, "page_Y": 0.0}
+    _best_mag: dict[str, float] = {"page_X": 0.0, "page_Y": 0.0}
+    for world_name, (page_axis, _sign) in axis_map.items():
+        if page_axis not in _best_mag:
+            continue
+        proj_vec = page_x if page_axis == "page_X" else page_y
+        mag = abs(_dot3(_world_vecs[world_name], proj_vec))
+        if mag > _best_mag[page_axis]:
+            _best_mag[page_axis] = mag
+            la_offset[page_axis] = round(la_world[world_name], 6)
+
+    # Ready-to-paste helper snippet — one function per active (non-depth) axis.
+    _param = {"world_X": "x", "world_Y": "y", "world_Z": "z"}
+    _view  = {"page_X": "VIEW_X", "page_Y": "VIEW_Y"}
+    lines = ["# Coordinate helpers (replace VIEW_X/VIEW_Y/SCALE with your values):"]
+    for world_name in ("world_X", "world_Y", "world_Z"):
+        page_axis, sign = axis_map[world_name]
+        if page_axis == "depth":
+            continue
+        param = _param[world_name]
+        expr = _helper_expr(param, _view[page_axis], la_world[world_name], sign)
+        lines.append(f"# def {param.upper()}({param}): return {expr}")
 
     return json.dumps(
-        {k: [v[0], round(v[1], 6)] for k, v in result.items()},
+        {
+            **{k: [v[0], round(v[1], 6)] for k, v in axis_map.items()},
+            "look_at_offset": la_offset,
+            "helper_snippet": "\n".join(lines),
+        },
         indent=2,
     )

--- a/tests/test_drawing_tooling.py
+++ b/tests/test_drawing_tooling.py
@@ -34,6 +34,51 @@ class TestViewAxes:
         assert result["world_X"][0] == "page_X"
         assert result["world_X"][1] == -1.0
 
+    def test_look_at_offset_zero_at_origin(self):
+        from build123d_mcp.tools.view_axes import view_axes
+        result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
+        assert "look_at_offset" in result
+        assert result["look_at_offset"]["page_X"] == 0.0
+        assert result["look_at_offset"]["page_Y"] == 0.0
+
+    def test_look_at_offset_front_view_z_centroid(self):
+        """Front view with part centroid at z=-4.65: page_Y offset should be -4.65."""
+        from build123d_mcp.tools.view_axes import view_axes
+        # camera on -Y axis, up=+Z → world_Z maps to page_Y
+        result = json.loads(view_axes((0, -100, 0), (0, 0, 1), (0, 0, -4.65)))
+        assert result["look_at_offset"]["page_Y"] == -4.65
+
+    def test_look_at_offset_top_view_y_centroid(self):
+        """Top view (camera +Z, up +Y): world_Y → page_Y. look_at y=3.0 offset captured."""
+        from build123d_mcp.tools.view_axes import view_axes
+        # Camera on +Z axis, look_at Y=3 → world_Y maps to page_Y → offset = 3.0
+        result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 3.0, 0)))
+        assert result["look_at_offset"]["page_Y"] == 3.0
+        assert result["look_at_offset"]["page_X"] == 0.0
+
+    def test_helper_snippet_present_and_non_empty(self):
+        from build123d_mcp.tools.view_axes import view_axes
+        result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
+        assert "helper_snippet" in result
+        assert "VIEW_X" in result["helper_snippet"]
+        assert "SCALE" in result["helper_snippet"]
+
+    def test_helper_snippet_includes_offset_when_nonzero(self):
+        """When look_at has a non-zero component, the snippet incorporates the offset."""
+        from build123d_mcp.tools.view_axes import view_axes
+        # Top view: world_X → page_X, world_Y → page_Y, look_at x=3.0
+        result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (3.0, 0, 0)))
+        assert "3.0" in result["helper_snippet"]
+
+    def test_helper_snippet_clean_when_offset_zero(self):
+        """No offset terms when look_at is at origin."""
+        from build123d_mcp.tools.view_axes import view_axes
+        result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
+        # Clean form: def X(x): return VIEW_X + x * SCALE  (no subtraction)
+        snippet = result["helper_snippet"]
+        assert "- 0" not in snippet
+        assert "+ 0" not in snippet
+
 
 # ---------------------------------------------------------------------------
 # lint_drawing (session mode)


### PR DESCRIPTION
## Summary

Closes #158.

`project_to_viewport` centres the projected compound at `look_at`. Without the `look_at` term in coordinate helpers, every annotation is offset by `look_at_component × SCALE` mm. For the motivating case (disc spring centred at `cz = −4.65 mm` at 2:1 scale) this was a **9.3 mm systematic error**.

## New JSON fields

**`look_at_offset: {page_X, page_Y}`** — the `look_at` world component along the dominant axis for each page axis. Multiply by `SCALE` to get the page-space correction.

**`helper_snippet: str`** — ready-to-paste coordinate helpers with the offset baked in:
```python
# def X(x): return VIEW_X + x * SCALE
# def Z(z): return VIEW_Y + (z + 4.65) * SCALE
```

## Implementation note

`look_at_offset` uses the dominant (highest-projection-magnitude) world axis per page axis, so it stays correct even when a slightly tilted view (non-zero `look_at` at finite camera distance) maps two world axes to the same page axis.

## Test plan
- [ ] 6 new tests: zero offset, z-centroid front view, y-centroid top view, snippet present, snippet includes offset, clean snippet when zero
- [ ] Full suite: 491 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)