### PR TITLE
fix(server): route state-dependent MCP tools through WorkerSession (closes #179)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -338,22 +338,19 @@ def shape_compare(object_a: str, object_b: str) -> str:
 @mcp.tool()
 def align_check(object_a: str, object_b: str, axis: str = "Z", mode: str = "flush") -> str:
     """Check alignment between two named objects along an axis. axis: X, Y, or Z. mode: flush (signed distance between bbox extremes — positive=A extends further), center (offset between bbox centroids), clearance (gap between nearest faces — positive=apart, negative=overlap). Returns JSON: {delta, axis, mode, object_a, object_b, interpretation}."""
-    from build123d_mcp.tools.align_check import align_check as _align_check
-    return _align_check(_session, object_a, object_b, axis=axis, mode=mode)
+    return _session.align_check(object_a, object_b, axis=axis, mode=mode)
 
 
 @mcp.tool()
 def resolve(object_name: str, selector: str, label: str = "") -> str:
     """Evaluate a selector expression against a named object and return a geometry descriptor. selector is a Python expression suffix applied to the object, e.g. '.faces().filter_by(Axis.Z).last()'. If label is given, the descriptor is stored in session.geometry_refs[label] and appears in session_state(). Returns JSON: {label, ref, object, selector, type, area/length, center, normal (for Face)}. The ref field uses @cad[object#label] format."""
-    from build123d_mcp.tools.resolve import resolve as _resolve
-    return _resolve(_session, object_name, selector, label=label)
+    return _session.resolve(object_name, selector, label=label)
 
 
 @mcp.tool()
 def script(save_to: str = "") -> str:
     """Return a single Python script assembled from all successfully executed code blocks in this session. Prepends 'from build123d import *' if not already present. If save_to is given, writes the script to that path and returns {script_path, blocks}; otherwise returns {script, blocks}. Useful for exporting a reproducible script after an interactive session."""
-    from build123d_mcp.tools.script import script as _script
-    return _script(_session, save_to=save_to)
+    return _session.script(save_to=save_to)
 
 
 @mcp.tool()
@@ -544,8 +541,7 @@ def build123d_presentation_cookbook() -> str:
               description="Live session state: current shape diagnostics, named objects, snapshots, and user-defined variables.")
 def build123d_session_state() -> str:
     """Live session state as JSON."""
