### PR TITLE
fix(security): keep dunder block active under --allow-all-imports (closes #187)

### DIFF
--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -333,20 +333,15 @@ def check_ast(code: str) -> None:
     except SyntaxError:
         return
 
-    if ALLOW_ALL_IMPORTS:
-        # Still block dangerous calls even in unrestricted mode.
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
-                    raise ValueError(f"Call to '{node.func.id}' is not allowed.")
-        return
-
+    # ALLOW_ALL_IMPORTS relaxes only the import allowlist; the blocked-call and
+    # dunder-attribute layers still apply (as documented in the README) (issue #187).
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            for alias in node.names:
-                _check_module(alias.name)
+            if not ALLOW_ALL_IMPORTS:
+                for alias in node.names:
+                    _check_module(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.module:
+            if not ALLOW_ALL_IMPORTS and node.module:
                 _check_module(node.module)
         elif isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:

--- a/tests/test_allow_all_imports_sandbox.py
+++ b/tests/test_allow_all_imports_sandbox.py
@@ -1,0 +1,46 @@
+"""--allow-all-imports relaxes only the import allowlist (issue #187).
+
+The README documents that with ``--allow-all-imports`` the other sandbox
+layers — restricted builtins, exec timeout, and the dunder-attribute block —
+still apply. These tests pin that posture for ``check_ast``: import checks are
+skipped, but blocked-builtin calls and dunder-attribute traversal are not.
+"""
+
+import pytest
+
+import build123d_mcp.security as _sec
+from build123d_mcp.security import check_ast
+
+
+@pytest.fixture
+def allow_all(monkeypatch):
+    """Enable ALLOW_ALL_IMPORTS for the test, auto-restored afterwards."""
+    monkeypatch.setattr(_sec, "ALLOW_ALL_IMPORTS", True)
+
+
+def test_import_allowlist_relaxed(allow_all):
+    """The whole point of the flag: arbitrary imports pass the AST check."""
+    check_ast("import os")  # must not raise
+
+
+def test_blocked_call_still_rejected(allow_all):
+    """Blocked bare-name calls remain blocked under allow-all."""
+    with pytest.raises(ValueError, match="not allowed"):
+        check_ast("open('/etc/passwd')")
+
+
+def test_dunder_traversal_still_rejected(allow_all):
+    """Dunder-attribute traversal stays blocked under allow-all (issue #187)."""
+    with pytest.raises(ValueError, match="dunder attribute"):
+        check_ast("(1).__class__.__mro__")
+
+
+def test_subclasses_dunder_still_rejected(allow_all):
+    """The __subclasses__ escape chain stays blocked under allow-all."""
+    with pytest.raises(ValueError, match="dunder attribute"):
+        check_ast("().__class__.__base__.__subclasses__()")
+
+
+def test_allowed_inspection_dunder_permitted(allow_all):
+    """Read-only inspection dunders remain usable under allow-all."""
+    check_ast("x.__class__")  # in _ALLOWED_DUNDER_ATTRS — must not raise


### PR DESCRIPTION
Closes #187.

## Problem
`check_ast()` had a dedicated `if ALLOW_ALL_IMPORTS:` branch that checked only blocked bare-name calls and then `return`ed — skipping the `ast.Attribute` dunder-rejection logic that the non-allow-all path runs.

This contradicts `README.md` (security section), which documents that `--allow-all-imports` *"disable[s] the import allowlist entirely. The other layers (restricted builtins for `open`/`eval`/etc, exec timeout, **dunder-attribute block**) still apply."* In allow-all mode, `(1).__class__.__mro__` slipped through.

## Fix
Collapse the divergent early-return into the single AST walk and gate **only** the import checks behind `ALLOW_ALL_IMPORTS`. Blocked-call and dunder-attribute checks now run in every mode — code matches the documented posture, and the duplicated blocked-call loop is gone.

## Tests
New `tests/test_allow_all_imports_sandbox.py` pins the contract with `ALLOW_ALL_IMPORTS=True`:
- `import os` passes (allowlist relaxed)
- `open(...)` still rejected (blocked call)
- `.__mro__` and `.__base__.__subclasses__()` still rejected (dunder block)
- `.__class__` (allowed inspection dunder) still permitted

Confirmed red before the fix (the two dunder tests failed), green after.

Gate: `mypy` clean (39 files); `pytest` 540 passed.