### PR TITLE
fix(resolve): route selector through execute() sandbox (closes #186)

### DIFF
--- a/src/build123d_mcp/tools/resolve.py
+++ b/src/build123d_mcp/tools/resolve.py
@@ -35,7 +35,6 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
         return json.dumps({"error": f"build123d import failed: {exc}"})
 
     namespace["obj"] = obj
-    namespace["__builtins__"] = make_restricted_builtins()
 
     # The selector is model/user-controlled (resolve() is MCP-exposed), so route
     # it through the same sandbox checks execute() uses: reject dunder traversal,
@@ -49,6 +48,7 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
             "selector": selector,
         })
 
+    namespace["__builtins__"] = make_restricted_builtins()
     try:
         result = eval(expression, namespace)  # noqa: S307
     except Exception as exc:

--- a/src/build123d_mcp/tools/resolve.py
+++ b/src/build123d_mcp/tools/resolve.py
@@ -1,5 +1,7 @@
 import json
 
+from build123d_mcp.security import check_ast, make_restricted_builtins
+
 
 def resolve(session, object_name: str, selector: str, label: str = "") -> str:
     """Evaluate a selector expression against a named object and return a face/edge descriptor.
@@ -33,9 +35,22 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
         return json.dumps({"error": f"build123d import failed: {exc}"})
 
     namespace["obj"] = obj
+    namespace["__builtins__"] = make_restricted_builtins()
+
+    # The selector is model/user-controlled (resolve() is MCP-exposed), so route
+    # it through the same sandbox checks execute() uses: reject dunder traversal,
+    # blocked builtins, and disallowed imports before evaluating (issue #186).
+    expression = f"obj{selector}"
+    try:
+        check_ast(expression)
+    except ValueError as exc:
+        return json.dumps({
+            "error": f"Selector rejected: {exc}",
+            "selector": selector,
+        })
 
     try:
-        result = eval(f"obj{selector}", namespace)  # noqa: S307
+        result = eval(expression, namespace)  # noqa: S307
     except Exception as exc:
         return json.dumps({
             "error": f"Selector evaluation failed: {exc}",

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -73,6 +73,29 @@ def test_bad_selector_returns_error(box_session):
     assert "error" in result
 
 
+def test_dunder_traversal_rejected(box_session):
+    """Selector cannot traverse dunder attributes (issue #186 sandbox escape)."""
+    result = json.loads(resolve(box_session, "box", ".__class__.__mro__"))
+    assert "error" in result
+    assert "rejected" in result["error"].lower()
+
+
+def test_subclasses_escape_rejected(box_session):
+    """The classic __subclasses__() escape chain is blocked (issue #186)."""
+    result = json.loads(
+        resolve(box_session, "box", ".__class__.__base__.__subclasses__()")
+    )
+    assert "error" in result
+    assert "type" not in result
+
+
+def test_blocked_builtin_in_selector_rejected(box_session):
+    """A blocked builtin call in the selector is rejected (issue #186)."""
+    result = json.loads(resolve(box_session, "box", " or getattr(obj, 'volume')"))
+    assert "error" in result
+    assert "rejected" in result["error"].lower()
+
+
 def test_geometry_refs_cleared_on_reset(box_session):
     resolve(box_session, "box", ".faces().sort_by(Axis.Z)[-1]", label="top_face")
     assert "top_face" in box_session.geometry_refs


### PR DESCRIPTION
Closes #186.

## Problem
`resolve()` evaluated the model/user-controlled `selector` with raw `eval(f"obj{selector}", namespace)`, bypassing the AST checks, restricted builtins, and dunder-attribute restrictions that `execute()` enforces. `resolve()` is an MCP-exposed tool, so selector input is model-controlled.

Verified escape before the fix: `.__class__.__base__.__subclasses__()` and `.__class__.__mro__` returned descriptors instead of being rejected — the same traversal `execute()` blocks.

## Fix
Run `check_ast()` on the full `obj{selector}` expression and evaluate it in a namespace seeded with `make_restricted_builtins()` — the same pattern `load_part()` already uses in `library.py`. Dunder traversal, blocked builtins (`getattr`/`eval`/…), and disallowed imports in the selector are now rejected with a clean JSON error. Legitimate selectors (e.g. `.faces().sort_by(Axis.Z)[-1]`) are unaffected.

## Tests
Adds 3 regression tests mirroring the `execute()` sandbox escapes:
- dunder traversal (`.__class__.__mro__`) rejected
- `__subclasses__()` escape chain rejected
- blocked-builtin call in selector rejected

Gate: `mypy` clean (39 files); `pytest` 535 passed.