-    from build123d_mcp.tools.session_state import session_state
-    return session_state(_session)
+    return _session.session_state()
 
 
 @mcp.resource("build123d://bd_warehouse", mime_type="text/plain",
@@ -593,9 +589,8 @@ def suggest_view_layout(
     Iso position is approximate (75% of 3-D diagonal as half-extent) — verify
     with render_view() and adjust manually if the iso overlaps a neighbour.
     """
-    from build123d_mcp.tools.suggest_view_layout import suggest_view_layout as _fn
-    return _fn(_session, object_name, page_w, page_h, scale, views,
-               title_block_w, title_block_h, margin)
+    return _session.suggest_view_layout(object_name, page_w, page_h, scale, views,
+                                        title_block_w, title_block_h, margin)
 
 
 @mcp.resource("build123d://skill/drawing", mime_type="text/plain",

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -177,6 +177,28 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
         return save_drawing_annotations(session, args["svg_path"])
 
+    if op == "align_check":
+        from build123d_mcp.tools.align_check import align_check
+        return align_check(session, args["object_a"], args["object_b"],
+                           axis=args.get("axis", "Z"), mode=args.get("mode", "flush"))
+
+    if op == "resolve":
+        from build123d_mcp.tools.resolve import resolve
+        return resolve(session, args["object_name"], args["selector"], label=args.get("label", ""))
+
+    if op == "suggest_view_layout":
+        from build123d_mcp.tools.suggest_view_layout import suggest_view_layout
+        return suggest_view_layout(
+            session, args["object_name"], args.get("page_w", 297.0),
+            args.get("page_h", 210.0), args.get("scale", 1.0), args.get("views"),
+            args.get("title_block_w", 150.0), args.get("title_block_h", 30.0),
+            args.get("margin", 10.0),
+        )
+
+    if op == "script":
+        from build123d_mcp.tools.script import script
+        return script(session, save_to=args.get("save_to", ""))
+
     raise ValueError(f"Unknown operation: '{op}'")
 
 
@@ -417,6 +439,42 @@ class WorkerSession:
             {"svg_path": svg_path},
             self._SHORT_TIMEOUT,
         )
+
+    def align_check(self, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush") -> str:
+        return self._call(
+            "align_check",
+            {"object_a": object_a, "object_b": object_b, "axis": axis, "mode": mode},
+            self._SHORT_TIMEOUT,
+        )
+
+    def resolve(self, object_name: str, selector: str, label: str = "") -> str:
+        return self._call(
+            "resolve",
+            {"object_name": object_name, "selector": selector, "label": label},
+            self._SHORT_TIMEOUT,
+        )
+
+    def suggest_view_layout(
+        self,
+        object_name: str,
+        page_w: float = 297.0,
+        page_h: float = 210.0,
+        scale: float = 1.0,
+        views: list[str] | None = None,
+        title_block_w: float = 150.0,
+        title_block_h: float = 30.0,
+        margin: float = 10.0,
+    ) -> str:
+        return self._call(
+            "suggest_view_layout",
+            {"object_name": object_name, "page_w": page_w, "page_h": page_h,
+             "scale": scale, "views": views, "title_block_w": title_block_w,
+             "title_block_h": title_block_h, "margin": margin},
+            self._SHORT_TIMEOUT,
+        )
+
+    def script(self, save_to: str = "") -> str:
+        return self._call("script", {"save_to": save_to}, self._SHORT_TIMEOUT)
 
     def search_library(self, query: str = "") -> str:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)

--- a/tests/test_session_resource.py
+++ b/tests/test_session_resource.py
@@ -1,18 +1,26 @@
-"""Test the build123d://session MCP resource wiring."""
+"""Test the build123d://session MCP resource wiring.
+
+The resource dispatches through the production session proxy, so it is
+exercised against a real WorkerSession — the object server.py uses in
+production — rather than an in-process Session (issue #179).
+"""
 import json
 
 import pytest
 
-from build123d_mcp.session import Session
+from build123d_mcp.worker import WorkerSession
 
 
 @pytest.fixture
 def patched_server(monkeypatch):
-    """Return the server module with _session set to a real Session."""
+    """Return the server module with _session set to a real WorkerSession."""
     import build123d_mcp.server as srv
-    s = Session()
+    s = WorkerSession(exec_timeout=30)
     monkeypatch.setattr(srv, "_session", s, raising=False)
-    return srv, s
+    try:
+        yield srv, s
+    finally:
+        s._kill_worker()
 
 
 def test_session_resource_empty(patched_server):

--- a/tests/test_worker_session_tools.py
+++ b/tests/test_worker_session_tools.py
@@ -46,7 +46,7 @@ def test_resolve_routes_to_worker(ws):
 def test_resolve_label_persists_in_worker_session_state(ws):
     ws.resolve("a", ".faces().sort_by(Axis.Z)[-1]", label="top")
     state = json.loads(ws.session_state())
-    assert "top" in state.get("geometry_refs", {})
+    assert "top" in state["geometry_refs"]
 
 
 def test_suggest_view_layout_routes_to_worker(ws):
@@ -57,6 +57,7 @@ def test_suggest_view_layout_routes_to_worker(ws):
 
 def test_script_routes_to_worker(ws):
     result = json.loads(ws.script())
-    # execute_history lives in the worker; the parent proxy would report 0 blocks.
-    assert result["blocks"] >= 1
+    # The fixture runs exactly one execute() call; execute_history lives in the
+    # worker, so the parent proxy would report 0 blocks (the #179 bug).
+    assert result["blocks"] == 1
     assert "Box(1, 1, 1)" in result["script"]

--- a/tests/test_worker_session_tools.py
+++ b/tests/test_worker_session_tools.py
@@ -1,0 +1,62 @@
+"""WorkerSession end-to-end routing for state-dependent tools (issue #179).
+
+align_check, resolve, suggest_view_layout, and script read Session state
+(objects, current_shape, geometry_refs, execute_history) that lives in the
+worker subprocess. In production ``_session`` is a ``WorkerSession`` proxy, so
+each must dispatch into the worker instead of reading the empty parent proxy.
+These tests spawn a real WorkerSession and exercise the proxy methods that
+server.py calls.
+"""
+
+import json
+
+import pytest
+
+from build123d_mcp.worker import WorkerSession
+
+
+@pytest.fixture
+def ws():
+    s = WorkerSession(exec_timeout=30)
+    s.execute(
+        "from build123d import *\n"
+        "show(Box(1, 1, 1), 'a')\n"
+        "show(Box(1, 1, 1).move(Location((0, 0, 1))), 'b')\n"
+    )
+    try:
+        yield s
+    finally:
+        s._kill_worker()
+
+
+def test_align_check_routes_to_worker(ws):
+    result = json.loads(ws.align_check("a", "b", axis="Z", mode="center"))
+    assert "error" not in result
+    assert result["object_a"] == "a"
+    # b's centre sits 1 mm above a's on Z; delta = a_cen - b_cen = -1.0
+    assert abs(result["delta"] + 1.0) < 1e-6
+
+
+def test_resolve_routes_to_worker(ws):
+    result = json.loads(ws.resolve("a", ".faces().sort_by(Axis.Z)[-1]"))
+    assert "error" not in result
+    assert result["type"] == "Face"
+
+
+def test_resolve_label_persists_in_worker_session_state(ws):
+    ws.resolve("a", ".faces().sort_by(Axis.Z)[-1]", label="top")
+    state = json.loads(ws.session_state())
+    assert "top" in state.get("geometry_refs", {})
+
+
+def test_suggest_view_layout_routes_to_worker(ws):
+    result = json.loads(ws.suggest_view_layout("a"))
+    assert "error" not in result
+    assert "views" in result
+
+
+def test_script_routes_to_worker(ws):
+    result = json.loads(ws.script())
+    # execute_history lives in the worker; the parent proxy would report 0 blocks.
+    assert result["blocks"] >= 1
+    assert "Box(1, 1, 1)" in result["script"]


### PR DESCRIPTION
Closes #179.

## Problem
In production `_session` is a `WorkerSession` proxy; the real `Session` state (`objects`, `current_shape`, `geometry_refs`, `execute_history`) lives in the worker subprocess. Five MCP entrypoints bypassed the proxy and called their helper directly with `_session`, hitting the empty parent:

- `align_check` → `AttributeError: 'WorkerSession' object has no attribute 'objects'`
- `resolve` → same (and labels never persisted)
- `suggest_view_layout` → reads `objects`, fails
- `script` → returned `{"script": "", "blocks": 0}` (history lives in the worker)
- `build123d://session` resource → called `session_state(_session)` directly

## Fix
Add worker `_dispatch` cases + matching `WorkerSession` proxy methods for `align_check`, `resolve`, `suggest_view_layout`, `script` (`session_state` already had both), and update `server.py` to call the proxy methods — matching the established `measure`/`render_view`/`export`/`inspect_drawing` pattern.

`execute_code(_session, …)` (line 19) was correctly left alone — it only uses `.execute()`, which the proxy already forwards.

## Tests
- New `tests/test_worker_session_tools.py`: spawns a real `WorkerSession` and exercises all four tools end-to-end, including `resolve` label persistence visible via `session_state` (proves cross-process state). Confirmed red before the fix (AttributeError), green after.
- `tests/test_session_resource.py`: converted to drive the resource through a `WorkerSession` (the production proxy) rather than an in-process `Session`, per the issue's explicit ask for WorkerSession e2e coverage.

Gate: `mypy` clean (39 files); `pytest` 545 passed.