### PR TITLE
Add per-version Python classifiers (3.10-3.12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
 keywords = ["mcp", "build123d", "cad", "3d", "ai"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Scientific/Engineering",
 ]


### PR DESCRIPTION
The `pypi/pyversions` badge rendered only "python 3" because the package metadata carried just the generic `Programming Language :: Python :: 3` classifier. This adds explicit `3.10`/`3.11`/`3.12` classifiers matching `requires-python = >=3.10,<3.13`.

Note: the badge reads the latest **published** PyPI release, so it updates on the next release (0.3.39+), not from this merge alone.