### PR TITLE
fix(security): route remaining file writers through safe_output_path

### DIFF
--- a/src/build123d_mcp/tools/render_drawing.py
+++ b/src/build123d_mcp/tools/render_drawing.py
@@ -54,10 +54,14 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
 
     result: dict = {"png": png, "size_bytes": len(png), "width": out_width}
     if save_to:
+        # Route through the central path policy (rejects traversal / writes
+        # outside the allowed roots) before opening, like render_view(save_to=...).
+        from build123d_mcp.tools._paths import safe_output_path
+        abs_path = safe_output_path(save_to)
         try:
-            with open(save_to, "wb") as f:
+            with open(abs_path, "wb") as f:
                 f.write(png)
-            result["png_path"] = save_to
+            result["png_path"] = abs_path
         except OSError as e:
-            result["error"] = f"Could not write {save_to}: {e}"
+            result["error"] = f"Could not write {abs_path}: {e}"
     return result

--- a/src/build123d_mcp/tools/save_drawing_annotations.py
+++ b/src/build123d_mcp/tools/save_drawing_annotations.py
@@ -7,6 +7,8 @@ build123d renders Text as filled glyph paths (not SVG <text> elements).
 import json
 import pathlib
 
+from build123d_mcp.tools._paths import safe_output_path
+
 
 def save_drawing_annotations(session, svg_path: str) -> str:
     """Write session.drawing_annotations to <svg_path>.dims.json.
@@ -18,9 +20,12 @@ def save_drawing_annotations(session, svg_path: str) -> str:
     Returns:
         A message string describing how many annotations were saved and where.
     """
+    # Derive the sidecar path, then route it through the central path policy
+    # (rejects traversal / writes outside the allowed roots) before opening.
     sidecar = pathlib.Path(svg_path).with_suffix(".dims.json")
+    abs_sidecar = safe_output_path(str(sidecar))
     annotations = session.drawing_annotations
-    with open(sidecar, "w") as f:
+    with open(abs_sidecar, "w") as f:
         json.dump(annotations, f, indent=2, default=str)
     n = len(annotations)
-    return f"Saved {n} annotation(s) to {sidecar}"
+    return f"Saved {n} annotation(s) to {abs_sidecar}"

--- a/src/build123d_mcp/tools/script.py
+++ b/src/build123d_mcp/tools/script.py
@@ -1,5 +1,7 @@
 import json
 
+from build123d_mcp.tools._paths import safe_output_path
+
 
 def script(session, save_to: str = "") -> str:
     """Join all successfully executed code blocks into a single script.
@@ -23,11 +25,14 @@ def script(session, save_to: str = "") -> str:
         joined = "\n\n".join(blocks)
 
     if save_to:
+        # Route through the central path policy (rejects traversal / writes
+        # outside the allowed roots) before opening, like export()/render_view().
+        abs_path = safe_output_path(save_to)
         try:
-            with open(save_to, "w", encoding="utf-8") as f:
+            with open(abs_path, "w", encoding="utf-8") as f:
                 f.write(joined)
         except OSError as exc:
-            return json.dumps({"error": f"Failed to write script: {exc}", "path": save_to})
-        return json.dumps({"script_path": save_to, "blocks": n}, indent=2)
+            return json.dumps({"error": f"Failed to write script: {exc}", "path": abs_path})
+        return json.dumps({"script_path": abs_path, "blocks": n}, indent=2)
 
     return json.dumps({"script": joined, "blocks": n}, indent=2)

--- a/tests/test_drawing_tooling.py
+++ b/tests/test_drawing_tooling.py
@@ -2,6 +2,7 @@
 view_axes, lint_drawing, render_drawing, inspect_drawing(svg_path=...).
 """
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -364,8 +365,10 @@ class TestRenderDrawing:
         src.write_text(svg)
         out_path = tmp_path / "out.png"
         result = render_drawing(str(src), width=200, save_to=str(out_path))
-        assert result.get("png_path") == str(out_path)
         assert out_path.exists()
+        # png_path is the policy-resolved realpath (may differ from str(out_path)
+        # under a symlinked TMPDIR, e.g. macOS /var -> /private/var).
+        assert os.path.samefile(result["png_path"], out_path)
         assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,102 @@
