### PR TITLE
Keep server.json registry version in sync with the package (#181)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,17 +74,7 @@ jobs:
       - name: Sync server.json version with the release tag
         run: |
           tag=${{ github.event.release.tag_name }}
-          version=${tag#v}
-          python3 - <<EOF
-          import json
-          with open("server.json") as f:
-              d = json.load(f)
-          d["version"] = "$version"
-          for p in d.get("packages", []):
-              p["version"] = "$version"
-          with open("server.json", "w") as f:
-              json.dump(d, f, indent=2)
-          EOF
+          python3 scripts/sync_server_json.py "${tag#v}"
       - name: Install mcp-publisher
         run: |
           # Resolve the latest release tag via the API rather than the
@@ -125,18 +115,7 @@ jobs:
         run: |
           new_base=$(grep '^version = ' pyproject.toml \
             | sed 's/version = "\(.*\)"/\1/' | sed 's/\.dev[0-9]*$//')
-          python3 - "$new_base" <<'EOF'
-          import json, sys
-          base = sys.argv[1]
-          with open("server.json") as f:
-              data = json.load(f)
-          data["version"] = base
-          for package in data.get("packages", []):
-              package["version"] = base
-          with open("server.json", "w") as f:
-              json.dump(data, f, indent=2)
-              f.write("\n")
-          EOF
+          python3 scripts/sync_server_json.py "$new_base"
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,11 +121,27 @@ jobs:
           base="${current%.dev*}"
           IFS='.' read -r major minor patch <<< "$base"
           uv version "${major}.${minor}.$((patch + 1)).dev0"
+      - name: Sync server.json to the new base version
+        run: |
+          new_base=$(grep '^version = ' pyproject.toml \
+            | sed 's/version = "\(.*\)"/\1/' | sed 's/\.dev[0-9]*$//')
+          python3 - "$new_base" <<'EOF'
+          import json, sys
+          base = sys.argv[1]
+          with open("server.json") as f:
+              data = json.load(f)
+          data["version"] = base
+          for package in data.get("packages", []):
+              package["version"] = base
+          with open("server.json", "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+          EOF
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           new_version=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          git add pyproject.toml uv.lock
+          git add pyproject.toml uv.lock server.json
           git commit -m "chore: bump version to ${new_version} after release"
           git push

--- a/scripts/sync_server_json.py
+++ b/scripts/sync_server_json.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Rewrite server.json's version (and package versions) to a given version.
+
+Keeps the MCP registry manifest aligned with the package version. Used by the
+release workflow (the registry-publish step syncs to the release tag; the
+bump-version step syncs to the next dev base) and guarded by
+``tests/test_server_json_version.py``. Operates on ``server.json`` in the current
+working directory.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def sync_server_json(version: str, path: Path = Path("server.json")) -> None:
+    """Set the top-level and per-package ``version`` fields in server.json."""
+    data = json.loads(path.read_text())
+    data["version"] = version
+    for package in data.get("packages", []):
+        package["version"] = version
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    sync_server_json(sys.argv[1])

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/pzfreo/build123d-mcp",
     "source": "github"
   },
-  "version": "0.3.14",
+  "version": "0.3.39",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "build123d-mcp",
-      "version": "0.3.14",
+      "version": "0.3.39",
       "transport": {
         "type": "stdio"
       },

--- a/tests/test_server_json_version.py
+++ b/tests/test_server_json_version.py
@@ -1,0 +1,30 @@
+"""server.json registry metadata must track the package version (issue #181)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _package_base_version() -> str:
+    """The pyproject version with any ``.devN`` suffix stripped."""
+    text = (_ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+    assert match, "could not find version in pyproject.toml"
+    return re.sub(r"\.dev\d+$", "", match.group(1))
+
+
+def test_server_json_version_matches_package() -> None:
+    base = _package_base_version()
+    server = json.loads((_ROOT / "server.json").read_text())
+
+    assert server["version"] == base, (
+        f"server.json version {server['version']!r} != package base {base!r}"
+    )
+    for package in server.get("packages", []):
+        assert package["version"] == base, (
+            f"server.json package version {package['version']!r} != package base {base!r}"
+        )

--- a/tests/test_sync_server_json.py
+++ b/tests/test_sync_server_json.py
@@ -1,0 +1,22 @@
+"""scripts/sync_server_json.py rewrites server.json versions consistently."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "sync_server_json.py"
+
+
+def test_sync_rewrites_top_level_and_package_versions(tmp_path: Path) -> None:
+    server = tmp_path / "server.json"
+    server.write_text(json.dumps({"version": "0.0.1", "packages": [{"version": "0.0.1"}]}))
+
+    subprocess.run([sys.executable, str(_SCRIPT), "9.9.9"], cwd=tmp_path, check=True)
+
+    data = json.loads(server.read_text())
+    assert data["version"] == "9.9.9"
+    assert all(pkg["version"] == "9.9.9" for pkg in data["packages"])
+    assert server.read_text().endswith("\n")  # consistent trailing newline


### PR DESCRIPTION
Closes #181.

`server.json` advertised **0.3.14** while `pyproject` is **0.3.39.dev0** — the release workflow syncs the *registry publish* but never commits `server.json` back, so it drifted 25 patches behind.

- realign `server.json` to the current base version (0.3.39)
- add `tests/test_server_json_version.py` — fails when `server.json` diverges from the pyproject base version
- update the release workflow's `bump-version` job to re-sync + commit `server.json`, so it can't drift again after a release

mypy clean, 531 passed.