### PR TITLE
feat(skill): default to saving a standalone regeneration script (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.38 — 2026-06-07
+
+### Changed
+
+- **`b123d-drawing` skill now defaults to saving a standalone regeneration
+  script.** After generating a drawing, the agent writes a clean, committable
+  `scripts/drawings/<part>.py` (via `generate_script()` for STEP inputs, or a
+  hand-written rebuild + `make_drawing` for in-session objects) so drawings live
+  in version control as reproducible code, not only as output artifacts — unless
+  the user opts out. Restores the `scripts/drawings/` convention dropped in the
+  v0.3.37 rewrite. Closes #175.
+
 ## v0.3.37 — 2026-06-07
 
 ### Changed

--- a/src/build123d_mcp/skills/b123d-drawing/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-drawing/SKILL.md
@@ -134,6 +134,63 @@ correctly. `view_annotation_overlap` warnings from the lint step usually show up
 here as cramped leaders — fix them with the builder (Step 2) if they matter.
 
 ---
+
+## Step 4 — Save a standalone regeneration script (default)
+
+Unless the user opts out, also write a clean, committable script to
+`scripts/drawings/<part>.py` that regenerates the drawing in a single run. The
+drawing should live in version control as reproducible code, not only as output
+artifacts. This must be a tidy reproducible script — **not** a dump of your
+exploratory `execute()` session.
+
+Pick the case that matches how you obtained the geometry:
+
+**A — Drawing from a STEP file** → use `generate_script()`. It writes an
+editable `build_drawing` script (including the customise-before-export seam)
+that reloads the STEP from disk:
+
+```python
+from build123d_drafting import generate_script
+
+generate_script(
+    "path/to/part.step",
+    out="scripts/drawings/bracket",   # → writes scripts/drawings/bracket.py
+    title="BRACKET", number="DWG-042",
+    tolerance="ISO 2768-f", drawn_by="Your Name",
+)
+```
+
+The generated script exports its SVG/DXF **next to itself** (the `out=_stem`
+line uses the script's own path), e.g. `scripts/drawings/bracket.svg`. If you
+want the outputs under `drawings/` instead, edit the final `dwg.export(...)`
+line in the generated script.
+
+**B — Drawing an in-session object** → `generate_script()` cannot embed a live
+object (it reloads geometry from disk and raises `TypeError` on a `Shape`).
+Write the script by hand so it is self-contained:
+
+1. Reconstruct the part — import the project's part-building module if one
+   exists (preferred), otherwise inline the minimal construction code.
+2. Call `make_drawing` / `build_drawing` with the same parameters you used.
+
+```python
+#!/usr/bin/env python3
+"""BRACKET — regenerates drawings/bracket.svg + .dxf in one run."""
+from build123d_drafting import make_drawing
+from myproject.bracket import build_bracket   # the part's source of truth
+
+part = build_bracket()
+make_drawing(part, out="drawings/bracket", title="BRACKET",
+             number="DWG-042", tolerance="ISO 2768-f", drawn_by="Your Name")
+```
+
+If the part was built ad-hoc in the session with no importable source, export it
+to STEP once and use case A instead — that keeps the script reproducible without
+pasting scratch geometry code.
+
+Tell the user where the script was saved.
+
+---
 ---
 
 # Manual pipeline (fallback)
@@ -549,6 +606,17 @@ pdf_y = PAGE_H - abs(vb_y)
 
 If the assert fires, the SVG was generated with a different coordinate convention;
 inspect the `viewBox` before placing the image.
+
+---
+
+## Manual 9 — Save a standalone regeneration script (default)
+
+The same default as Step 4 applies: unless the user opts out, save a clean,
+committable `scripts/drawings/<part>.py` that regenerates the drawing in one run.
+For the manual pipeline there is no `generate_script()` shortcut, so assemble the
+script by hand — reconstruct the part (import its source module, or load the STEP)
+followed by the projection / annotation / export steps above. Keep it tidy and
+reproducible, not a paste of the exploratory session.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses #175. The v0.3.37 `b123d-drawing` skill rewrite runs the whole drawing flow inside `execute()` and exports SVG/DXF, but never instructs the agent to write a committable `.py`. Drawings ended up existing only as output artifacts with no version-controlled regeneration script — a regression from the pre-rewrite skill, which referenced `scripts/drawings/`.

## Change (doc-only)

Adds a new default step to the skill:

- **Step 4 — Save a standalone regeneration script (default)** (automatic / builder path)
- **Manual 9** — the same default for the manual fallback path

Unless the user opts out, the agent now saves a clean, committable `scripts/drawings/<part>.py` that regenerates the drawing in one run:

- **STEP input** → `generate_script()` (emits an editable `build_drawing` script with the customise-before-export seam).
- **In-session object** → hand-written script that reconstructs the part (import its source module, or load a STEP) + `make_drawing` / `build_drawing`.

Documents two real footguns: `generate_script()` exports its SVG/DXF *next to itself* (`out=_stem`), and it raises `TypeError` on a live `Shape`.

The script must be a tidy reproducible version, **not** a dump of the exploratory `execute()` session.

## Testing

- `uv run pytest tests/` → 530 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)