+"""Path-safety coverage for the remaining file-writing MCP tools (issue #180).
+
+export() and render_view(save_to=...) already route writes through
+``safe_output_path``; script(), render_drawing(), and
+save_drawing_annotations() wrote to caller-provided paths directly. These
+tests mirror the export_file / render_view traversal + outside-root tests and
+assert the same central rejection, plus a happy-path write to a temp root.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+from build123d_mcp.session import Session
+from build123d_mcp.tools.render_drawing import render_drawing
+from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
+from build123d_mcp.tools.script import script
+
+_OUTSIDE_ROOT_PATH = (
+    r"C:\Windows\System32\drivers\etc\hosts"
+    if sys.platform == "win32"
+    else "/etc/passwd"
+)
+_TRAVERSAL = "../../etc/passwd"
+_VALID_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">\n'
+    '  <rect x="5" y="5" width="40" height="40" fill="green"/>\n'
+    "</svg>"
+)
+
+
+@pytest.fixture
+def session():
+    return Session()
+
+
+# --- script(save_to=...) ---------------------------------------------------
+
+def test_script_save_to_path_traversal_rejected(session):
+    session.execute("from build123d import *\nresult = Box(5, 5, 5)")
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        script(session, save_to=_TRAVERSAL + ".py")
+
+
+def test_script_save_to_outside_roots_rejected(session):
+    session.execute("from build123d import *\nresult = Box(5, 5, 5)")
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        script(session, save_to=_OUTSIDE_ROOT_PATH)
+
+
+def test_script_save_to_tmp_allowed(session, tmp_path):
+    session.execute("from build123d import *\nresult = Box(5, 5, 5)")
+    target = tmp_path / "out.py"
+    result = json.loads(script(session, save_to=str(target)))
+    assert os.path.exists(target)
+    assert "script_path" in result
+
+
+# --- render_drawing(save_to=...) -------------------------------------------
+
+def test_render_drawing_save_to_path_traversal_rejected(tmp_path):
+    svg = tmp_path / "in.svg"
+    svg.write_text(_VALID_SVG)
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        render_drawing(str(svg), width=120, save_to=_TRAVERSAL + ".png")
+
+
+def test_render_drawing_save_to_outside_roots_rejected(tmp_path):
+    svg = tmp_path / "in.svg"
+    svg.write_text(_VALID_SVG)
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        render_drawing(str(svg), width=120, save_to=_OUTSIDE_ROOT_PATH)
+
+
+def test_render_drawing_save_to_tmp_allowed(tmp_path):
+    svg = tmp_path / "in.svg"
+    svg.write_text(_VALID_SVG)
+    out = tmp_path / "out.png"
+    result = render_drawing(str(svg), width=120, save_to=str(out))
+    assert out.exists()
+    assert result.get("error") is None
+
+
+# --- save_drawing_annotations(svg_path -> sidecar) -------------------------
+
+def test_save_drawing_annotations_path_traversal_rejected(session):
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        save_drawing_annotations(session, _TRAVERSAL + ".svg")
+
+
+def test_save_drawing_annotations_outside_roots_rejected(session):
+    # /etc/passwd.svg derives sidecar /etc/passwd.dims.json — outside the roots.
+    with pytest.raises(ValueError, match="outside the allowed write roots"):
+        save_drawing_annotations(session, _OUTSIDE_ROOT_PATH + ".svg")
+
+
+def test_save_drawing_annotations_tmp_allowed(session, tmp_path):
+    svg_path = str(tmp_path / "drawing.svg")
+    result = save_drawing_annotations(session, svg_path)
+    assert (tmp_path / "drawing.dims.json").exists()
+    assert "annotation" in result


### PR DESCRIPTION
Closes #180.

The sandbox path policy rejects traversal and writes outside the workspace/temp roots. `export()` and `render_view(save_to=...)` enforce it via `safe_output_path`, but three other MCP-exposed file writers wrote to caller-provided paths directly — a model-driven caller could write to `../../etc/passwd` or any absolute path:

| Tool | Before | After |
|------|--------|-------|
| `script(save_to=...)` | `open(save_to, "w")` | `open(safe_output_path(save_to), "w")` |
| `render_drawing(save_to=...)` | `open(save_to, "wb")` | `open(safe_output_path(save_to), "wb")` |
| `save_drawing_annotations(svg_path)` | `open(<derived sidecar>, "w")` | validates the derived `.dims.json` sidecar before opening |

Each now resolves its write target through the central policy before opening, raising `ValueError("...outside the allowed write roots")` on rejection — identical surfacing to the reference tools. The resolved absolute path is returned in `script_path` / `png_path` / the save message, matching how `export()` reports `abs_path`.

## Tests
`tests/test_path_safety.py` — for all three tools: path-traversal rejected, outside-root rejected, and a temp-root happy path, mirroring the existing `export_file` / `render_view(save_to=...)` path tests. Each rejection test was verified **red** against the prior code (the tools wrote or raised `OSError` rather than the policy `ValueError`).

## Gate
- `uv run mypy src/build123d_mcp/` — clean (39 files)
- `uv run pytest tests/ --timeout=300` — 574 passed (565 + 9 new)