### PR TITLE
fix(skill): remove [SEND:] marker — environment-specific convention

### DIFF
--- a/src/build123d_mcp/skills/b123d-drawing/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-drawing/SKILL.md
@@ -359,7 +359,7 @@ dxf_exp.write(str(output_dir / "part_name.dxf"))
 mcp__build123d-mcp__render_drawing(svg_path='drawings/part_name.svg', save_to='/tmp/dwg.png')
 ```
 
-Send with `[SEND: /tmp/dwg.png]` for user review before moving on.
+Review the rendered PNG before moving on.
 
 ---
 


### PR DESCRIPTION
The b123d-drawing skill's Step 7 told the agent to deliver the rendered PNG with `[SEND: /tmp/dwg.png]`.

`[SEND:]` is a personal Telegram-bot convention (defined in a private global CLAUDE.md), **not** a general Claude Code or MCP feature. Since this skill is checked into the repo and installed into other users' environments via `install_skill` (Claude / Cursor / Windsurf), the reference leaked a private setup that does nothing for anyone else.

Replaced with environment-neutral wording: "Review the rendered PNG before moving on."

🤖 Generated with [Claude Code](https://claude.ai/claude-code)