### PR TITLE
docs: assess micropython-wasm as a build123d sandbox

### DIFF
--- a/docs/micropython-wasm-feasibility.md
+++ b/docs/micropython-wasm-feasibility.md
@@ -1,0 +1,111 @@
+# Feasibility: micropython-wasm as a sandbox for build123d
+
+**Status:** assessment only — no implementation.
+**Context:** [Simon Willison, "Running Python code in a sandbox with MicroPython and WASM"](https://simonwillison.net/2026/Jun/6/micropython-in-a-sandbox/) (6 Jun 2026), announcing the [`micropython-wasm`](https://github.com/simonw/micropython-wasm) alpha package.
+
+## Verdict
+
+Running build123d *inside* micropython-wasm is **not feasible as a drop-in**, and the one
+technically-possible variant (a hybrid sandbox) defeats its own purpose. The realistic
+security wins for this project lie in OS-level isolation of the existing worker subprocess —
+which the codebase is already architected for.
+
+---
+
+## What micropython-wasm is
+
+A Python package that bundles a custom MicroPython interpreter compiled to a ~362 KB
+WebAssembly (WASI) blob and runs it via **wasmtime**. Its strengths:
+
+- Clean PyPI install with binary wheels (wasmtime ships them).
+- **Memory limits** native to wasmtime; **CPU limits** via wasmtime "fuel" (instruction budget,
+  ~20 M default in the article).
+- Default-deny capabilities: no filesystem, no network, no env inheritance unless explicitly granted.
+- Host-function interop (a small C shim, ~78 lines, marshals values across the boundary as JSON).
+- Persistent interpreter state via a resident VM that blocks on a `__session_next__()` host
+  function pulling code off a queue.
+
+Its design target is **pure-Python plugin logic** — Simon's example is "fetch JSON → reformat
+into a list of dicts → insert rows." build123d is the opposite kind of workload.
+
+---
+
+## 1. The categorical blocker: build123d is a thin veneer over a C++ kernel
+
+build123d's dependency chain:
+
+```
+build123d  →  OCP (pybind11 bindings)  →  OpenCASCADE (libTK*.so, C++)  +  numpy (C ext)
+```
+
+`security.py` already encodes this reality. It maintains a separate `OCP_ALLOWLIST` for the
+OpenCASCADE Python bindings, and its transitive-safety checker explicitly bails on anything
+that isn't pure Python:
+
+```python
+if not spec.origin.endswith(".py"):
+    return None  # C extension or built-in — no AST to check
+```
+
+MicroPython-WASM runs a lean interpreter with **no CPython C-API, no pybind11 ABI, and no
+`dlopen` of native shared libraries**. It therefore cannot `import OCP`, and cannot `import
+numpy` (also in the allowlist, also a C extension). build123d cannot run inside the sandbox at
+all. This is an ABI wall, not a tuning problem (fuel size / memory cap are irrelevant).
+
+## 2. Compiling OCCT itself to WASM is a different (huge) project
+
+OpenCASCADE *has* been compiled to WASM before (e.g. `opencascade.js`), but:
+
+- Those target **Emscripten/browser**, not the **WASI/wasmtime** runtime micropython-wasm uses.
+- You would need MicroPython *and* OCCT in the same WASM module, plus bindings bridging them.
+  OCP's pybind11 bindings target CPython's C-API, so they would need a ground-up rewrite
+  against MicroPython's very different C API.
+- That is building a bespoke CAD-in-WASM runtime — a multi-month toolchain effort,
+  categorically different from "adopt micropython-wasm."
+
+## 3. The hybrid variant is possible but low-value
+
+You could run only user arithmetic / control-flow inside WASM and marshal geometry calls out
+to a trusted build123d worker. But **the dangerous surface *is* the geometry layer** — file
+export, `import_cad_file`, and any build123d internal that touches the filesystem. Those would
+run *outside* the sandbox with full privileges. You would be sandboxing `for i in range(10)`
+while leaving the C++ kernel and all I/O exposed. `security.md` already flags this exact gap
+("Build123d internals … could be called from user code"). WASM does not help here.
+
+## 4. The project already implements Simon's own top recommendation
+
+`security.md`'s top hardening recommendation is:
+
+> Run each execute() call in a subprocess … the subprocess can be killed hard on timeout.
+
+`worker.py` already does exactly this: a `spawn`-context subprocess holds the `Session`,
+communicates over a `Pipe`, and is **`SIGKILL`-ed and restarted on timeout**
+(`WorkerSession._call`). Structurally this is the *same* pattern Simon describes building — a
+resident interpreter plus a request/reply queue — reached independently. For a C++-kernel
+workload, OS process isolation is the correct and only realistic boundary; WASM is the wrong tool.
+
+## 5. Where the real wins are (no WASM needed)
+
+The gaps a WASM sandbox might be expected to close, and the pragmatic OS-level fix for each
+within the *existing* worker architecture:
+
+| Gap (`security.md`) | WASM would fix? | Realistic fix in current architecture |
+|---|---|---|
+| **Memory exhaustion** (`[0]*10**10`) | yes (linear-mem cap) | `resource.setrlimit(RLIMIT_AS)` in `worker_main` before serving — ~5 lines |
+| **CPU** beyond wall-clock | yes (fuel) | already have hard `SIGKILL` timeout; could add `RLIMIT_CPU` |
+| **Filesystem** (worker inherits full FS) | partial (WASI preopen) | run worker in container/namespace, or seccomp; read-only mount + one output dir |
+| **Network** | yes (default-deny) | `--network none` container, or seccomp socket block |
+
+`worker_main` is a single chokepoint where per-process rlimits / seccomp can be applied.
+
+---
+
+## Bottom line
+
+- **Run build123d in micropython-wasm:** no — C-extension ABI wall (OCP + numpy).
+- **Hybrid sandbox:** technically yes, security value ≈ zero — the risky surface stays outside.
+- **Borrow ideas:** already present — `WorkerSession` is Simon's persistent-session pattern;
+  fuel has no clean CPython equivalent, so wall-clock + `RLIMIT_CPU` is the substitute.
+- **Highest-ROI next step (independent of this article):** add `setrlimit(RLIMIT_AS)` to
+  `worker_main` to close the one un-mitigated, easy-to-trigger DoS (memory exhaustion), entirely
+  within the existing architecture.

--- a/docs/micropython-wasm-feasibility.md
+++ b/docs/micropython-wasm-feasibility.md
@@ -1,111 +1,123 @@
-# Feasibility: micropython-wasm as a sandbox for build123d
+# Feasibility: a WASM + Python sandbox for build123d
 
 **Status:** assessment only — no implementation.
 **Context:** [Simon Willison, "Running Python code in a sandbox with MicroPython and WASM"](https://simonwillison.net/2026/Jun/6/micropython-in-a-sandbox/) (6 Jun 2026), announcing the [`micropython-wasm`](https://github.com/simonw/micropython-wasm) alpha package.
 
+> **Correction note.** An earlier version of this document claimed it was *categorically
+> impossible* to run build123d in a WASM Python, on the grounds that OCP/OpenCASCADE and numpy
+> are C extensions. That reasoning holds **only for MicroPython**. It is **wrong in general**:
+> Pyodide (full CPython on WASM) loads C extensions compiled to WASM, and OCP/OpenCASCADE has
+> already been ported — **build123d runs in Pyodide+WASM today**. This document is the corrected
+> assessment.
+
 ## Verdict
 
-Running build123d *inside* micropython-wasm is **not feasible as a drop-in**, and the one
-technically-possible variant (a hybrid sandbox) defeats its own purpose. The realistic
-security wins for this project lie in OS-level isolation of the existing worker subprocess —
-which the codebase is already architected for.
+- **Simon's `micropython-wasm` (the article's tool): cannot run build123d.** MicroPython has no
+  CPython C-API / pybind11 ABI, so it cannot load OCP, OpenCASCADE, or numpy.
+- **Pyodide + `OCP.wasm`: *can* run build123d, and does so in shipping projects today.** This is
+  a genuine WASM+Python path and was wrongly dismissed before.
+- **Whether it is a *stronger* sandbox is a separate question.** The real isolation boundary is
+  the host runtime's capability model (Deno / WASI), **not** Pyodide itself — Pyodide has active
+  critical sandbox-escape CVEs. Adopting it is a large re-platform with significant losses
+  (VTK rendering, file I/O), and is roughly comparable in isolation strength to simply
+  confining the existing CPython worker with OS primitives.
 
 ---
 
-## What micropython-wasm is
+## 1. MicroPython-wasm: still no
 
-A Python package that bundles a custom MicroPython interpreter compiled to a ~362 KB
-WebAssembly (WASI) blob and runs it via **wasmtime**. Its strengths:
-
-- Clean PyPI install with binary wheels (wasmtime ships them).
-- **Memory limits** native to wasmtime; **CPU limits** via wasmtime "fuel" (instruction budget,
-  ~20 M default in the article).
-- Default-deny capabilities: no filesystem, no network, no env inheritance unless explicitly granted.
-- Host-function interop (a small C shim, ~78 lines, marshals values across the boundary as JSON).
-- Persistent interpreter state via a resident VM that blocks on a `__session_next__()` host
-  function pulling code off a queue.
-
-Its design target is **pure-Python plugin logic** — Simon's example is "fetch JSON → reformat
-into a list of dicts → insert rows." build123d is the opposite kind of workload.
-
----
-
-## 1. The categorical blocker: build123d is a thin veneer over a C++ kernel
-
-build123d's dependency chain:
+build123d's dependency chain is:
 
 ```
 build123d  →  OCP (pybind11 bindings)  →  OpenCASCADE (libTK*.so, C++)  +  numpy (C ext)
 ```
 
-`security.py` already encodes this reality. It maintains a separate `OCP_ALLOWLIST` for the
-OpenCASCADE Python bindings, and its transitive-safety checker explicitly bails on anything
-that isn't pure Python:
-
-```python
-if not spec.origin.endswith(".py"):
-    return None  # C extension or built-in — no AST to check
-```
-
 MicroPython-WASM runs a lean interpreter with **no CPython C-API, no pybind11 ABI, and no
-`dlopen` of native shared libraries**. It therefore cannot `import OCP`, and cannot `import
-numpy` (also in the allowlist, also a C extension). build123d cannot run inside the sandbox at
-all. This is an ABI wall, not a tuning problem (fuel size / memory cap are irrelevant).
+`dlopen` of native libraries**. It cannot `import OCP` or `import numpy`. `security.py` already
+treats OCP as a special C-extension case (`OCP_ALLOWLIST`) and its transitive checker bails on
+non-`.py` modules. For MicroPython specifically, the ABI wall is real.
 
-## 2. Compiling OCCT itself to WASM is a different (huge) project
+Simon's tool targets **pure-Python plugin logic** (his example: "fetch JSON → reformat into a
+list of dicts → insert rows"), which is the opposite of build123d's C++-kernel workload.
 
-OpenCASCADE *has* been compiled to WASM before (e.g. `opencascade.js`), but:
+## 2. Pyodide is different — and OCP.wasm already exists
 
-- Those target **Emscripten/browser**, not the **WASI/wasmtime** runtime micropython-wasm uses.
-- You would need MicroPython *and* OCCT in the same WASM module, plus bindings bridging them.
-  OCP's pybind11 bindings target CPython's C-API, so they would need a ground-up rewrite
-  against MicroPython's very different C API.
-- That is building a bespoke CAD-in-WASM runtime — a multi-month toolchain effort,
-  categorically different from "adopt micropython-wasm."
+Pyodide is **full CPython compiled to WASM (Emscripten)** and **can load C extensions compiled
+to WASM** — this is how numpy/scipy run in the browser. Crucially, the CAD kernel has been
+ported:
 
-## 3. The hybrid variant is possible but low-value
+- **[`Yeicor/OCP.wasm`](https://github.com/Yeicor/OCP.wasm)** — ports OCP + OpenCASCADE (and
+  lib3mf) to WASM via Pyodide. build123d runs in a browser Pyodide REPL.
+- **`build123d-sandbox`** and **[yet-another-cad-viewer](https://github.com/yeicor-3d/yet-another-cad-viewer)**
+  — shipping web apps running build123d fully client-side via Pyodide+WASM.
+- Tracked upstream in [CadQuery Discussion #1876](https://github.com/CadQuery/cadquery/discussions/1876).
 
-You could run only user arithmetic / control-flow inside WASM and marshal geometry calls out
-to a trusted build123d worker. But **the dangerous surface *is* the geometry layer** — file
-export, `import_cad_file`, and any build123d internal that touches the filesystem. Those would
-run *outside* the sandbox with full privileges. You would be sandboxing `for i in range(10)`
-while leaving the C++ kernel and all I/O exposed. `security.md` already flags this exact gap
-("Build123d internals … could be called from user code"). WASM does not help here.
+So "build123d can't run in a WASM Python" is **false**. The earlier categorical claim conflated
+MicroPython's limitation with WASM-Python in general.
 
-## 4. The project already implements Simon's own top recommendation
+## 3. The catches that matter for *this* project
 
-`security.md`'s top hardening recommendation is:
+**a. Pyodide is browser/Node-native (Emscripten), not server-side WASI/wasmtime.** OCP.wasm runs
+in a browser, or under Node/Deno — *not* in the wasmtime model Simon's article is about. Simon
+explicitly rejected Pyodide server-side ("can only run in a browser or Node.js"), which is
+precisely *why* he built micropython-wasm. To use OCP.wasm on a server you run **Pyodide under
+Deno** (see [Simon's TIL](https://til.simonwillison.net/deno/pyodide-sandbox)) or Node.
 
-> Run each execute() call in a subprocess … the subprocess can be killed hard on timeout.
+**b. Pyodide is not itself the security boundary — and has active critical escapes.**
+This is the load-bearing point:
 
-`worker.py` already does exactly this: a `spawn`-context subprocess holds the `Session`,
-communicates over a `Pipe`, and is **`SIGKILL`-ed and restarted on timeout**
-(`WorkerSession._call`). Structurally this is the *same* pattern Simon describes building — a
-resident interpreter plus a request/reply queue — reached independently. For a C++-kernel
-workload, OS process isolation is the correct and only realistic boundary; WASM is the wrong tool.
+- **CVE-2026-5752 (CVSS 9.3): Pyodide sandbox escape → root command execution** (reported
+  unpatched).
+- Grist's Pyodide-formula sandbox escape ("Cellbreak", Cyera Research).
+- **`langchain-sandbox`** — the canonical "Pyodide under Deno" server sandbox — was
+  **archived January 2026, "no longer maintained,"** recommending hosted sandbox APIs instead.
+  Its own docs state *"the actual security guarantees depend on … Deno permissions."*
 
-## 5. Where the real wins are (no WASM needed)
+In other words, **Deno's (or a WASI runtime's) capability model is the wall, not Pyodide.**
+"Stronger sandbox via WASM+Python" decodes to "run a WASM Python under a host that denies
+network/filesystem capabilities" — which is the same *kind* of outer-boundary confinement you
+can apply to the existing CPython worker.
 
-The gaps a WASM sandbox might be expected to close, and the pragmatic OS-level fix for each
-within the *existing* worker architecture:
+**c. The re-platform cost is large and hits build123d-mcp specifically:**
 
-| Gap (`security.md`) | WASM would fix? | Realistic fix in current architecture |
-|---|---|---|
-| **Memory exhaustion** (`[0]*10**10`) | yes (linear-mem cap) | `resource.setrlimit(RLIMIT_AS)` in `worker_main` before serving — ~5 lines |
-| **CPU** beyond wall-clock | yes (fuel) | already have hard `SIGKILL` timeout; could add `RLIMIT_CPU` |
-| **Filesystem** (worker inherits full FS) | partial (WASI preopen) | run worker in container/namespace, or seccomp; read-only mount + one output dir |
-| **Network** | yes (default-deny) | `--network none` container, or seccomp socket block |
+- Replace the backend: CPython subprocess → Pyodide-under-Deno, with JS↔Python↔WASM marshaling.
+- **No VTK** (the port is `cadquery-ocp-novtk`). `tools/render.py` is pyvista/VTK-based and
+  **would not work** — rendering must be redone via mesh export + a JS/three.js viewer.
+- **File access is unsupported** in the Pyodide sandbox model — `export`, `import_cad_file` must
+  be re-plumbed through a virtual FS.
+- 50–70 MB WASM payload, multi-second startup latency, Pyodide-version lag, and OCP.wasm is a
+  largely-untested partial port.
 
-`worker_main` is a single chokepoint where per-process rlimits / seccomp can be applied.
+## 4. The existing architecture already does the outer-boundary part
+
+`security.md`'s top hardening recommendation — *"run each execute() call in a subprocess …
+killed hard on timeout"* — is already implemented in `worker.py`: a `spawn`-context subprocess
+holds the `Session`, talks over a `Pipe`, and is `SIGKILL`-ed on timeout (`WorkerSession._call`).
+This is structurally the same persistent-session pattern Simon describes building.
+
+Because the real isolation in *both* the Pyodide-under-Deno path and the OS-confined-subprocess
+path comes from the **outer capability layer**, the cheaper, lower-risk win is to confine the
+existing worker rather than re-platform onto WASM.
 
 ---
 
-## Bottom line
+## Comparison
 
-- **Run build123d in micropython-wasm:** no — C-extension ABI wall (OCP + numpy).
-- **Hybrid sandbox:** technically yes, security value ≈ zero — the risky surface stays outside.
-- **Borrow ideas:** already present — `WorkerSession` is Simon's persistent-session pattern;
-  fuel has no clean CPython equivalent, so wall-clock + `RLIMIT_CPU` is the substitute.
-- **Highest-ROI next step (independent of this article):** add `setrlimit(RLIMIT_AS)` to
-  `worker_main` to close the one un-mitigated, easy-to-trigger DoS (memory exhaustion), entirely
-  within the existing architecture.
+| Approach | Runs build123d? | Stronger sandbox? | Cost |
+|---|---|---|---|
+| **MicroPython-wasm** (Simon's tool, the article) | **No** — no C-ext support | n/a | n/a |
+| **Pyodide + OCP.wasm under Deno/WASI** | **Yes** (real, shipping) | Yes vs. *today's* setup (network/FS denial) — but the boundary is Deno/WASI, not Pyodide, which has CVSS-9.3 escapes | **Large** re-platform; lose VTK rendering + file I/O; unmaintained reference tooling |
+| **Current CPython worker + OS confinement** (container / seccomp / `RLIMIT_AS`) | Yes (unchanged) | Comparable isolation strength | **Small**, fits existing `worker.py` |
+
+## Recommendations
+
+1. **Don't pursue MicroPython-wasm** for build123d — it cannot load the kernel.
+2. **Treat Pyodide + OCP.wasm as a real but major option**, justified mainly if a
+   *browser-native, zero-install* deployment is itself a goal (as in build123d-sandbox). As a
+   pure server-side hardening play it is high-cost and leans on a stack with active critical
+   CVEs and unmaintained reference tooling.
+3. **Highest-ROI hardening (independent of WASM):** confine the existing worker —
+   `resource.setrlimit(RLIMIT_AS)` in `worker_main` to close the unbounded-memory DoS (the one
+   easy-to-trigger gap in `security.md`), plus optional container/seccomp/`--network none` for
+   the filesystem/network surface. This is where the real isolation lives in every option, at a
+   fraction of the engineering cost.


### PR DESCRIPTION
Feasibility findings on whether Simon Willison's micropython-wasm could
sandbox build123d execution. Conclusion: not feasible as a drop-in (OCP/
OpenCASCADE and numpy are C extensions that MicroPython-WASM cannot load);
the realistic wins are OS-level isolation of the existing worker subprocess.