### PR TITLE
chore(lint): adopt ruff format + objective lint gate (Phase 1, #185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,14 @@ jobs:
         if: runner.os == 'Linux'
         run: uv run mypy src/build123d_mcp/
 
+      # Lint + format are OS-independent — run once on Linux (like mypy).
+      - name: Lint
+        if: runner.os == 'Linux'
+        run: uv run ruff check .
+
+      - name: Format check
+        if: runner.os == 'Linux'
+        run: uv run ruff format --check .
+
       - name: Run tests
         run: uv run pytest tests/ -v --timeout=300

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,23 @@ dev = [
     "pytest-timeout",
     "mypy",
     "pytest-cov>=7.1.0",
+    "ruff",
 ]
 
 [tool.mypy]
 files = ["src"]
 ignore_missing_imports = true
+
+[tool.ruff]
+# line-length 100 matches the existing code; E501 is not enabled, so this only
+# governs where the formatter reflows code (not comments or strings).
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+# Phase 1 (issue #185): objective, auto-fixable rules only. Safety/complexity
+# rules (BLE blind-except, S bandit, C901) are intentionally deferred — the
+# sandbox/worker design uses deliberate broad-excepts and eval/exec/subprocess
+# that would each need per-site noqa judgement, out of scope for an automated
+# baseline.
+select = ["F", "I", "UP", "C4"]

--- a/src/build123d_mcp/bd_warehouse_resource.py
+++ b/src/build123d_mcp/bd_warehouse_resource.py
@@ -2,13 +2,12 @@
 
 If bd_warehouse is not installed the resource returns a short explanation.
 """
+
 from __future__ import annotations
 
 import importlib
 import inspect
-import pkgutil
 import re
-from typing import Optional
 
 # Standard build123d parameters — not useful to show in the catalogue.
 _SKIP_PARAMS = frozenset({"self", "rotation", "align", "mode", "hand", "simple"})
@@ -61,7 +60,7 @@ def _sizes_for_type(cls, type_value: str) -> list[str]:
         return []
 
 
-def _format_class(cls) -> Optional[str]:
+def _format_class(cls) -> str | None:
     """Return a formatted entry for one class, or None to skip."""
     sig = inspect.signature(cls.__init__) if hasattr(cls, "__init__") else None
     lines = [f"{cls.__name__}{_sig_summary(cls)}"]
@@ -95,7 +94,7 @@ def _format_class(cls) -> Optional[str]:
 
 def build_bd_warehouse_text() -> str:
     try:
-        import bd_warehouse  # noqa: PLC0415
+        import bd_warehouse  # noqa: F401, PLC0415  # imported only to probe availability
     except ImportError:
         return (
             "bd_warehouse is not installed.\n"

--- a/src/build123d_mcp/drafting_cookbook.py
+++ b/src/build123d_mcp/drafting_cookbook.py
@@ -12,14 +12,14 @@ Sections with a label are runnable code blocks executed by
 tests/test_drafting_cookbook.py — they must end with `result = ...`
 or `show(...)` so current_shape is set.
 """
+
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class Section:
     text: str
-    label: Optional[str] = None
+    label: str | None = None
 
 
 SECTIONS: list[Section] = [
@@ -150,7 +150,6 @@ SECTIONS: list[Section] = [
         "  # 3. Verify numerically before rendering\n"
         "  # => call inspect_drawing() to get bboxes + lint warnings"
     ),
-
     Section(
         text="""\
 ## ENGINEERING-DRAWING CONVENTIONS — read before you dimension
@@ -202,7 +201,6 @@ SECTIONS: list[Section] = [
 ## CLASSES → annotate() each → set_page() → lint_drawing() == 0 violations →
 ## render to eyeball → export. Never export before lint is clean."""
     ),
-
     Section(
         text="""\
 ## The Draft config — set once, reuse everywhere
@@ -213,7 +211,6 @@ SECTIONS: list[Section] = [
 # Common engineering settings: smaller font, single-decimal mm, narrow arrows
 # draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=2.0)"""
     ),
-
     Section(
         label="basic_dimension",
         text="""\
@@ -232,7 +229,6 @@ show(result, "dim")
 # (Dimension wraps build123d's ExtensionLine; reach for raw ExtensionLine only
 #  when you need its lower-level offset/tolerance knobs directly.)""",
     ),
-
     Section(
         label="dimension_with_tolerance",
         text="""\
@@ -250,7 +246,6 @@ result = ExtensionLine(
 )
 show(result, "tol_dim")""",
     ),
-
     Section(
         label="diameter_dimension",
         text="""\
@@ -267,7 +262,6 @@ result = DimensionLine(
 )
 show(result, "dia_dim")""",
     ),
-
     Section(
         label="project_to_view",
         text="""\
@@ -289,7 +283,6 @@ print(f"visible edges: {len(visible.edges())}, hidden: {len(hidden.edges())}")
 result = Compound(children=list(visible))
 show(result, "top_view")""",
     ),
-
     Section(
         label="dimensioned_view",
         text="""\
@@ -312,7 +305,6 @@ hole   = Leader((10, 0, 0), (24, 12, 0), "⌀6 THRU", draft)   # hole → callou
 result = Compound(children=list(visible) + [length, width, hole])
 show(result, "dimensioned_top")""",
     ),
-
     Section(
         label="title_block",
         text="""\
@@ -331,7 +323,6 @@ result = TechnicalDrawing(
 )
 show(result, "title_sheet")""",
     ),
-
     Section(
         label="build_then_review_then_ship",
         text="""\
@@ -364,7 +355,6 @@ hole   = Leader((10, 0, 0), (24, 12, 0), "⌀6 THRU", draft)
 result = Compound(children=list(visible) + [length, width, hole])
 show(result, "bracket_top_view")""",
     ),
-
     Section(
         label="multi_view_layout",
         text="""\
@@ -391,7 +381,6 @@ side_view  = side.translate((30, 0, 0))
 result = Compound(children=[top_view, front_view, side_view])
 show(result, "three_view")""",
     ),
-
     Section(
         label="hole_table_pattern",
         text="""\
@@ -425,7 +414,6 @@ visible, _ = plate.project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 result = Compound(children=list(visible) + labels)
 show(result, "hole_callouts_demo")""",
     ),
-
     Section(
         label="clean_svg_export",
         text="""\
@@ -469,7 +457,6 @@ exporter.add_shape(length, layer="dims")
 result = Compound(children=list(visible) + [length])
 show(result, "clean_svg_demo")""",
     ),
-
     Section(
         label="stacking_and_page_bounds",
         text="""\
@@ -513,7 +500,6 @@ set_page(297, 210, margin=10)
 result = Compound(children=list(visible) + [total, left, right, height])
 show(result, "stacked_dims_demo")""",
     ),
-
     Section(
         text="""\
 ## CENTERLINE-LABEL COLLISION AVOIDANCE
@@ -547,7 +533,6 @@ show(result, "stacked_dims_demo")""",
 ##   annotate(d, "bore_dim")
 ##   lint_drawing()  # → label_centerline_overlap warning if label crosses bore_cl"""
     ),
-
     Section(
         label="gdt_symbols",
         text="""\
@@ -590,7 +575,6 @@ result = Compound(children=[
 ])
 show(result, "gdt_demo")""",
     ),
-
     Section(
         text="""\
 ## Limitations and gaps in build123d.drafting today
@@ -606,7 +590,6 @@ show(result, "gdt_demo")""",
 # When you hit any of these, the answer is to compose the lower-level
 # build123d primitives yourself — Sketch + Line + Text + Polyline."""
     ),
-
     Section(
         text="""\
 ## When to use which output format
@@ -689,6 +672,7 @@ def _build123d_version_banner() -> str:
     """Reflect the actually-installed build123d version so callers know exactly
     which API surface these examples target."""
     from importlib.metadata import PackageNotFoundError, version
+
     try:
         v = version("build123d")
     except PackageNotFoundError:

--- a/src/build123d_mcp/presentation_cookbook.py
+++ b/src/build123d_mcp/presentation_cookbook.py
@@ -21,14 +21,14 @@ Sections with a label are runnable code blocks executed by
 tests/test_presentation_cookbook.py — they must end with `result = ...`
 or `show(...)` so current_shape is set.
 """
+
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class Section:
     text: str
-    label: Optional[str] = None
+    label: str | None = None
 
 
 SECTIONS: list[Section] = [
@@ -66,7 +66,6 @@ SECTIONS: list[Section] = [
         "still re-use the same constants and assertions as your canonical\n"
         "model — single source of truth is preserved."
     ),
-
     Section(
         label="scaled_draft",
         text="""\
@@ -100,7 +99,6 @@ result = ExtensionLine(
 )
 show(result, "scaled_dim")""",
     ),
-
     Section(
         label="layered_svg_export",
         text="""\
@@ -138,7 +136,6 @@ exporter.add_shape(length_dim, layer="dims")
 result = Compound(children=list(visible) + [length_dim])
 show(result, "layered_demo")""",
     ),
-
     Section(
         label="filled_feature_highlight",
         text="""\
@@ -172,7 +169,6 @@ peg_fill    = Pos( 6, 0, 0) * Circle(1.0)   # ø2 locating peg
 result = Compound(children=list(visible) + [insert_fill, peg_fill])
 show(result, "filled_features_demo")""",
     ),
-
     Section(
         label="legend_with_swatches",
         text="""\
@@ -216,7 +212,6 @@ labels   = [label(y, t) for y, t in entries]
 result = Compound(children=swatches + labels)
 show(result, "legend_demo")""",
     ),
-
     Section(
         label="reference_axes",
         text="""\
@@ -253,7 +248,6 @@ for ty in Y_TICKS:
 result = Compound(children=axis_parts)
 show(result, "axes_demo")""",
     ),
-
     Section(
         label="title_and_subtitle",
         text="""\
@@ -275,7 +269,6 @@ subtitle = Location((9, 13.0, 0)) * Text(
 result = Compound(children=[title, subtitle])
 show(result, "title_demo")""",
     ),
-
     Section(
         text="""\
 ## Recipe 7: layer ordering in the exporter
@@ -300,7 +293,6 @@ show(result, "title_demo")""",
 #   exporter.add_shape(axes,        layer="axes")           # 4. axes
 #   exporter.add_shape(title_block, layer="title")          # 5. title"""
     ),
-
     Section(
         text="""\
 ## Recipe 8: rasterise the SVG to PNG with resvg_py
@@ -318,7 +310,6 @@ show(result, "title_demo")""",
 # Run this from your repo's diagram script — the MCP sandbox blocks
 # resvg, so it lives outside the sandbox alongside your ExportSVG call."""
     ),
-
     Section(
         text="""\
 ## Decision: which output for which audience
@@ -340,6 +331,7 @@ def _build123d_version_banner() -> str:
     """Reflect the actually-installed build123d version so callers know exactly
     which API surface these examples target."""
     from importlib.metadata import PackageNotFoundError, version
+
     try:
         v = version("build123d")
     except PackageNotFoundError:

--- a/src/build123d_mcp/quickref.py
+++ b/src/build123d_mcp/quickref.py
@@ -6,14 +6,14 @@ Prose-only sections (no label) are reference documentation that cannot be run.
 build_quickref_text() assembles all sections into the MCP resource text.
 RUNNABLE_EXAMPLES is the list used by tests/test_quickref.py.
 """
+
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class Section:
     text: str
-    label: Optional[str] = None  # None = prose only, not tested
+    label: str | None = None  # None = prose only, not tested
 
 
 SECTIONS: list[Section] = [
@@ -21,7 +21,6 @@ SECTIONS: list[Section] = [
         "BUILD123D QUICK REFERENCE — all measurements in mm\n"
         "===================================================="
     ),
-
     Section(
         label="pattern1",
         text="""\
@@ -33,7 +32,6 @@ result = Box(20, 10, 5)
 result = result - Cylinder(3, 6).move(Location((0, 0, 0)))
 show(result, "part")""",
     ),
-
     Section(
         label="pattern2",
         text="""\
@@ -47,7 +45,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "part")""",
     ),
-
     Section(
         text="""\
 ## Primitives
@@ -57,7 +54,6 @@ Sphere(radius)
 Cone(bottom_radius, top_radius, height)
 Torus(major_radius, minor_radius)""",
     ),
-
     Section(
         text="""\
 ## Boolean operators (direct algebra)
@@ -65,7 +61,6 @@ a + b    # union
 a - b    # cut b from a
 a & b    # intersection""",
     ),
-
     Section(
         text="""\
 ## Boolean modes (inside BuildPart)
@@ -74,7 +69,6 @@ mode=Mode.SUBTRACT   # cut from existing solid
 mode=Mode.INTERSECT  # keep overlap only
 mode=Mode.REPLACE    # replace current solid entirely""",
     ),
-
     Section(
         label="align",
         text="""\
@@ -84,7 +78,6 @@ from build123d import *
 corner = Box(10, 5, 3, align=(Align.MIN, Align.MIN, Align.MIN))        # corner at origin
 result = Box(10, 5, 3, align=(Align.CENTER, Align.CENTER, Align.MIN))  # centred XY, bottom at Z=0""",
     ),
-
     Section(
         label="translate",
         text="""\
@@ -94,7 +87,6 @@ shape = Box(10, 5, 3)
 result = shape.move(Location((5, 0, 0)))
 rotated = shape.move(Location((5, 0, 0), (0, 0, 45)))""",
     ),
-
     Section(
         label="extrude",
         text="""\
@@ -108,7 +100,6 @@ with BuildPart() as p:
     extrude(amount=15)
 result = p.part""",
     ),
-
     Section(
         label="revolve",
         text="""\
@@ -121,7 +112,6 @@ with BuildPart() as p:
     revolve(axis=Axis.Z)                 # full 360°
 result = p.part""",
     ),
-
     Section(
         label="selectors",
         text="""\
@@ -134,7 +124,6 @@ top_edges   = result.edges().sort_by(Axis.Z)[-4:]       # 4 edges at highest Z (
 z_edges     = result.edges().filter_by(Axis.Z)          # edges parallel to Z
 flat_faces  = result.faces().filter_by(GeomType.PLANE)  # planar faces only""",
     ),
-
     Section(
         label="fillet_chamfer",
         text="""\
@@ -151,7 +140,6 @@ with BuildPart() as p:
     chamfer(p.part.edges().sort_by(Axis.Z)[-4:], length=0.5)
 result = p.part""",
     ),
-
     Section(
         label="joints_rigid",
         text="""\
@@ -172,7 +160,6 @@ plate.joints["mount"].connect_to(pin.joints["base"])
 show(plate, "plate")
 show(pin, "pin")""",
     ),
-
     Section(
         text="""\
 ## Joint types
@@ -186,7 +173,6 @@ BallJoint(label, to_part, joint_location, angular_range) # 3 rotations, 0 transl
 #   plate.joints["hinge"].connect_to(arm.joints["pivot"], angle=45)
 #   rail.joints["slot"].connect_to(carriage.joints["slide"], position=10)""",
     ),
-
     Section(
         label="grid_locations",
         text="""\
@@ -202,7 +188,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "plate_with_grid_holes")""",
     ),
-
     Section(
         label="polar_locations",
         text="""\
@@ -217,7 +202,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "flange")""",
     ),
-
     Section(
         label="manual_locations",
         text="""\
@@ -232,7 +216,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "plate_with_3_holes")""",
     ),
-
     Section(
         label="position_tangent_at",
         text="""\
@@ -248,7 +231,6 @@ with BuildLine() as l:
 result = l.line
 show(result, "chained_path")""",
     ),
-
     Section(
         label="op_sweep",
         text="""\
@@ -262,7 +244,6 @@ with BuildSketch() as profile:
 result = sweep(profile.sketch, path=path.line)
 show(result, "tube")""",
     ),
-
     Section(
         label="op_loft",
         text="""\
@@ -279,7 +260,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "transition")""",
     ),
-
     Section(
         label="op_mirror",
         text="""\
@@ -291,7 +271,6 @@ half = Box(10, 5, 3).move(Location((5, 0, 0)))   # off-centre half
 result = half + mirror(half, about=Plane.YZ)
 show(result, "symmetric")""",
     ),
-
     Section(
         label="op_offset",
         text="""\
@@ -305,7 +284,6 @@ with BuildSketch() as s:
 result = thicken(s.sketch, amount=1)   # turn into a 3D shell-base
 show(result, "offset_plate")""",
     ),
-
     Section(
         label="op_thicken",
         text="""\
@@ -316,7 +294,6 @@ sketch = Rectangle(20, 10)
 result = thicken(sketch, amount=3)
 show(result, "thickened_plate")""",
     ),
-
     Section(
         label="mode_private",
         text="""\
@@ -332,7 +309,6 @@ with BuildPart() as p:
 result = p.part
 show(result, "part_unchanged_by_private")""",
     ),
-
     Section(
         text="""\
 ## MCP server conventions
@@ -340,7 +316,6 @@ show(result, "part_unchanged_by_private")""",
 - show(shape, "name")      registers object, prints vol + face count as immediate confirmation
 - named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right""",
     ),
-
     Section(
         text="""\
 ## Common gotchas
@@ -359,6 +334,7 @@ def _build123d_version_banner() -> str:
     which API surface these examples target. The version may differ from the
     pyproject.toml pin if the user manually overrode it."""
     from importlib.metadata import PackageNotFoundError, version
+
     try:
         v = version("build123d")
     except PackageNotFoundError:

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -27,127 +27,131 @@ EXEC_TIMEOUT_SECONDS = 120
 
 # Modules user code may import. build123d's own internal imports are
 # unaffected — they run through the real import system, not this namespace.
-IMPORT_ALLOWLIST = frozenset({
-    # CAD libraries
-    "build123d",
-    "bd_warehouse",
-    "build123d_drafting",
-    # Numeric / math
-    "math",
-    "numpy",
-    "decimal",
-    "fractions",
-    "statistics",
-    "numbers",
-    "random",
-    # Data structures / utilities
-    "collections",
-    "itertools",
-    "functools",
-    "copy",
-    "operator",
-    "struct",
-    # Type system
-    "typing",
-    "abc",
-    "dataclasses",
-    "enum",
-    # String / text
-    "re",
-    "string",
-    "textwrap",
-    "pprint",
-    # Serialisation (in-memory only — no I/O)
-    "json",
-    "base64",
-    "hashlib",
-    # Misc stdlib
-    "io",
-    "warnings",
-    "contextlib",
-    # Introspection — signature(), getdoc(), getmembers() are read-only and help with
-    # API discovery without requiring docs. Cannot execute code.
-    "inspect",
-})
+IMPORT_ALLOWLIST = frozenset(
+    {
+        # CAD libraries
+        "build123d",
+        "bd_warehouse",
+        "build123d_drafting",
+        # Numeric / math
+        "math",
+        "numpy",
+        "decimal",
+        "fractions",
+        "statistics",
+        "numbers",
+        "random",
+        # Data structures / utilities
+        "collections",
+        "itertools",
+        "functools",
+        "copy",
+        "operator",
+        "struct",
+        # Type system
+        "typing",
+        "abc",
+        "dataclasses",
+        "enum",
+        # String / text
+        "re",
+        "string",
+        "textwrap",
+        "pprint",
+        # Serialisation (in-memory only — no I/O)
+        "json",
+        "base64",
+        "hashlib",
+        # Misc stdlib
+        "io",
+        "warnings",
+        "contextlib",
+        # Introspection — signature(), getdoc(), getmembers() are read-only and help with
+        # API discovery without requiring docs. Cannot execute code.
+        "inspect",
+    }
+)
 
 # OCP (OpenCASCADE Python bindings) sub-modules that are safe to import.
 # These are purely geometric — no filesystem, no OS, no network access.
 # Blocked: STEPControl, IGESControl, OSD, Storage, PCDM, TDocStd, Interface,
 #          IFSelect, XCAFDoc, Resource — all of which expose file I/O.
-OCP_ALLOWLIST = frozenset({
-    # Geometric primitives
-    "OCP.gp",
-    # Topology
-    "OCP.TopAbs",
-    "OCP.TopExp",
-    "OCP.TopLoc",
-    "OCP.TopTools",
-    "OCP.TopoDS",
-    # B-rep core
-    "OCP.BRep",
-    "OCP.BRepTools",
-    "OCP.BRepLib",
-    # B-rep analysis
-    "OCP.BRepAdaptor",
-    "OCP.BRepBndLib",
-    "OCP.BRepCheck",
-    "OCP.BRepClass",
-    "OCP.BRepClass3d",
-    "OCP.BRepExtrema",
-    "OCP.BRepGProp",
-    "OCP.BRepIntCurveSurface",
-    # B-rep construction
-    "OCP.BRepBuilderAPI",
-    "OCP.BRepPrimAPI",
-    "OCP.BRepFeat",
-    "OCP.BRepFilletAPI",
-    "OCP.BRepOffsetAPI",
-    "OCP.BRepSweep",
-    "OCP.BRepProj",
-    # B-rep operations
-    "OCP.BRepAlgoAPI",
-    "OCP.BRepMesh",
-    # Geometry
-    "OCP.Geom",
-    "OCP.Geom2d",
-    "OCP.GeomAbs",
-    "OCP.GeomAPI",
-    "OCP.GeomAdaptor",
-    "OCP.GeomConvert",
-    "OCP.GeomFill",
-    "OCP.GeomLProp",
-    "OCP.GeomProjLib",
-    "OCP.GeomTools",
-    # Adaptors
-    "OCP.Adaptor2d",
-    "OCP.Adaptor3d",
-    # Properties and analysis
-    "OCP.GProp",
-    "OCP.GCPnts",
-    "OCP.Bnd",
-    "OCP.IntCurvesFace",
-    "OCP.IntTools",
-    "OCP.Extrema",
-    # Mesh / polygon
-    "OCP.Poly",
-    # Shape analysis and repair
-    "OCP.ShapeAnalysis",
-    "OCP.ShapeCustom",
-    "OCP.ShapeExtend",
-    "OCP.ShapeFix",
-    "OCP.ShapeUpgrade",
-    # Collection types
-    "OCP.TColgp",
-    "OCP.TColGeom",
-    "OCP.TColStd",
-    "OCP.TCollection",
-    # Misc safe
-    "OCP.MAT",
-    "OCP.Approx",
-    "OCP.Convert",
-    "OCP.BSpl",
-    "OCP.ProjLib",
-})
+OCP_ALLOWLIST = frozenset(
+    {
+        # Geometric primitives
+        "OCP.gp",
+        # Topology
+        "OCP.TopAbs",
+        "OCP.TopExp",
+        "OCP.TopLoc",
+        "OCP.TopTools",
+        "OCP.TopoDS",
+        # B-rep core
+        "OCP.BRep",
+        "OCP.BRepTools",
+        "OCP.BRepLib",
+        # B-rep analysis
+        "OCP.BRepAdaptor",
+        "OCP.BRepBndLib",
+        "OCP.BRepCheck",
+        "OCP.BRepClass",
+        "OCP.BRepClass3d",
+        "OCP.BRepExtrema",
+        "OCP.BRepGProp",
+        "OCP.BRepIntCurveSurface",
+        # B-rep construction
+        "OCP.BRepBuilderAPI",
+        "OCP.BRepPrimAPI",
+        "OCP.BRepFeat",
+        "OCP.BRepFilletAPI",
+        "OCP.BRepOffsetAPI",
+        "OCP.BRepSweep",
+        "OCP.BRepProj",
+        # B-rep operations
+        "OCP.BRepAlgoAPI",
+        "OCP.BRepMesh",
+        # Geometry
+        "OCP.Geom",
+        "OCP.Geom2d",
+        "OCP.GeomAbs",
+        "OCP.GeomAPI",
+        "OCP.GeomAdaptor",
+        "OCP.GeomConvert",
+        "OCP.GeomFill",
+        "OCP.GeomLProp",
+        "OCP.GeomProjLib",
+        "OCP.GeomTools",
+        # Adaptors
+        "OCP.Adaptor2d",
+        "OCP.Adaptor3d",
+        # Properties and analysis
+        "OCP.GProp",
+        "OCP.GCPnts",
+        "OCP.Bnd",
+        "OCP.IntCurvesFace",
+        "OCP.IntTools",
+        "OCP.Extrema",
+        # Mesh / polygon
+        "OCP.Poly",
+        # Shape analysis and repair
+        "OCP.ShapeAnalysis",
+        "OCP.ShapeCustom",
+        "OCP.ShapeExtend",
+        "OCP.ShapeFix",
+        "OCP.ShapeUpgrade",
+        # Collection types
+        "OCP.TColgp",
+        "OCP.TColGeom",
+        "OCP.TColStd",
+        "OCP.TCollection",
+        # Misc safe
+        "OCP.MAT",
+        "OCP.Approx",
+        "OCP.Convert",
+        "OCP.BSpl",
+        "OCP.ProjLib",
+    }
+)
 
 # When True, import checks are skipped entirely.  Set via --allow-all-imports.
 ALLOW_ALL_IMPORTS: bool = False
@@ -190,9 +194,7 @@ def _source_path(dotted_name: str) -> str | None:
     return spec.origin
 
 
-def _is_transitively_safe(
-    dotted_name: str, _visiting: frozenset[str] = frozenset()
-) -> bool:
+def _is_transitively_safe(dotted_name: str, _visiting: frozenset[str] = frozenset()) -> bool:
     """Return True if every transitive import of this module is from the allowlist.
 
     Pure-Python packages whose full import closure stays within
@@ -231,8 +233,11 @@ def _is_transitively_safe(
         # are checked individually when they're actually imported.
         try:
             spec = importlib.util.find_spec(dotted_name)
-            is_ns = (spec is not None and spec.origin is None
-                     and spec.submodule_search_locations is not None)
+            is_ns = (
+                spec is not None
+                and spec.origin is None
+                and spec.submodule_search_locations is not None
+            )
         except Exception:
             is_ns = False
         _transitive_safe_cache[dotted_name] = is_ns
@@ -253,7 +258,9 @@ def _is_transitively_safe(
             return False
 
     try:
-        with open(path, encoding="utf-8", errors="replace") as f:  # server-side read; not user-sandbox open
+        with open(
+            path, encoding="utf-8", errors="replace"
+        ) as f:  # server-side read; not user-sandbox open
             source = f.read()
         tree = ast.parse(source)
     except (OSError, SyntaxError):
@@ -296,13 +303,22 @@ def _is_transitively_safe(
 
 
 # Builtins that are dangerous even without an import.
-_BLOCKED_BUILTINS = frozenset({
-    "eval", "exec", "compile", "open", "breakpoint", "input",
-    # getattr/vars/hasattr can bypass the dunder-attribute AST block via string arguments
-    # (e.g. getattr(obj, '__class__')). dir() is safe: it only enumerates names already
-    # in scope; dunder attribute *access* is still blocked at the AST level.
-    "getattr", "vars", "hasattr",
-})
+_BLOCKED_BUILTINS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "breakpoint",
+        "input",
+        # getattr/vars/hasattr can bypass the dunder-attribute AST block via string arguments
+        # (e.g. getattr(obj, '__class__')). dir() is safe: it only enumerates names already
+        # in scope; dunder attribute *access* is still blocked at the AST level.
+        "getattr",
+        "vars",
+        "hasattr",
+    }
+)
 
 # Dunder attributes that are safe to read (no traversal to __subclasses__ etc.
 # because those are still blocked).  __class__ is safe: __subclasses__ is still
@@ -310,17 +326,28 @@ _BLOCKED_BUILTINS = frozenset({
 _ALLOWED_DUNDER_ATTRS = frozenset({"__name__", "__doc__", "__class__"})
 
 # Bare-name calls that are caught at the AST level (before exec runs).
-_BLOCKED_CALL_NAMES = frozenset({
-    "__import__", "eval", "exec", "compile", "open", "breakpoint", "input",
-    # Same rationale as _BLOCKED_BUILTINS: getattr/vars/hasattr bypass the dunder check
-    # via string arguments. dir() allowed.
-    "getattr", "vars", "hasattr",
-})
+_BLOCKED_CALL_NAMES = frozenset(
+    {
+        "__import__",
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "breakpoint",
+        "input",
+        # Same rationale as _BLOCKED_BUILTINS: getattr/vars/hasattr bypass the dunder check
+        # via string arguments. dir() allowed.
+        "getattr",
+        "vars",
+        "hasattr",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
 # Layer 1: AST inspection
 # ---------------------------------------------------------------------------
+
 
 def check_ast(code: str) -> None:
     """Raise ValueError if code contains disallowed imports or dangerous calls.
@@ -345,9 +372,7 @@ def check_ast(code: str) -> None:
                 _check_module(node.module)
         elif isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
-                raise ValueError(
-                    f"Call to '{node.func.id}' is not allowed."
-                )
+                raise ValueError(f"Call to '{node.func.id}' is not allowed.")
         elif isinstance(node, ast.Attribute):
             if node.attr.startswith("__") and node.attr.endswith("__"):
                 if node.attr not in _ALLOWED_DUNDER_ATTRS:
@@ -392,6 +417,7 @@ def _check_module(dotted_name: str) -> None:
 # Layer 2: Restricted builtins
 # ---------------------------------------------------------------------------
 
+
 def make_restricted_builtins() -> dict[str, Any]:
     """Return a __builtins__ dict with dangerous functions removed.
 
@@ -401,6 +427,7 @@ def make_restricted_builtins() -> dict[str, Any]:
     namespace level even if AST inspection is somehow bypassed.
     """
     import builtins
+
     safe = vars(builtins).copy()
 
     for name in _BLOCKED_BUILTINS:
@@ -446,6 +473,7 @@ def make_restricted_builtins() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Timeout exception (raised by SIGALRM in Session or propagated by WorkerSession)
 # ---------------------------------------------------------------------------
+
 
 class ExecutionTimeout(Exception):
     pass

--- a/src/build123d_mcp/selectors_cookbook.py
+++ b/src/build123d_mcp/selectors_cookbook.py
@@ -5,14 +5,14 @@ Sections with a label are runnable code blocks executed by
 tests/test_selectors_cookbook.py — they must end with `result = ...` or
 `show(...)` so current_shape is set.
 """
+
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class Section:
     text: str
-    label: Optional[str] = None  # None = prose only, not tested
+    label: str | None = None  # None = prose only, not tested
 
 
 SECTIONS: list[Section] = [
@@ -27,7 +27,6 @@ SECTIONS: list[Section] = [
         "in the topology first, then drill down. Find the parent face,\n"
         "then ask the face for its edges. Avoids brittle global queries."
     ),
-
     Section(
         label="drilldown",
         text="""\
@@ -41,7 +40,6 @@ hole_edges = top_face.edges().filter_by(GeomType.CIRCLE)
 print(f"top face area: {top_face.area:.1f}, hole edges: {len(hole_edges)}")
 result = plate""",
     ),
-
     Section(
         label="cardinal_faces",
         text="""\
@@ -56,7 +54,6 @@ right  = plate.faces().sort_by(Axis.X)[-1]   # highest X
 print(f"top={top.area}, bottom={bottom.area}, right={right.area}")
 result = plate""",
     ),
-
     Section(
         label="by_geom_type_edges",
         text="""\
@@ -69,7 +66,6 @@ lines   = plate.edges().filter_by(GeomType.LINE)
 print(f"circles: {len(circles)}, lines: {len(lines)}")
 result = plate""",
     ),
-
     Section(
         label="by_geom_type_faces",
         text="""\
@@ -83,7 +79,6 @@ planes    = part.faces().filter_by(GeomType.PLANE)
 print(f"cylindrical faces (hole walls): {len(cylinders)}, planar: {len(planes)}")
 result = part""",
     ),
-
     Section(
         label="parallel_perpendicular",
         text="""\
@@ -97,7 +92,6 @@ side_x     = part.faces().filter_by(Axis.X)    # 2 faces: +X and -X
 print(f"horizontal: {len(horizontal)}, perpendicular to X: {len(side_x)}")
 result = part""",
     ),
-
     Section(
         label="largest_face",
         text="""\
@@ -110,7 +104,6 @@ longest_edge = part.edges().sort_by(SortBy.LENGTH)[-1]
 print(f"largest face area: {largest_face.area}, longest edge: {longest_edge.length}")
 result = part""",
     ),
-
     Section(
         label="lambda_filter",
         text="""\
@@ -122,7 +115,6 @@ twenty_long = part.edges().filter_by(lambda e: abs(e.length - 20) < 1e-3)
 print(f"edges ~20mm long: {len(twenty_long)}")
 result = part""",
     ),
-
     Section(
         label="circles_by_radius",
         text="""\
@@ -136,7 +128,6 @@ r3 = plate.edges().filter_by(GeomType.CIRCLE).filter_by(lambda e: abs(e.radius -
 print(f"3mm circles: {len(r3)}")
 result = plate""",
     ),
-
     Section(
         label="select_last_in_builder",
         text="""\
@@ -153,7 +144,6 @@ with BuildPart() as p:
     fillet(new.filter_by(GeomType.CIRCLE), radius=0.5)
 result = p.part""",
     ),
-
     Section(
         label="select_modes",
         text="""\
@@ -170,7 +160,6 @@ with BuildPart() as p:
     print(f"ALL: {len(p.edges(Select.ALL))}, LAST: {len(p.edges(Select.LAST))}")
 result = p.part""",
     ),
-
     Section(
         label="chain_filters",
         text="""\
@@ -183,7 +172,6 @@ small_circles = part.edges().filter_by(GeomType.CIRCLE).filter_by(lambda e: e.ra
 print(f"small circles: {len(small_circles)}")
 result = part""",
     ),
-
     Section(
         label="sort_then_slice",
         text="""\
@@ -199,7 +187,6 @@ two_biggest = plate.edges().filter_by(GeomType.CIRCLE).sort_by(SortBy.RADIUS)[-2
 print(f"two biggest circles, radii: {sorted(e.radius for e in two_biggest)}")
 result = plate""",
     ),
-
     Section(
         label="convex_fillets",
         text="""\
@@ -213,7 +200,6 @@ result = p.part
 outer_fillets = result.faces().filter_by(Face.is_circular_convex)
 print(f"outer fillet faces: {len(outer_fillets)}")""",
     ),
-
     Section(
         label="concave_fillets",
         text="""\
@@ -228,7 +214,6 @@ result = p.part
 hole_walls = result.faces().filter_by(Face.is_circular_concave)
 print(f"concave circular faces (hole walls): {len(hole_walls)}")""",
     ),
-
     Section(
         label="inner_wires_count",
         text="""\
@@ -247,7 +232,6 @@ faces_with_4_holes = plate.faces().filter_by(lambda f: len(f.inner_wires()) == 4
 print(f"faces with 4 holes: {len(faces_with_4_holes)}")
 result = plate""",
     ),
-
     Section(
         text="""\
 ## Operator shortcuts — terse but harder to read
@@ -267,7 +251,6 @@ result = plate""",
 #   part.edges() | GeomType.CIRCLE | (lambda e: e.radius < 5)
 #                                        # = chained filter_by""",
     ),
-
     Section(
         text="""\
 ## Common pitfalls
@@ -294,6 +277,7 @@ def _build123d_version_banner() -> str:
     """Reflect the actually-installed build123d version so callers know exactly
     which API surface these examples target."""
     from importlib.metadata import PackageNotFoundError, version
+
     try:
         v = version("build123d")
     except PackageNotFoundError:

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -16,21 +16,45 @@ _has_library = False
 def execute(code: str) -> str:
     """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly."""
     from build123d_mcp.tools.execute import execute_code
+
     return execute_code(_session, code)
 
 
 @mcp.tool()
-def render_view(direction: str = "iso", objects: str = "", quality: str = "standard", clip_plane: str = "", clip_at: float | None = None, azimuth: float = 0.0, elevation: float = 0.0, save_to: str = "", format: str = "png", label_objects: bool = False, highlights: list[dict] | None = None, colors: dict[str, str] | None = None, mode: str = "auto") -> list:
+def render_view(
+    direction: str = "iso",
+    objects: str = "",
+    quality: str = "standard",
+    clip_plane: str = "",
+    clip_at: float | None = None,
+    azimuth: float = 0.0,
+    elevation: float = 0.0,
+    save_to: str = "",
+    format: str = "png",
+    label_objects: bool = False,
+    highlights: list[dict] | None = None,
+    colors: dict[str, str] | None = None,
+    mode: str = "auto",
+) -> list:
     """Render model. Auto-detects 3D vs 2D inputs: solids go through the VTK tessellation path; 2D shapes (Sketches, Compounds of edges, dimensioned drawings composed via build123d.drafting) go through the ezdxf+matplotlib raster path. Use this to review your dimensioned drawings the same way you review 3D parts. format: 'png' (raster, default), 'svg' (HLR line drawing — works without a display, no shading but precise edges), 'dxf' (HLR line drawing as DXF — the standard 2D CAD interchange format; use when you need projected polylines as parseable geometry rather than as a raster, e.g. to draw an annotated overlay on top of an accurate base layer instead of redrawing the shape by hand), or 'both' (returns the PNG and SVG together — useful when you want shaded depth cues plus crisp edge geometry). If the raster path fails (typically headless host with no display backend) and format='png', the server falls back to SVG automatically. Renders confirm appearance, not geometry — verify boolean operations with measure() before rendering. direction: top, front, side, iso. objects: comma-separated names or name:color pairs e.g. 'u_frame:blue,roller:red' (default: all, auto-coloured). quality: standard, high. clip_plane: x, y, z to slice; clip_at: absolute world coordinate along that axis (default: each mesh's midpoint). azimuth/elevation: camera rotation in degrees applied after the direction preset. save_to: optional file path; for format='both' the PNG and SVG are written as <save_to>.png and <save_to>.svg. mode: render-pipeline selector. 'auto' (default) detects 2D vs 3D from shape content (no solids + flat in Z = 2D). '2d' forces the 2D pipeline (errors if any shape is 3D). '3d' forces the 3D pipeline (errors if every shape is flat 2D). Useful when the auto-detection picks wrong (e.g. a Compound with both a 2D Sketch and a 3D solid silently routes to 3D). The actual path used is reported in the response as 'Rendered via <mode> pipeline.' colors: optional dict mapping object names (e.g. 'bracket') and special layer keys (`_dims`, `_labels`) to colour names like 'red'/'blue' or '#aabbcc'. Overrides the per-object name:color syntax and the default blue dimension colour. Use this when you need fine-grained colour control for presentation diagrams (different parts in different hues, distinct dimension colour, etc.). Only affects PNG/SVG output for 2D drawings; ignored for 3D solids and DXF. label_objects: when true, each named object from show() is labelled at its centroid in the PNG. highlights: optional list of specific entities to label, e.g. [{"object": "bracket", "type": "edge", "index": 5, "label": "hinge_edge"}]; type is 'face', 'edge', or 'vertex' and index matches shape.faces()/edges()/vertices() position. The referenced object must already be registered with show() and included in the rendered set. Labels are PNG-only; SVG output is unlabelled."""
     result = _session.render_view(
-        direction=direction, objects=objects, quality=quality,
-        clip_plane=clip_plane, clip_at=clip_at, azimuth=azimuth,
-        elevation=elevation, save_to=save_to, format=format,
-        label_objects=label_objects, highlights=highlights, colors=colors,
+        direction=direction,
+        objects=objects,
+        quality=quality,
+        clip_plane=clip_plane,
+        clip_at=clip_at,
+        azimuth=azimuth,
+        elevation=elevation,
+        save_to=save_to,
+        format=format,
+        label_objects=label_objects,
+        highlights=highlights,
+        colors=colors,
         mode=mode,
     )
 
     contents: list = []
+
     # Helper: prefer the user-requested save_to path (in result["<fmt>_path"])
     # over a fresh tempfile. When save_to is set, render_view has already
     # written the file at the requested path; we just need a path to deliver
@@ -47,11 +71,13 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
 
     if "png" in result:
         path = _path_for("png", ".png")
-        contents.append(ImageContent(
-            type="image",
-            data=base64.b64encode(result["png"]).decode(),
-            mimeType="image/png",
-        ))
+        contents.append(
+            ImageContent(
+                type="image",
+                data=base64.b64encode(result["png"]).decode(),
+                mimeType="image/png",
+            )
+        )
         contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
 
     if "svg" in result:
@@ -62,10 +88,12 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
     # so clients deliver the file without the ImageContent base64 round-trip.
     if "dxf" in result:
         path = _path_for("dxf", ".dxf")
-        contents.append(TextContent(
-            type="text",
-            text=f"DXF saved: {path}\n[SEND: {path}]",
-        ))
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"DXF saved: {path}\n[SEND: {path}]",
+            )
+        )
     if result.get("fallback"):
         contents.append(TextContent(type="text", text=result["fallback"]))
     if result.get("png_error"):
@@ -77,9 +105,12 @@ def render_view(direction: str = "iso", objects: str = "", quality: str = "stand
         for w in result["label_warnings"]:
             contents.append(TextContent(type="text", text=f"Warning: {w}"))
     if result.get("render_mode"):
-        contents.append(TextContent(
-            type="text", text=f"Rendered via {result['render_mode']} pipeline.",
-        ))
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"Rendered via {result['render_mode']} pipeline.",
+            )
+        )
     return contents
 
 
@@ -149,7 +180,11 @@ def inspect_drawing(objects: str = "", svg_path: str = "") -> str:
 
 
 @mcp.tool()
-def view_axes(viewport_origin: list[float], viewport_up: list[float] = [0.0, 1.0, 0.0], look_at: list[float] = [0.0, 0.0, 0.0]) -> str:
+def view_axes(
+    viewport_origin: list[float],
+    viewport_up: list[float] = [0.0, 1.0, 0.0],
+    look_at: list[float] = [0.0, 0.0, 0.0],
+) -> str:
     """Return the world→page axis mapping for a project_to_viewport call,
     computed analytically (no projection performed). Use this BEFORE rendering
     a projected view to confirm which world axis ends up on which page axis
@@ -236,16 +271,20 @@ def render_drawing(svg_path: str, width: int = 1200, save_to: str = "") -> list:
             os.close(fd)
             with open(path, "wb") as f:
                 f.write(result["png"])
-        contents.append(ImageContent(
-            type="image",
-            data=base64.b64encode(result["png"]).decode(),
-            mimeType="image/png",
-        ))
+        contents.append(
+            ImageContent(
+                type="image",
+                data=base64.b64encode(result["png"]).decode(),
+                mimeType="image/png",
+            )
+        )
         contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
-        contents.append(TextContent(
-            type="text",
-            text=f"Rasterised {svg_path} to PNG ({result['size_bytes']} bytes, width={result['width']}px).",
-        ))
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"Rasterised {svg_path} to PNG ({result['size_bytes']} bytes, width={result['width']}px).",
+            )
+        )
     return contents
 
 
@@ -363,6 +402,7 @@ def import_cad_file(path: str, name: str = "") -> str:
 def repair_hints(error_text: str) -> str:
     """Given an error message from execute(), return targeted fix suggestions for common build123d mistakes: wrong Location syntax, missing .part, CadQuery idioms, blocked imports, degenerate boolean results, fillet edge selection, and more. Pass the full error string from execute() or last_error()."""
     from build123d_mcp.tools.repair_hints import repair_hints as _repair_hints
+
     return _repair_hints(error_text)
 
 
@@ -379,6 +419,7 @@ def version() -> str:
     # it still answers when the worker subprocess is down — exactly the stale /
     # broken-install case this tool exists to diagnose.
     from build123d_mcp.tools.version import version_info
+
     return "\n".join(f"{name}: {ver}" for name, ver in version_info().items())
 
 
@@ -505,50 +546,73 @@ BUILD123D-MCP WORKFLOW GUIDE
 """
 
 
-@mcp.resource("build123d://quickref", mime_type="text/plain",
-              description="build123d API quick reference: primitives, booleans, positioning, sketch-to-3D, selectors, fillets.")
+@mcp.resource(
+    "build123d://quickref",
+    mime_type="text/plain",
+    description="build123d API quick reference: primitives, booleans, positioning, sketch-to-3D, selectors, fillets.",
+)
 def build123d_quickref() -> str:
     """build123d API quick reference."""
     from build123d_mcp.quickref import build_quickref_text
+
     return build_quickref_text()
 
 
-@mcp.resource("build123d://selectors", mime_type="text/plain",
-              description="Task-indexed cookbook of selector patterns: get the top face, find circular edges, filter by area/length/radius, Select.LAST in builder context, fillet detection, and the operator shortcuts.")
+@mcp.resource(
+    "build123d://selectors",
+    mime_type="text/plain",
+    description="Task-indexed cookbook of selector patterns: get the top face, find circular edges, filter by area/length/radius, Select.LAST in builder context, fillet detection, and the operator shortcuts.",
+)
 def build123d_selectors_cookbook() -> str:
     """build123d selectors cookbook — task-indexed patterns."""
     from build123d_mcp.selectors_cookbook import build_selectors_cookbook_text
+
     return build_selectors_cookbook_text()
 
 
-@mcp.resource("build123d://drafting", mime_type="text/plain",
-              description="Code-first 2D engineering drawings cookbook: project a 3D part to a 2D view, dimension with ExtensionLine/DimensionLine, add tolerances, compose a TechnicalDrawing title block, multi-view sheet layout, hole-table pattern, export to DXF/SVG.")
+@mcp.resource(
+    "build123d://drafting",
+    mime_type="text/plain",
+    description="Code-first 2D engineering drawings cookbook: project a 3D part to a 2D view, dimension with ExtensionLine/DimensionLine, add tolerances, compose a TechnicalDrawing title block, multi-view sheet layout, hole-table pattern, export to DXF/SVG.",
+)
 def build123d_drafting_cookbook() -> str:
     """build123d 2D drafting cookbook — code-first engineering drawings."""
     from build123d_mcp.drafting_cookbook import build_drafting_cookbook_text
+
     return build_drafting_cookbook_text()
 
 
-@mcp.resource("build123d://presentation", mime_type="text/plain",
-              description="Code-first design-discussion diagrams: per-group colour via ExportSVG layers, filled feature highlights, legends with swatches, reference axes, titles, and Draft scaling for small parts. Sister cookbook to build123d://drafting (which targets fabrication handoff).")
+@mcp.resource(
+    "build123d://presentation",
+    mime_type="text/plain",
+    description="Code-first design-discussion diagrams: per-group colour via ExportSVG layers, filled feature highlights, legends with swatches, reference axes, titles, and Draft scaling for small parts. Sister cookbook to build123d://drafting (which targets fabrication handoff).",
+)
 def build123d_presentation_cookbook() -> str:
     """build123d presentation cookbook — discussion diagrams (vs drafting's fab drawings)."""
     from build123d_mcp.presentation_cookbook import build_presentation_cookbook_text
+
     return build_presentation_cookbook_text()
 
 
-@mcp.resource("build123d://session", mime_type="application/json",
-              description="Live session state: current shape diagnostics, named objects, snapshots, and user-defined variables.")
+@mcp.resource(
+    "build123d://session",
+    mime_type="application/json",
+    description="Live session state: current shape diagnostics, named objects, snapshots, and user-defined variables.",
+)
 def build123d_session_state() -> str:
     """Live session state as JSON."""
     return _session.session_state()
 
 
-@mcp.resource("build123d://bd_warehouse", mime_type="text/plain",
-              description="Catalogue of pre-built parametric parts in bd_warehouse: bearings, fasteners, gears, pipes, threads, and more.")
+@mcp.resource(
+    "build123d://bd_warehouse",
+    mime_type="text/plain",
+    description="Catalogue of pre-built parametric parts in bd_warehouse: bearings, fasteners, gears, pipes, threads, and more.",
+)
 def build123d_bd_warehouse() -> str:
     """bd_warehouse component catalogue."""
     from build123d_mcp.bd_warehouse_resource import build_bd_warehouse_text
+
     return build_bd_warehouse_text()
 
 
@@ -589,15 +653,20 @@ def suggest_view_layout(
     Iso position is approximate (75% of 3-D diagonal as half-extent) — verify
     with render_view() and adjust manually if the iso overlaps a neighbour.
     """
-    return _session.suggest_view_layout(object_name, page_w, page_h, scale, views,
-                                        title_block_w, title_block_h, margin)
+    return _session.suggest_view_layout(
+        object_name, page_w, page_h, scale, views, title_block_w, title_block_h, margin
+    )
 
 
-@mcp.resource("build123d://skill/drawing", mime_type="text/plain",
-              description="The b123d-drawing engineering workflow skill: step-by-step guide for creating multi-view engineering drawings from build123d geometry (views, scale, annotation, lint, SVG/DXF/PDF export).")
+@mcp.resource(
+    "build123d://skill/drawing",
+    mime_type="text/plain",
+    description="The b123d-drawing engineering workflow skill: step-by-step guide for creating multi-view engineering drawings from build123d geometry (views, scale, annotation, lint, SVG/DXF/PDF export).",
+)
 def build123d_drawing_skill() -> str:
     """b123d-drawing engineering workflow skill."""
     from build123d_mcp.tools.install_skill import _load_raw
+
     return _load_raw()
 
 
@@ -616,6 +685,7 @@ def install_skill(target: str = "claude", force: bool = False) -> str:
     force: overwrite existing installation (default False)
     """
     from build123d_mcp.tools.install_skill import install_skill as _install
+
     return _install(target=target, force=force)
 
 
@@ -663,7 +733,9 @@ Call workflow_hints() if unsure which tool to use next.
 def _cmd_install_skill(argv: list) -> None:
     import argparse
     import sys
-    from build123d_mcp.tools.install_skill import TARGETS, install_skill as _install
+
+    from build123d_mcp.tools.install_skill import TARGETS
+    from build123d_mcp.tools.install_skill import install_skill as _install
 
     p = argparse.ArgumentParser(
         prog="build123d-mcp install-skill",
@@ -679,8 +751,12 @@ def _cmd_install_skill(argv: list) -> None:
     args = p.parse_args(argv)
 
     from build123d_mcp.tools.install_skill import _dest_exists
+
     if not args.force and _dest_exists(args.target):
-        print(f"Skill already installed for '{args.target}' — use --force to overwrite.", file=sys.stderr)
+        print(
+            f"Skill already installed for '{args.target}' — use --force to overwrite.",
+            file=sys.stderr,
+        )
         sys.exit(1)
     print(_install(target=args.target, force=args.force))
 
@@ -750,44 +826,50 @@ Part library file format (Python, any .py file under --library path):
       return Box(width, width, width)
 """,
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {version('build123d-mcp')}")
     parser.add_argument(
-        "--library", metavar="PATH",
+        "--version", action="version", version=f"%(prog)s {version('build123d-mcp')}"
+    )
+    parser.add_argument(
+        "--library",
+        metavar="PATH",
         default=os.environ.get("BUILD123D_PART_LIBRARY", ""),
         help="Path to part library directory (overrides BUILD123D_PART_LIBRARY env var)",
     )
     parser.add_argument(
-        "--allow-all-imports", action="store_true",
+        "--allow-all-imports",
+        action="store_true",
         default=os.environ.get("BUILD123D_ALLOW_ALL_IMPORTS", "").lower() in ("1", "true", "yes"),
         help="Disable the import allowlist — any Python module can be imported. "
-             "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
+        "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
     )
     parser.add_argument(
-        "--allow-imports", metavar="MODULES",
+        "--allow-imports",
+        metavar="MODULES",
         default=os.environ.get("BUILD123D_ALLOW_IMPORTS", ""),
         help="Comma-separated extra modules added to the import allowlist on top of "
-             "the defaults (e.g. --allow-imports scipy,pandas). Each entry permits the "
-             "named module and all its submodules. Use this for CAD scripts that need "
-             "extra packages without disabling the sandbox via --allow-all-imports. "
-             "Overrides BUILD123D_ALLOW_IMPORTS env var.",
+        "the defaults (e.g. --allow-imports scipy,pandas). Each entry permits the "
+        "named module and all its submodules. Use this for CAD scripts that need "
+        "extra packages without disabling the sandbox via --allow-all-imports. "
+        "Overrides BUILD123D_ALLOW_IMPORTS env var.",
     )
     parser.add_argument(
-        "--exec-timeout", metavar="SECONDS", type=int,
+        "--exec-timeout",
+        metavar="SECONDS",
+        type=int,
         default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT", "120")),
         help="Execution time limit in seconds for user code (default: 120). "
-             "Overrides BUILD123D_EXEC_TIMEOUT env var.",
+        "Overrides BUILD123D_EXEC_TIMEOUT env var.",
     )
     args = parser.parse_args()
 
     if args.library and not os.path.isdir(args.library):
         parser.error(f"Library path is not a directory: {args.library}")
 
-    extra_imports = tuple(
-        m.strip() for m in args.allow_imports.split(",") if m.strip()
-    )
+    extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
 
     if args.allow_all_imports or extra_imports:
         import build123d_mcp.security as _sec
+
         if args.allow_all_imports:
             _sec.ALLOW_ALL_IMPORTS = True
         if extra_imports:

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -1,7 +1,7 @@
 import copy
 import io
 import signal
-from contextlib import redirect_stdout, redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from typing import Any
 
 from build123d_mcp.security import (
@@ -11,10 +11,10 @@ from build123d_mcp.security import (
     make_restricted_builtins,
 )
 
-
 # Names injected by the session itself — excluded from rollback and new-key detection.
-_INJECTED = frozenset({"__builtins__", "show", "named_face", "annotate",
-                       "register_centerline", "set_page"})
+_INJECTED = frozenset(
+    {"__builtins__", "show", "named_face", "annotate", "register_centerline", "set_page"}
+)
 
 
 class Session:
@@ -82,8 +82,14 @@ class Session:
                 meta["label_str"] = lbl
             if getattr(result, "is_centerline", False):
                 meta["is_centerline"] = True
-            for attr in ("measured_length", "tip", "elbow",
-                         "label_bbox", "dim_level_y", "segments"):
+            for attr in (
+                "measured_length",
+                "tip",
+                "elbow",
+                "label_bbox",
+                "dim_level_y",
+                "segments",
+            ):
                 val = getattr(result, attr, None)
                 if val is not None:
                     meta[attr] = val
@@ -162,8 +168,10 @@ class Session:
                 "max_x": width - margin,
                 "max_y": height - margin,
             }
-            print(f"Page set: {width}×{height} mm, margin={margin} mm "
-                  f"(drawable area {width-2*margin}×{height-2*margin} mm)")
+            print(
+                f"Page set: {width}×{height} mm, margin={margin} mm "
+                f"(drawable area {width - 2 * margin}×{height - 2 * margin} mm)"
+            )
 
         self.namespace["set_page"] = set_page
 
@@ -191,13 +199,20 @@ class Session:
         def named_face(shape: Any, name: str) -> Any:
             """Return a face of shape by semantic name: top/bottom/front/back/left/right."""
             from build123d import Axis
+
             match name.lower():
-                case "top":    return shape.faces().sort_by(Axis.Z)[-1]
-                case "bottom": return shape.faces().sort_by(Axis.Z)[0]
-                case "front":  return shape.faces().sort_by(Axis.Y)[-1]
-                case "back":   return shape.faces().sort_by(Axis.Y)[0]
-                case "right":  return shape.faces().sort_by(Axis.X)[-1]
-                case "left":   return shape.faces().sort_by(Axis.X)[0]
+                case "top":
+                    return shape.faces().sort_by(Axis.Z)[-1]
+                case "bottom":
+                    return shape.faces().sort_by(Axis.Z)[0]
+                case "front":
+                    return shape.faces().sort_by(Axis.Y)[-1]
+                case "back":
+                    return shape.faces().sort_by(Axis.Y)[0]
+                case "right":
+                    return shape.faces().sort_by(Axis.X)[-1]
+                case "left":
+                    return shape.faces().sort_by(Axis.X)[0]
                 case _:
                     raise ValueError(
                         f"Unknown face name '{name}'. Use: top, bottom, front, back, left, right"
@@ -211,8 +226,12 @@ class Session:
             bb = shape.bounding_box()
             return {
                 "vol": shape.volume,
-                "size_x": bb.size.X, "size_y": bb.size.Y, "size_z": bb.size.Z,
-                "center_x": bb.center().X, "center_y": bb.center().Y, "center_z": bb.center().Z,
+                "size_x": bb.size.X,
+                "size_y": bb.size.Y,
+                "size_z": bb.size.Z,
+                "center_x": bb.center().X,
+                "center_y": bb.center().Y,
+                "center_z": bb.center().Z,
                 "faces": len(shape.faces()),
                 "edges": len(shape.edges()),
                 "verts": len(shape.vertices()),
@@ -273,8 +292,12 @@ class Session:
             and a["faces"] == b["faces"]
             and a["edges"] == b["edges"]
             and a["verts"] == b["verts"]
-            and a["size_x"] == b["size_x"] and a["size_y"] == b["size_y"] and a["size_z"] == b["size_z"]
-            and a["center_x"] == b["center_x"] and a["center_y"] == b["center_y"] and a["center_z"] == b["center_z"]
+            and a["size_x"] == b["size_x"]
+            and a["size_y"] == b["size_y"]
+            and a["size_z"] == b["size_z"]
+            and a["center_x"] == b["center_x"]
+            and a["center_y"] == b["center_y"]
+            and a["center_z"] == b["center_z"]
         )
         if identical:
             warnings.append(
@@ -296,14 +319,24 @@ class Session:
         try:
             check_ast(code)
         except ValueError as e:
-            self.last_error_detail = {"type": "SecurityError", "message": str(e), "line": None, "excerpt": None}
+            self.last_error_detail = {
+                "type": "SecurityError",
+                "message": str(e),
+                "line": None,
+                "excerpt": None,
+            }
             return f"Error: SecurityError: {e}"
 
         try:
             compiled = compile(code, "<mcp>", "exec")
         except SyntaxError as e:
             excerpt = self._syntax_excerpt(code, e.lineno)
-            self.last_error_detail = {"type": "SyntaxError", "message": str(e), "line": e.lineno, "excerpt": excerpt}
+            self.last_error_detail = {
+                "type": "SyntaxError",
+                "message": str(e),
+                "line": e.lineno,
+                "excerpt": excerpt,
+            }
             return f"Error: SyntaxError: {e}"
 
         values_before = {
@@ -324,10 +357,12 @@ class Session:
         _alarm_set = False
         _old_handler: Any = None
         try:
+
             def _timeout_handler(signum: int, frame: Any) -> None:
                 raise ExecutionTimeout(
                     f"Code exceeded the {self.exec_timeout}s execution time limit."
                 )
+
             _old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
             signal.alarm(max(1, self.exec_timeout - 2))
             _alarm_set = True
@@ -347,7 +382,12 @@ class Session:
             self.objects.update(objects_before)
             self.drawing_annotations.clear()
             self.drawing_annotations.update(annotations_before)
-            self.last_error_detail = {"type": "ExecutionTimeout", "message": str(e), "line": None, "excerpt": None}
+            self.last_error_detail = {
+                "type": "ExecutionTimeout",
+                "message": str(e),
+                "line": None,
+                "excerpt": None,
+            }
             return f"Error: ExecutionTimeout: {e}"
         except AssertionError as e:
             self._rollback_namespace(values_before)
@@ -357,7 +397,12 @@ class Session:
             self.drawing_annotations.clear()
             self.drawing_annotations.update(annotations_before)
             msg = str(e) or "Constraint failed"
-            self.last_error_detail = {"type": "AssertionError", "message": msg, "line": None, "excerpt": None}
+            self.last_error_detail = {
+                "type": "AssertionError",
+                "message": msg,
+                "line": None,
+                "excerpt": None,
+            }
             return f"Constraint failed: {e}" if str(e) else "Constraint failed"
         except Exception as e:
             exc = e
@@ -419,12 +464,12 @@ class Session:
         start = max(0, lineno - 3)
         end = min(len(lines), lineno + 2)
         return "\n".join(
-            f"{i + 1:3d}{'→ ' if i + 1 == lineno else '  '}{lines[i]}"
-            for i in range(start, end)
+            f"{i + 1:3d}{'→ ' if i + 1 == lineno else '  '}{lines[i]}" for i in range(start, end)
         )
 
     def _make_error_detail(self, exc: Exception, code: str) -> dict[str, Any]:
         import traceback as tb_module
+
         frames = tb_module.extract_tb(exc.__traceback__)
         mcp_frames = [f for f in frames if f.filename == "<mcp>"]
         lineno: int | None = mcp_frames[-1].lineno if mcp_frames else None
@@ -441,7 +486,7 @@ class Session:
 
     def _update_current_shape(self, new_keys: set[str]) -> None:
         try:
-            from build123d import Shape, BuildPart
+            from build123d import BuildPart, Shape
         except ImportError:
             return
 

--- a/src/build123d_mcp/tools/_paths.py
+++ b/src/build123d_mcp/tools/_paths.py
@@ -42,8 +42,7 @@ def _safe_path(filename: str, kind: str) -> str:
         if resolved == root or resolved.startswith(root + os.sep):
             return resolved
     raise ValueError(
-        f"Path '{filename}' resolves to '{resolved}', "
-        f"which is outside the allowed {kind} roots."
+        f"Path '{filename}' resolves to '{resolved}', which is outside the allowed {kind} roots."
     )
 
 

--- a/src/build123d_mcp/tools/align_check.py
+++ b/src/build123d_mcp/tools/align_check.py
@@ -1,8 +1,7 @@
 import json
 
 
-def align_check(session, object_a: str, object_b: str,
-                axis: str = "Z", mode: str = "flush") -> str:
+def align_check(session, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush") -> str:
     """Check alignment between two named objects along an axis.
 
     Args:
@@ -27,10 +26,12 @@ def align_check(session, object_a: str, object_b: str,
 
     for name in (object_a, object_b):
         if not name or name not in session.objects:
-            return json.dumps({
-                "error": f"Unknown object '{name}'.",
-                "registered": list(session.objects.keys()),
-            })
+            return json.dumps(
+                {
+                    "error": f"Unknown object '{name}'.",
+                    "registered": list(session.objects.keys()),
+                }
+            )
 
     shape_a = session.objects[object_a]
     shape_b = session.objects[object_b]
@@ -65,17 +66,23 @@ def align_check(session, object_a: str, object_b: str,
         if abs(delta) < 1e-4:
             interp = f"{object_a} and {object_b} are flush on {axis} axis."
         elif delta > 0:
-            interp = f"{object_a} extends {abs(delta):.4g} mm further than {object_b} on {axis} axis."
+            interp = (
+                f"{object_a} extends {abs(delta):.4g} mm further than {object_b} on {axis} axis."
+            )
         else:
-            interp = f"{object_b} extends {abs(delta):.4g} mm further than {object_a} on {axis} axis."
+            interp = (
+                f"{object_b} extends {abs(delta):.4g} mm further than {object_a} on {axis} axis."
+            )
 
     elif mode == "center":
         delta = round(a_cen - b_cen, 6)
         if abs(delta) < 1e-4:
             interp = f"Centers of {object_a} and {object_b} are aligned on {axis} axis."
         else:
-            interp = (f"Center of {object_a} is {abs(delta):.4g} mm "
-                      f"{'above' if delta > 0 else 'below'} center of {object_b} on {axis} axis.")
+            interp = (
+                f"Center of {object_a} is {abs(delta):.4g} mm "
+                f"{'above' if delta > 0 else 'below'} center of {object_b} on {axis} axis."
+            )
 
     else:  # clearance
         # Gap between nearest faces: b_min - a_max (A below B) vs a_min - b_max (B below A)
@@ -94,11 +101,14 @@ def align_check(session, object_a: str, object_b: str,
         else:
             interp = f"{object_a} and {object_b} are touching on {axis} axis."
 
-    return json.dumps({
-        "delta": delta,
-        "axis": axis,
-        "mode": mode,
-        "object_a": object_a,
-        "object_b": object_b,
-        "interpretation": interp,
-    }, indent=2)
+    return json.dumps(
+        {
+            "delta": delta,
+            "axis": axis,
+            "mode": mode,
+            "object_a": object_a,
+            "object_b": object_b,
+            "interpretation": interp,
+        },
+        indent=2,
+    )

--- a/src/build123d_mcp/tools/cross_sections.py
+++ b/src/build123d_mcp/tools/cross_sections.py
@@ -2,6 +2,7 @@ import json
 
 
 def cross_sections(session, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
-    from build123d_mcp.tools.measure import _resolve_shape, _cross_sections
+    from build123d_mcp.tools.measure import _cross_sections, _resolve_shape
+
     shape = _resolve_shape(session, object_name)
     return json.dumps(_cross_sections(shape, axis, num_slices), indent=2)

--- a/src/build123d_mcp/tools/diff.py
+++ b/src/build123d_mcp/tools/diff.py
@@ -48,7 +48,9 @@ def _fmt_shape_diff(a: dict | None, b: dict | None, label: str) -> str | None:
 
 def diff_snapshot(session, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
     if snapshot_a not in session.snapshots:
-        return f"Error: no snapshot named '{snapshot_a}'. Available: {list(session.snapshots.keys())}"
+        return (
+            f"Error: no snapshot named '{snapshot_a}'. Available: {list(session.snapshots.keys())}"
+        )
 
     snap_a = session.snapshots[snapshot_a]
     diag_a = _collect(snap_a["current_shape"], snap_a["objects"])
@@ -64,7 +66,10 @@ def diff_snapshot(session, snapshot_a: str, snapshot_b: str = "", format: str = 
 
     if format == "json":
         import json
-        return json.dumps({"a": {"label": snapshot_a, **diag_a}, "b": {"label": label_b, **diag_b}}, indent=2)
+
+        return json.dumps(
+            {"a": {"label": snapshot_a, **diag_a}, "b": {"label": label_b, **diag_b}}, indent=2
+        )
 
     lines = [f"diff: {snapshot_a} → {label_b}", ""]
 

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -3,7 +3,6 @@ import re
 
 from build123d_mcp.tools.repair_hints import _HINTS
 
-
 _SUGGESTED_FIXES = {
     "boolean_fail": (
         "Check that both operands are valid solids and their intersection is non-empty; "
@@ -97,8 +96,7 @@ def _classify_from_error_string(error_result: str) -> dict:
 def execute_code(session, code: str) -> str:
     result = session.execute(code)
     if result.startswith("Error:") or result.startswith("Constraint failed"):
-        matched = [hint for patterns, hint in _HINTS
-                   if any(re.search(p, result) for p in patterns)]
+        matched = [hint for patterns, hint in _HINTS if any(re.search(p, result) for p in patterns)]
         if matched:
             result += "\n\nHint: " + ("\n      ".join(matched))
 

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -20,11 +20,14 @@ def _resolve_shape(session, object_name: str):
         if not session.objects:
             raise ValueError("No named objects in session. Use show() to register shapes first.")
         from build123d import Compound
+
         children = [_labelled_copy(s, name) for name, s in session.objects.items()]
         return Compound(label="assembly", children=children)
     if object_name:
         if object_name not in session.objects:
-            raise ValueError(f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}")
+            raise ValueError(
+                f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}"
+            )
         return _labelled_copy(session.objects[object_name], object_name)
     if session.current_shape is None:
         raise ValueError("No shape in session. Execute code to create geometry first.")
@@ -67,6 +70,7 @@ def _is_2d(shape) -> bool:
 def _write_dxf(shape, abs_path: str) -> None:
     """Write a 2D shape (Sketch, Compound of edges/sketches) to DXF."""
     from build123d import ExportDXF
+
     label = getattr(shape, "label", "") or "drawing"
     exporter = ExportDXF()
     exporter.add_layer(label)
@@ -77,6 +81,7 @@ def _write_dxf(shape, abs_path: str) -> None:
 def _write_svg(shape, abs_path: str) -> None:
     """Write a 2D shape (Sketch, Compound of edges/sketches) to SVG."""
     from build123d import ExportSVG
+
     label = getattr(shape, "label", "") or "drawing"
     exporter = ExportSVG(margin=5)
     exporter.add_layer(label, line_weight=0.4)
@@ -87,6 +92,7 @@ def _write_svg(shape, abs_path: str) -> None:
 def _write_one(shape, abs_path: str, fmt: str) -> None:
     if fmt == "step":
         from build123d import export_step
+
         export_step(shape, abs_path)
     elif fmt == "stl":
         _stl_write(shape, abs_path)
@@ -121,7 +127,7 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
         if bad_3d:
             raise ValueError(
                 f"Cannot export 3D shape as {bad_3d}. Use 'step' or 'stl' for 3D solids; "
-                f"use render_view(format=\"dxf\") for the projected 2D outline."
+                f'use render_view(format="dxf") for the projected 2D outline.'
             )
 
     exported = []

--- a/src/build123d_mcp/tools/health_check.py
+++ b/src/build123d_mcp/tools/health_check.py
@@ -9,8 +9,12 @@ def health_check(_session) -> str:
     # PNG render (VTK + display)
     try:
         from build123d import Box
+
         from build123d_mcp.tools.render import _QUALITY, _do_render_png
-        img_bytes, _warnings = _do_render_png([("test", Box(1, 1, 1), None)], _QUALITY["standard"], "iso", "", None, 0.0, 0.0)
+
+        img_bytes, _warnings = _do_render_png(
+            [("test", Box(1, 1, 1), None)], _QUALITY["standard"], "iso", "", None, 0.0, 0.0
+        )
         results["render_png"] = {"ok": True, "bytes": len(img_bytes)}
     except Exception as e:
         results["render_png"] = {"ok": False, "error": str(e)}
@@ -18,7 +22,9 @@ def health_check(_session) -> str:
     # SVG render (build123d HLR projection)
     try:
         from build123d import Box
+
         from build123d_mcp.tools.render import _do_render_svg
+
         svg = _do_render_svg([("test", Box(1, 1, 1), None)], "iso", "", None, 0.0, 0.0)
         results["render_svg"] = {"ok": True, "bytes": len(svg)}
     except Exception as e:
@@ -27,6 +33,7 @@ def health_check(_session) -> str:
     # STEP export
     try:
         from build123d import Box, export_step
+
         fd, path = tempfile.mkstemp(suffix=".step")
         os.close(fd)
         export_step(Box(1, 1, 1), path)
@@ -38,6 +45,7 @@ def health_check(_session) -> str:
     # STL export
     try:
         from build123d import Box, Mesher
+
         fd, path = tempfile.mkstemp(suffix=".stl")
         os.close(fd)
         m = Mesher()

--- a/src/build123d_mcp/tools/import_step.py
+++ b/src/build123d_mcp/tools/import_step.py
@@ -66,4 +66,5 @@ def _load_step(resolved: str):
 
 def _load_stl(resolved: str):
     from build123d import import_stl
+
     return import_stl(resolved)

--- a/src/build123d_mcp/tools/inspect_drawing.py
+++ b/src/build123d_mcp/tools/inspect_drawing.py
@@ -1,4 +1,5 @@
 """inspect_drawing — structured bbox/annotation report for a 2D drawing session."""
+
 import json
 import os
 import re
@@ -60,26 +61,39 @@ def _inspect_svg(svg_path: str) -> str:
 
     layers: list[dict] = []
     text_entries: list[dict] = []
-    counts = {"path": 0, "line": 0, "polyline": 0, "polygon": 0, "rect": 0, "circle": 0, "g": 0, "text": 0}
+    counts = {
+        "path": 0,
+        "line": 0,
+        "polyline": 0,
+        "polygon": 0,
+        "rect": 0,
+        "circle": 0,
+        "g": 0,
+        "text": 0,
+    }
 
     for elem in root.iter():
         tag = elem.tag.replace(_SVG_NS, "")
         if tag in counts:
             counts[tag] += 1
         if tag == "g":
-            layers.append({
-                "id": elem.get("id"),
-                "transform": elem.get("transform"),
-                "fill": elem.get("fill"),
-            })
+            layers.append(
+                {
+                    "id": elem.get("id"),
+                    "transform": elem.get("transform"),
+                    "fill": elem.get("fill"),
+                }
+            )
         elif tag == "text":
-            text_entries.append({
-                "id": elem.get("id"),
-                "x": _strip_unit(elem.get("x")),
-                "y": _strip_unit(elem.get("y")),
-                "text": "".join(elem.itertext()).strip(),
-                "fill": elem.get("fill"),
-            })
+            text_entries.append(
+                {
+                    "id": elem.get("id"),
+                    "x": _strip_unit(elem.get("x")),
+                    "y": _strip_unit(elem.get("y")),
+                    "text": "".join(elem.itertext()).strip(),
+                    "fill": elem.get("fill"),
+                }
+            )
 
     # Sidecar: read <svg_path>.dims.json written by save_drawing_annotations().
     # build123d renders Text as filled glyph paths so <text> elements are absent;
@@ -93,19 +107,23 @@ def _inspect_svg(svg_path: str) -> str:
         except Exception:
             pass
 
-    return json.dumps({
-        "mode": "svg",
-        "path": svg_path,
-        "page": page,
-        "layers": layers,
-        "text": text_entries,
-        "counts": counts,
-        "annotations": annotations,
-        "annotations_note": (
-            "annotations loaded from sidecar" if annotations
-            else "no sidecar found — call save_drawing_annotations(svg_path) after building"
-        ),
-    }, indent=2)
+    return json.dumps(
+        {
+            "mode": "svg",
+            "path": svg_path,
+            "page": page,
+            "layers": layers,
+            "text": text_entries,
+            "counts": counts,
+            "annotations": annotations,
+            "annotations_note": (
+                "annotations loaded from sidecar"
+                if annotations
+                else "no sidecar found — call save_drawing_annotations(svg_path) after building"
+            ),
+        },
+        indent=2,
+    )
 
 
 def inspect_drawing(session, objects: str = "", svg_path: str = "") -> str:
@@ -199,6 +217,7 @@ def _lint(objects: dict, annotations: dict) -> list[str]:
         measured = ann.get("measured_length")
         if label and measured and measured > 1e-6:
             import re
+
             nums = re.findall(r"\d+\.?\d*", label.split("±")[0].split("+")[0].lstrip("ø⌀Rr"))
             if nums:
                 try:
@@ -207,15 +226,13 @@ def _lint(objects: dict, annotations: dict) -> list[str]:
                     if ratio > 0.005:
                         warnings.append(
                             f"'{name}': label '{label}' value {label_val:.3f} differs from "
-                            f"measured length {measured:.3f} by {ratio*100:.1f}% — possible axis swap"
+                            f"measured length {measured:.3f} by {ratio * 100:.1f}% — possible axis swap"
                         )
                 except ValueError:
                     pass
 
         bb = entry.get("bbox")
-        tip = ann.get("tip")
         elbow = ann.get("elbow")
-        text_bb = None
         # For leaders, check elbow vs text bbox (approximated from overall bbox)
         if elbow and bb:
             ex, ey = elbow

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -17,26 +17,34 @@ TARGETS = ("claude", "agents-md", "cursor", "windsurf")
 
 # Delimiters used when appending to shared files (AGENTS.md, .windsurfrules)
 _START = "<!-- b123d-drawing:start -->"
-_END   = "<!-- b123d-drawing:end -->"
+_END = "<!-- b123d-drawing:end -->"
 
 
 def _load_raw() -> str:
-    return (files("build123d_mcp") / "skills" / "b123d-drawing" / "SKILL.md").read_text(encoding="utf-8")
+    return (files("build123d_mcp") / "skills" / "b123d-drawing" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
 
 
 def _strip_claude_markers(text: str) -> str:
     """Remove Claude Code-specific inline markers that other agents don't understand."""
     # [SEND: /tmp/foo.png]  →  show the rendered image at /tmp/foo.png to the user
     text = re.sub(
-        r'\[SEND:\s*([^\]]+)\]',
-        r'(show the rendered image at \1 to the user)',
+        r"\[SEND:\s*([^\]]+)\]",
+        r"(show the rendered image at \1 to the user)",
         text,
     )
+
     # [ASK: question | opt1 | opt2]  →  ask the user: question (opt1 / opt2)
     def _ask_replace(m: re.Match) -> str:
         parts = [p.strip() for p in m.group(1).split("|")]
-        return f"(ask the user: {parts[0]}" + (f" — options: {', '.join(parts[1:])}" if len(parts) > 1 else "") + ")"
-    text = re.sub(r'\[ASK:\s*([^\]]+)\]', _ask_replace, text)
+        return (
+            f"(ask the user: {parts[0]}"
+            + (f" — options: {', '.join(parts[1:])}" if len(parts) > 1 else "")
+            + ")"
+        )
+
+    text = re.sub(r"\[ASK:\s*([^\]]+)\]", _ask_replace, text)
     return text
 
 

--- a/src/build123d_mcp/tools/interference.py
+++ b/src/build123d_mcp/tools/interference.py
@@ -13,11 +13,18 @@ def _compute_interference(shape_a: Any, shape_b: Any) -> tuple:
         return (False, 0.0, None)
 
     bb = inter.bounding_box()
-    return (True, vol, {
-        "xmin": bb.min.X, "xmax": bb.max.X,
-        "ymin": bb.min.Y, "ymax": bb.max.Y,
-        "zmin": bb.min.Z, "zmax": bb.max.Z,
-    })
+    return (
+        True,
+        vol,
+        {
+            "xmin": bb.min.X,
+            "xmax": bb.max.X,
+            "ymin": bb.min.Y,
+            "ymax": bb.max.Y,
+            "zmin": bb.min.Z,
+            "zmax": bb.max.Z,
+        },
+    )
 
 
 def interference(session, object_a: str, object_b: str) -> str:
@@ -33,8 +40,11 @@ def interference(session, object_a: str, object_b: str) -> str:
     if not interferes:
         return json.dumps({"interferes": False, "volume": 0.0}, indent=2)
 
-    return json.dumps({
-        "interferes": True,
-        "volume": volume,
-        "bounds": bounds,
-    }, indent=2)
+    return json.dumps(
+        {
+            "interferes": True,
+            "volume": volume,
+            "bounds": bounds,
+        },
+        indent=2,
+    )

--- a/src/build123d_mcp/tools/library.py
+++ b/src/build123d_mcp/tools/library.py
@@ -92,12 +92,14 @@ class _LibraryIndex:
         terms = query.lower().split()
         results = []
         for part in parts:
-            text = " ".join([
-                part["name"],
-                part["description"],
-                part["category"],
-                " ".join(part["tags"]),
-            ]).lower()
+            text = " ".join(
+                [
+                    part["name"],
+                    part["description"],
+                    part["category"],
+                    " ".join(part["tags"]),
+                ]
+            ).lower()
             if all(term in text for term in terms):
                 results.append(_public(part))
         return results
@@ -150,6 +152,7 @@ def load_part(session, index: _LibraryIndex, name: str, params: str = "") -> str
 
     # Execute part file in isolated restricted namespace
     from build123d_mcp.security import check_ast, make_restricted_builtins
+
     with open(entry["path"]) as f:
         source = f.read()
     check_ast(source)

--- a/src/build123d_mcp/tools/lint_drawing.py
+++ b/src/build123d_mcp/tools/lint_drawing.py
@@ -16,15 +16,17 @@ Two modes:
 The structured violation list is JSON so the LLM can iterate without rendering.
 Each violation's `check` is the helpers' stable `LintIssue.code`.
 """
+
 import json
 import os
 import re
 import xml.etree.ElementTree as ET
-
 from types import SimpleNamespace
 
 from build123d_drafting import (
     find_interferences,
+)
+from build123d_drafting import (
     lint_drawing as _helper_lint,
 )
 
@@ -92,18 +94,42 @@ def _reconstruct(session):
         label = meta.get("label_str", "")
         segs = meta.get("segments") or []
         if meta.get("is_centerline") or meta.get("type") in ("Centerline", "centerline"):
-            items.append((name, _standin(shape, label=label, is_centerline=True,
-                                         label_bbox=None, segments=segs)))
+            items.append(
+                (
+                    name,
+                    _standin(
+                        shape, label=label, is_centerline=True, label_bbox=None, segments=segs
+                    ),
+                )
+            )
         elif meta.get("elbow") is not None:
-            items.append((name, _standin(shape, label=label,
-                                         tip=tuple(meta.get("tip") or (0.0, 0.0)),
-                                         elbow=tuple(meta["elbow"]),
-                                         label_bbox=meta.get("label_bbox"), segments=segs)))
+            items.append(
+                (
+                    name,
+                    _standin(
+                        shape,
+                        label=label,
+                        tip=tuple(meta.get("tip") or (0.0, 0.0)),
+                        elbow=tuple(meta["elbow"]),
+                        label_bbox=meta.get("label_bbox"),
+                        segments=segs,
+                    ),
+                )
+            )
         else:
-            items.append((name, _standin(shape, label=label,
-                                         measured_length=meta.get("measured_length") or 0.0,
-                                         dim_level_y=meta.get("dim_level_y"),
-                                         label_bbox=meta.get("label_bbox"), segments=segs)))
+            items.append(
+                (
+                    name,
+                    _standin(
+                        shape,
+                        label=label,
+                        measured_length=meta.get("measured_length") or 0.0,
+                        dim_level_y=meta.get("dim_level_y"),
+                        label_bbox=meta.get("label_bbox"),
+                        segments=segs,
+                    ),
+                )
+            )
     return items
 
 
@@ -127,16 +153,18 @@ def _lint_session(
         if view_shape_names is not None:
             missing = [n for n in view_shape_names if n not in session.objects]
             for m in missing:
-                violations.append({
-                    "severity": "warning",
-                    "check": "unknown_view_shape_name",
-                    "object": m,
-                    "message": (
-                        f"view_shape_names: '{m}' not found in session objects "
-                        f"— view-overlap check may be incomplete. "
-                        f"Call show(shape, '{m}') inside execute() before running lint."
-                    ),
-                })
+                violations.append(
+                    {
+                        "severity": "warning",
+                        "check": "unknown_view_shape_name",
+                        "object": m,
+                        "message": (
+                            f"view_shape_names: '{m}' not found in session objects "
+                            f"— view-overlap check may be incomplete. "
+                            f"Call show(shape, '{m}') inside execute() before running lint."
+                        ),
+                    }
+                )
             view_shapes = [session.objects[n] for n in view_shape_names if n in session.objects]
         for issue in _helper_lint(results, drawing_scale=drawing_scale, view_shapes=view_shapes):
             if issue.code not in _PER_ITEM_CODES:
@@ -148,7 +176,8 @@ def _lint_session(
     # helper's label↔frame check).
     if session.drawing_page:
         violations += _lint_page_bounds(
-            session.drawing_annotations, session.objects, session.drawing_page)
+            session.drawing_annotations, session.objects, session.drawing_page
+        )
     return violations
 
 
@@ -172,15 +201,17 @@ def _lint_page_bounds(annotations: dict, objects: dict, page: dict) -> list[dict
         if bb.max.Y > page["max_y"]:
             overshoots.append(f"top by {bb.max.Y - page['max_y']:.1f} mm")
         for detail in overshoots:
-            violations.append({
-                "severity": "error",
-                "check": "annotation_out_of_bounds",
-                "object": name,
-                "message": (
-                    f"annotation '{name}' extends past page edge ({detail}) "
-                    f"— move it inward or reduce offset"
-                ),
-            })
+            violations.append(
+                {
+                    "severity": "error",
+                    "check": "annotation_out_of_bounds",
+                    "object": name,
+                    "message": (
+                        f"annotation '{name}' extends past page edge ({detail}) "
+                        f"— move it inward or reduce offset"
+                    ),
+                }
+            )
     return violations
 
 
@@ -207,8 +238,7 @@ def _lint_svg(svg_path: str, drawing_scale: float = 1.0) -> list[dict]:
     try:
         tree = ET.parse(svg_path)
     except (FileNotFoundError, ET.ParseError) as e:
-        return [{"severity": "error", "check": "svg_parse",
-                 "object": svg_path, "message": str(e)}]
+        return [{"severity": "error", "check": "svg_parse", "object": svg_path, "message": str(e)}]
 
     def walk(elem, inherited_fill):
         fill = elem.get("fill", inherited_fill)
@@ -218,19 +248,20 @@ def _lint_svg(svg_path: str, drawing_scale: float = 1.0) -> list[dict]:
         if elem.tag.replace(_SVG_NS, "") == "text":
             layer_id = elem.get("id") or "?"
             no_fill = fill in (None, "none", "")
-            detail = (" and has no fill (renders as illegible outlines)"
-                      if no_fill else "")
-            violations.append({
-                "severity": "error",
-                "check": "native_svg_text",
-                "object": layer_id,
-                "message": (
-                    f"native <text> element id='{layer_id}'{detail}. build123d "
-                    f"renders text as filled glyph paths, not <text> — native SVG "
-                    f"text won't export to DXF and won't scale with the model. "
-                    f"Re-export the label from build123d geometry."
-                ),
-            })
+            detail = " and has no fill (renders as illegible outlines)" if no_fill else ""
+            violations.append(
+                {
+                    "severity": "error",
+                    "check": "native_svg_text",
+                    "object": layer_id,
+                    "message": (
+                        f"native <text> element id='{layer_id}'{detail}. build123d "
+                        f"renders text as filled glyph paths, not <text> — native SVG "
+                        f"text won't export to DXF and won't scale with the model. "
+                        f"Re-export the label from build123d geometry."
+                    ),
+                }
+            )
         for child in elem:
             walk(child, fill)
 
@@ -252,18 +283,22 @@ def _lint_svg(svg_path: str, drawing_scale: float = 1.0) -> list[dict]:
                     if issue.code == "label_vs_measured":
                         violations.append(_violation(issue, name))
         except Exception as exc:
-            violations.append({
-                "severity": "warning",
-                "check": "sidecar_read",
-                "object": sidecar,
-                "message": f"Could not read sidecar: {exc}",
-            })
+            violations.append(
+                {
+                    "severity": "warning",
+                    "check": "sidecar_read",
+                    "object": sidecar,
+                    "message": f"Could not read sidecar: {exc}",
+                }
+            )
 
     return violations
 
 
 def lint_drawing(
-    session, svg_path: str = "", drawing_scale: float = 1.0,
+    session,
+    svg_path: str = "",
+    drawing_scale: float = 1.0,
     view_shape_names: list[str] | None = None,
 ) -> str:
     """Run structural drawing checks; return JSON with a `violations` list.
@@ -278,6 +313,9 @@ def lint_drawing(
     Returns:
         JSON: {"violations": [{severity, check, object, message}, ...]}
     """
-    violations = (_lint_svg(svg_path, drawing_scale) if svg_path
-                  else _lint_session(session, drawing_scale, view_shape_names))
+    violations = (
+        _lint_svg(svg_path, drawing_scale)
+        if svg_path
+        else _lint_session(session, drawing_scale, view_shape_names)
+    )
     return json.dumps({"violations": violations}, indent=2)

--- a/src/build123d_mcp/tools/list_objects.py
+++ b/src/build123d_mcp/tools/list_objects.py
@@ -7,13 +7,15 @@ def list_objects(session) -> str:
     results = []
     for name, shape in session.objects.items():
         try:
-            results.append({
-                "name": name,
-                "volume": round(shape.volume, 4),
-                "faces": len(shape.faces()),
-                "edges": len(shape.edges()),
-                "vertices": len(shape.vertices()),
-            })
+            results.append(
+                {
+                    "name": name,
+                    "volume": round(shape.volume, 4),
+                    "faces": len(shape.faces()),
+                    "edges": len(shape.edges()),
+                    "vertices": len(shape.vertices()),
+                }
+            )
         except Exception as e:
             results.append({"name": name, "error": str(e)})
     return json.dumps(results, indent=2)

--- a/src/build123d_mcp/tools/measure.py
+++ b/src/build123d_mcp/tools/measure.py
@@ -5,7 +5,9 @@ import math
 def _resolve_shape(session, object_name: str):
     if object_name:
         if object_name not in session.objects:
-            raise ValueError(f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}")
+            raise ValueError(
+                f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}"
+            )
         return session.objects[object_name]
     if session.current_shape is None:
         raise ValueError("No shape in session. Execute code to create geometry first.")
@@ -15,6 +17,7 @@ def _resolve_shape(session, object_name: str):
 def _center_of_mass(shape) -> dict:
     from OCP.BRepGProp import BRepGProp
     from OCP.GProp import GProp_GProps
+
     props = GProp_GProps()
     BRepGProp.VolumeProperties_s(shape.wrapped, props)
     com = props.CentreOfMass()
@@ -23,13 +26,19 @@ def _center_of_mass(shape) -> dict:
 
 _SURFACE_NAMES = None
 
+
 def _get_surface_names():
     global _SURFACE_NAMES
     if _SURFACE_NAMES is None:
         from OCP.GeomAbs import (
-            GeomAbs_BSplineSurface, GeomAbs_Cone, GeomAbs_Cylinder,
-            GeomAbs_Plane, GeomAbs_Sphere, GeomAbs_Torus,
+            GeomAbs_BSplineSurface,
+            GeomAbs_Cone,
+            GeomAbs_Cylinder,
+            GeomAbs_Plane,
+            GeomAbs_Sphere,
+            GeomAbs_Torus,
         )
+
         _SURFACE_NAMES = {
             GeomAbs_Plane: "Plane",
             GeomAbs_Cylinder: "Cylinder",
@@ -44,7 +53,7 @@ def _get_surface_names():
 def _face_inventory(shape) -> list:
     from OCP.BRepAdaptor import BRepAdaptor_Surface
     from OCP.BRepGProp import BRepGProp
-    from OCP.GeomAbs import GeomAbs_Cylinder, GeomAbs_Cone, GeomAbs_Sphere, GeomAbs_Torus
+    from OCP.GeomAbs import GeomAbs_Cone, GeomAbs_Cylinder, GeomAbs_Sphere, GeomAbs_Torus
     from OCP.GProp import GProp_GProps
     from OCP.TopAbs import TopAbs_FACE
     from OCP.TopExp import TopExp_Explorer
@@ -91,6 +100,7 @@ def _face_inventory(shape) -> list:
 def _inertia(shape) -> dict:
     from OCP.BRepGProp import BRepGProp
     from OCP.GProp import GProp_GProps
+
     props = GProp_GProps()
     BRepGProp.VolumeProperties_s(shape.wrapped, props)
     mat = props.MatrixOfInertia()
@@ -108,13 +118,13 @@ def _cross_sections(shape, axis: str = "Z", num_slices: int = 10) -> list:
     from OCP.BRepAlgoAPI import BRepAlgoAPI_Section
     from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeFace
     from OCP.BRepGProp import BRepGProp
+    from OCP.gp import gp_Dir, gp_Pln, gp_Pnt
     from OCP.GProp import GProp_GProps
     from OCP.ShapeAnalysis import ShapeAnalysis_FreeBounds
     from OCP.TopAbs import TopAbs_EDGE
     from OCP.TopExp import TopExp_Explorer
-    from OCP.TopTools import TopTools_HSequenceOfShape
     from OCP.TopoDS import TopoDS
-    from OCP.gp import gp_Dir, gp_Pln, gp_Pnt
+    from OCP.TopTools import TopTools_HSequenceOfShape
 
     axis = axis.upper()
     bb = shape.bounding_box()
@@ -179,27 +189,33 @@ def measure(session, object_name: str = "") -> str:
     cx = round((bb.min.X + bb.max.X) / 2, 4)
     cy = round((bb.min.Y + bb.max.Y) / 2, 4)
     cz = round((bb.min.Z + bb.max.Z) / 2, 4)
-    return json.dumps({
-        "volume": round(shape.volume, 4),
-        "area": round(shape.area, 4),
-        "topology": {
-            "faces": len(shape.faces()),
-            "edges": len(shape.edges()),
-            "vertices": len(shape.vertices()),
+    return json.dumps(
+        {
+            "volume": round(shape.volume, 4),
+            "area": round(shape.area, 4),
+            "topology": {
+                "faces": len(shape.faces()),
+                "edges": len(shape.edges()),
+                "vertices": len(shape.vertices()),
+            },
+            "bbox": {
+                "xmin": round(bb.min.X, 4),
+                "xmax": round(bb.max.X, 4),
+                "ymin": round(bb.min.Y, 4),
+                "ymax": round(bb.max.Y, 4),
+                "zmin": round(bb.min.Z, 4),
+                "zmax": round(bb.max.Z, 4),
+                "xsize": round(bb.size.X, 4),
+                "ysize": round(bb.size.Y, 4),
+                "zsize": round(bb.size.Z, 4),
+                "center": {"x": cx, "y": cy, "z": cz},
+            },
+            "center_of_mass": _center_of_mass(shape),
+            "inertia": _inertia(shape),
+            "face_inventory": _face_inventory(shape),
         },
-        "bbox": {
-            "xmin": round(bb.min.X, 4), "xmax": round(bb.max.X, 4),
-            "ymin": round(bb.min.Y, 4), "ymax": round(bb.max.Y, 4),
-            "zmin": round(bb.min.Z, 4), "zmax": round(bb.max.Z, 4),
-            "xsize": round(bb.size.X, 4),
-            "ysize": round(bb.size.Y, 4),
-            "zsize": round(bb.size.Z, 4),
-            "center": {"x": cx, "y": cy, "z": cz},
-        },
-        "center_of_mass": _center_of_mass(shape),
-        "inertia": _inertia(shape),
-        "face_inventory": _face_inventory(shape),
-    }, indent=2)
+        indent=2,
+    )
 
 
 def clearance(session, object_a: str, object_b: str) -> str:
@@ -258,11 +274,14 @@ def clearance(session, object_a: str, object_b: str) -> str:
     else:
         status = "apart"
 
-    return json.dumps({
-        "clearance": dist,
-        "status": status,
-        "containment": containment,
-        "intersection_volume": intersection if intersection is not None else 0.0,
-        "a_volume_outside_b": a_outside_b,
-        "b_volume_outside_a": b_outside_a,
-    }, indent=2)
+    return json.dumps(
+        {
+            "clearance": dist,
+            "status": status,
+            "containment": containment,
+            "intersection_volume": intersection if intersection is not None else 0.0,
+            "a_volume_outside_b": a_outside_b,
+            "b_volume_outside_a": b_outside_a,
+        },
+        indent=2,
+    )

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -55,14 +55,20 @@ def _ensure_display() -> None:
         except Exception:
             pass
 
+
 _PALETTE = [
-    "lightblue", "lightcoral", "lightgreen",
-    "lightyellow", "plum", "peachpuff", "lightcyan",
+    "lightblue",
+    "lightcoral",
+    "lightgreen",
+    "lightyellow",
+    "plum",
+    "peachpuff",
+    "lightcyan",
 ]
 
 _QUALITY = {
     "standard": {"linear_deflection": 0.001, "angular_deflection": 0.1},
-    "high":     {"linear_deflection": 0.0005, "angular_deflection": 0.02},
+    "high": {"linear_deflection": 0.0005, "angular_deflection": 0.02},
 }
 
 _VALID_FORMATS = ("png", "svg", "dxf", "both")
@@ -94,10 +100,13 @@ def _resolve_shapes(session, objects: str):
 
 def _color_to_rgb(name: str) -> tuple[float, float, float]:
     from matplotlib.colors import to_rgb
+
     return to_rgb(name)
 
 
-def _camera_direction(direction: str) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+def _camera_direction(
+    direction: str,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
     """Return (position_unit_vector, view_up) for the named view direction."""
     if direction == "top":
         return (0.0, 0.0, 1.0), (0.0, 1.0, 0.0)
@@ -128,7 +137,9 @@ def _resolve_object_labels(shapes) -> list[tuple[tuple[float, float, float], str
     return out
 
 
-def _resolve_highlights(session, shapes, highlights) -> list[tuple[tuple[float, float, float], str]]:
+def _resolve_highlights(
+    session, shapes, highlights
+) -> list[tuple[tuple[float, float, float], str]]:
     """Validate and resolve highlight specs to [(position, label)].
 
     Each highlight must be a dict with keys: object, type, index, label.
@@ -160,7 +171,9 @@ def _resolve_highlights(session, shapes, highlights) -> list[tuple[tuple[float, 
                 f"Add it to objects= or omit the highlight."
             )
         if ent_type not in ("face", "edge", "vertex"):
-            raise ValueError(f"highlight type must be 'face', 'edge', or 'vertex', got '{ent_type}'")
+            raise ValueError(
+                f"highlight type must be 'face', 'edge', or 'vertex', got '{ent_type}'"
+            )
         if not isinstance(index, int):
             raise ValueError(f"highlight index must be int, got {type(index).__name__}: {index!r}")
 
@@ -195,6 +208,7 @@ def _add_label_actors(renderer, labels) -> None:
     if not labels:
         return
     import vtk
+
     for position, text in labels:
         actor = vtk.vtkBillboardTextActor3D()
         actor.SetPosition(*position)
@@ -210,8 +224,11 @@ def _add_label_actors(renderer, labels) -> None:
         renderer.AddActor(actor)
 
 
-def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevation, labels=None) -> tuple[bytes, list[str]]:
+def _do_render_png(
+    shapes, tess, direction, clip_plane, clip_at, azimuth, elevation, labels=None
+) -> tuple[bytes, list[str]]:
     import tempfile
+
     import vtk
 
     _ensure_display()
@@ -240,9 +257,7 @@ def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevat
 
     for i, (name, shape, obj_color) in enumerate(shapes):
         try:
-            verts, tris = shape.tessellate(
-                tess["linear_deflection"], tess["angular_deflection"]
-            )
+            verts, tris = shape.tessellate(tess["linear_deflection"], tess["angular_deflection"])
         except Exception as exc:
             failed.append(f"{name}: {exc}")
             continue
@@ -264,7 +279,9 @@ def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevat
 
         if clip_plane:
             if clip_at is not None:
-                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
+                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[
+                    clip_plane
+                ]
             else:
                 bounds = poly.GetBounds()  # xmin, xmax, ymin, ymax, zmin, zmax
                 cx = (bounds[0] + bounds[1]) / 2
@@ -312,7 +329,11 @@ def _do_render_png(shapes, tess, direction, clip_plane, clip_at, azimuth, elevat
         actor_count += 1
 
     if actor_count == 0:
-        msg = "All shapes failed to tessellate: " + "; ".join(failed) if failed else "No geometry to render"
+        msg = (
+            "All shapes failed to tessellate: " + "; ".join(failed)
+            if failed
+            else "No geometry to render"
+        )
         raise RuntimeError(msg)
 
     if label_renderer is not None:
@@ -358,15 +379,16 @@ def _viewport_origin_for(direction: str, shapes, azimuth: float, elevation: floa
     side they rotate around the cardinal axis-aligned baseline.
     """
     from build123d import Vector
+
     # Aggregate bounding centre across all shapes for look_at
     centres = [shape.center() for _name, shape, _c in shapes]
     centre = sum(centres, Vector(0, 0, 0)) * (1.0 / len(centres))
 
     # Direction vector matches the VTK camera baseline
     dx, dy, dz = {
-        "top":   (0.0, 0.0, 1.0),
+        "top": (0.0, 0.0, 1.0),
         "front": (0.0, -1.0, 0.0),
-        "side":  (1.0, 0.0, 0.0),
+        "side": (1.0, 0.0, 0.0),
     }.get(direction, (1.0, 1.0, 1.0))
     up = (0.0, 1.0, 0.0) if direction == "top" else (0.0, 0.0, 1.0)
 
@@ -411,6 +433,7 @@ def _do_render_svg(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
     only the keep-side.
     """
     import tempfile
+
     from build123d import ExportSVG, Plane, Vector
 
     # Optionally clip each shape to the keep-side of the requested plane
@@ -418,7 +441,9 @@ def _do_render_svg(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
     if clip_plane:
         for name, shape, color in shapes:
             if clip_at is not None:
-                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
+                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[
+                    clip_plane
+                ]
             else:
                 c = shape.center()
                 origin = {"x": (c.X, 0, 0), "y": (0, c.Y, 0), "z": (0, 0, c.Z)}[clip_plane]
@@ -441,12 +466,15 @@ def _do_render_svg(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
     for i, (name, shape, obj_color) in enumerate(clipped_shapes):
         try:
             visible, hidden = shape.project_to_viewport(
-                viewport_origin=origin, viewport_up=up, look_at=look_at,
+                viewport_origin=origin,
+                viewport_up=up,
+                look_at=look_at,
             )
         except Exception:
             continue
 
         from build123d import Color
+
         rgb = _color_to_rgb(obj_color if obj_color else _PALETTE[i % len(_PALETTE)])
         line_color = Color(*rgb)
 
@@ -478,13 +506,16 @@ def _do_render_dxf(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
     <name>_hidden (dashed). Clip-plane handling mirrors the SVG path.
     """
     import tempfile
+
     from build123d import ExportDXF, LineType, Plane, Vector
 
     clipped_shapes = []
     if clip_plane:
         for name, shape, color in shapes:
             if clip_at is not None:
-                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[clip_plane]
+                origin = {"x": (clip_at, 0, 0), "y": (0, clip_at, 0), "z": (0, 0, clip_at)}[
+                    clip_plane
+                ]
             else:
                 c = shape.center()
                 origin = {"x": (c.X, 0, 0), "y": (0, c.Y, 0), "z": (0, 0, c.Z)}[clip_plane]
@@ -505,7 +536,9 @@ def _do_render_dxf(shapes, direction, clip_plane, clip_at, azimuth, elevation) -
     for i, (name, shape, _obj_color) in enumerate(clipped_shapes):
         try:
             visible, hidden = shape.project_to_viewport(
-                viewport_origin=origin, viewport_up=up, look_at=look_at,
+                viewport_origin=origin,
+                viewport_up=up,
+                look_at=look_at,
             )
         except Exception:
             continue
@@ -568,9 +601,7 @@ def _resolve_2d_colors(shapes, colors: dict | None):
 
     default_dim = Color(0, 0.2, 0.7)
     dim_color = _to_color(colors["_dims"], default_dim) if "_dims" in colors else default_dim
-    label_color = (
-        _to_color(colors["_labels"], dim_color) if "_labels" in colors else dim_color
-    )
+    label_color = _to_color(colors["_labels"], dim_color) if "_labels" in colors else dim_color
 
     def part_color_for(name: str | None, supplied: str | None, index: int) -> "Color":
         if name and colors.get(name):
@@ -611,8 +642,9 @@ def _do_render_png_2d(shapes, label_objects: bool = False, colors: dict | None =
     import os as _os
     import re as _re
     import tempfile as _tempfile
+
     import resvg_py
-    from build123d import Color, Compound, ExportSVG, Text
+    from build123d import ExportSVG, Text
 
     part_color_for, dim_color, label_color = _resolve_2d_colors(shapes, colors)
 
@@ -640,7 +672,10 @@ def _do_render_png_2d(shapes, label_objects: bool = False, colors: dict | None =
         # Per-object part colour, shared blue for dimensions/annotations
         exporter.add_layer("part", line_color=single_part_color, line_weight=0.5)
         exporter.add_layer(
-            "dims", line_color=dim_color, fill_color=dim_color, line_weight=0.05,
+            "dims",
+            line_color=dim_color,
+            fill_color=dim_color,
+            line_weight=0.05,
         )
         # Walk children: edges → part layer; Sketch faces → dims layer
         for child in getattr(shape, "children", None) or [shape]:
@@ -666,7 +701,10 @@ def _do_render_png_2d(shapes, label_objects: bool = False, colors: dict | None =
             dims_layer = f"{base}_dims"
             exporter.add_layer(part_layer, line_color=obj_part_color, line_weight=0.5)
             exporter.add_layer(
-                dims_layer, line_color=dim_color, fill_color=dim_color, line_weight=0.05,
+                dims_layer,
+                line_color=dim_color,
+                fill_color=dim_color,
+                line_weight=0.05,
             )
             for child in getattr(shape, "children", None) or [shape]:
                 try:
@@ -682,7 +720,10 @@ def _do_render_png_2d(shapes, label_objects: bool = False, colors: dict | None =
 
     if label_shapes:
         exporter.add_layer(
-            "_labels", line_color=label_color, fill_color=label_color, line_weight=0.05,
+            "_labels",
+            line_color=label_color,
+            fill_color=label_color,
+            line_weight=0.05,
         )
         for txt in label_shapes:
             try:
@@ -698,10 +739,15 @@ def _do_render_png_2d(shapes, label_objects: bool = False, colors: dict | None =
         # resvg requires unitless or pixel sizes; build123d emits mm. Strip
         # the unit suffix from the top-level width/height attributes.
         svg = _re.sub(
-            r'(width|height)="([\d.]+)(mm|cm|in)"', r'\1="\2"', svg, count=2,
+            r'(width|height)="([\d.]+)(mm|cm|in)"',
+            r'\1="\2"',
+            svg,
+            count=2,
         )
         png_data = resvg_py.svg_to_bytes(
-            svg_string=svg, width=1200, background="#ffffff",
+            svg_string=svg,
+            width=1200,
+            background="#ffffff",
         )
         return bytes(png_data)
 
@@ -788,15 +834,19 @@ def render_view(
         if format in ("png", "both"):
             try:
                 result["png"] = _do_render_png_2d(
-                    shapes, label_objects=label_objects, colors=colors,
+                    shapes,
+                    label_objects=label_objects,
+                    colors=colors,
                 )
             except Exception as exc:
                 result["png_error"] = f"{type(exc).__name__}: {exc}"
         if format in ("svg", "both"):
             # 2D Sketches → SVG via ExportSVG with per-object colour and
             # part/dims layer split (mirrors the PNG path).
-            from build123d import ExportSVG
             import tempfile as _tempfile
+
+            from build123d import ExportSVG
+
             part_color_for, dim_col, _label_col = _resolve_2d_colors(shapes, colors)
             with _tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
                 svg_exporter = ExportSVG(margin=5)
@@ -806,7 +856,9 @@ def render_view(
                     part_layer = f"{base}_part"
                     dims_layer = f"{base}_dims"
                     svg_exporter.add_layer(part_layer, line_color=part_col, line_weight=0.4)
-                    svg_exporter.add_layer(dims_layer, line_color=dim_col, fill_color=dim_col, line_weight=0.05)
+                    svg_exporter.add_layer(
+                        dims_layer, line_color=dim_col, fill_color=dim_col, line_weight=0.05
+                    )
                     for child in getattr(shape, "children", None) or [shape]:
                         try:
                             target = dims_layer if len(child.faces()) > 0 else part_layer
@@ -824,8 +876,10 @@ def render_view(
             # 2D Sketches → DXF via ExportDXF. DXF colours use the small ACI
             # palette, so per-object hues are layer-only here — most DXF
             # viewers let users colour by layer in their own preferences.
-            from build123d import ExportDXF
             import tempfile as _tempfile
+
+            from build123d import ExportDXF
+
             with _tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
                 dxf_exporter = ExportDXF()
                 for i, (name, shape, _obj_color) in enumerate(shapes):
@@ -849,6 +903,7 @@ def render_view(
                     result["dxf"] = f.read()
         if save_to:
             from build123d_mcp.tools._paths import safe_output_path
+
             base, ext = os.path.splitext(save_to)
             if ext.lower() in (".png", ".svg", ".dxf"):
                 save_to = base
@@ -879,7 +934,13 @@ def render_view(
     if format in ("png", "both"):
         try:
             png_bytes, png_failed = _do_render_png(
-                shapes, tess, direction, clip_plane, clip_at, azimuth, elevation,
+                shapes,
+                tess,
+                direction,
+                clip_plane,
+                clip_at,
+                azimuth,
+                elevation,
                 labels=labels,
             )
             result["png"] = png_bytes
@@ -891,7 +952,12 @@ def render_view(
             if format == "png":
                 # Auto-fallback: produce SVG so the AI still gets a visual.
                 result["svg"] = _do_render_svg(
-                    shapes, direction, clip_plane, clip_at, azimuth, elevation,
+                    shapes,
+                    direction,
+                    clip_plane,
+                    clip_at,
+                    azimuth,
+                    elevation,
                 )
                 result["format"] = "svg"
                 result["fallback"] = (
@@ -905,16 +971,27 @@ def render_view(
 
     if format in ("svg", "both") and "svg" not in result:
         result["svg"] = _do_render_svg(
-            shapes, direction, clip_plane, clip_at, azimuth, elevation,
+            shapes,
+            direction,
+            clip_plane,
+            clip_at,
+            azimuth,
+            elevation,
         )
 
     if format == "dxf":
         result["dxf"] = _do_render_dxf(
-            shapes, direction, clip_plane, clip_at, azimuth, elevation,
+            shapes,
+            direction,
+            clip_plane,
+            clip_at,
+            azimuth,
+            elevation,
         )
 
     if save_to:
         from build123d_mcp.tools._paths import safe_output_path
+
         # Strip a known extension so format='both' produces consistent <base>.png and <base>.svg
         base, ext = os.path.splitext(save_to)
         if ext.lower() in (".png", ".svg", ".dxf"):

--- a/src/build123d_mcp/tools/render_drawing.py
+++ b/src/build123d_mcp/tools/render_drawing.py
@@ -7,6 +7,7 @@ then inspect the rendered PNG inline.
 
 resvg-py is already a runtime dep (used by render_view's 2D path).
 """
+
 import os
 import re
 
@@ -41,7 +42,7 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
         return {"error": "resvg-py is not installed in the server runtime."}
 
     try:
-        with open(svg_path, "r", encoding="utf-8") as f:
+        with open(svg_path, encoding="utf-8") as f:
             svg = f.read()
     except (OSError, UnicodeDecodeError) as e:
         return {"error": f"Could not read {svg_path}: {e}"}
@@ -50,9 +51,13 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
     out_width = width if width > 0 else 1200
 
     try:
-        png = bytes(resvg_py.svg_to_bytes(
-            svg_string=svg, width=out_width, background="#ffffff",
-        ))
+        png = bytes(
+            resvg_py.svg_to_bytes(
+                svg_string=svg,
+                width=out_width,
+                background="#ffffff",
+            )
+        )
     except Exception as e:
         return {"error": f"resvg failed: {type(e).__name__}: {e}"}
 
@@ -61,6 +66,7 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
         # Route through the central path policy (rejects traversal / writes
         # outside the allowed roots) before opening, like render_view(save_to=...).
         from build123d_mcp.tools._paths import safe_output_path
+
         abs_path = safe_output_path(save_to)
         try:
             with open(abs_path, "wb") as f:

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -42,9 +42,11 @@ _HINTS: list[tuple[list[str], str]] = [
         "Avoid `shape.edges()` (all edges) on complex shapes — pick specific ones.",
     ),
     (
-        [r"NameError.*\b(Box|Cylinder|Sphere|Cone|Torus|Extrude|BuildPart|"
-         r"BuildSketch|Align|Axis|Location|Plane|Vector|Color|Compound|Shell|"
-         r"Fillet|Chamfer|extrude|loft|sweep)\b"],
+        [
+            r"NameError.*\b(Box|Cylinder|Sphere|Cone|Torus|Extrude|BuildPart|"
+            r"BuildSketch|Align|Axis|Location|Plane|Vector|Color|Compound|Shell|"
+            r"Fillet|Chamfer|extrude|loft|sweep)\b"
+        ],
         "build123d name not in scope. Add `from build123d import *` at the top of "
         "the execute() call. If it was imported in a previous call, re-run that import "
         "or include it in this snippet.",

--- a/src/build123d_mcp/tools/resolve.py
+++ b/src/build123d_mcp/tools/resolve.py
@@ -16,20 +16,30 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
         and (for Face) normal.
     """
     if not object_name or object_name not in session.objects:
-        return json.dumps({
-            "error": f"Unknown object '{object_name}'.",
-            "registered": list(session.objects.keys()),
-        })
+        return json.dumps(
+            {
+                "error": f"Unknown object '{object_name}'.",
+                "registered": list(session.objects.keys()),
+            }
+        )
 
     obj = session.objects[object_name]
 
     # Build a namespace with build123d imports plus the shape as `obj`
     try:
-        from build123d import (  # noqa: F401
-            Axis, Edge, Face, Shape, Compound, Solid, Vector, Vertex,
-            ShapeList,
-        )
         import build123d as _bd
+        from build123d import (  # noqa: F401
+            Axis,
+            Compound,
+            Edge,
+            Face,
+            Shape,
+            ShapeList,
+            Solid,
+            Vector,
+            Vertex,
+        )
+
         namespace = {k: getattr(_bd, k) for k in dir(_bd) if not k.startswith("_")}
     except ImportError as exc:
         return json.dumps({"error": f"build123d import failed: {exc}"})
@@ -43,19 +53,23 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
     try:
         check_ast(expression)
     except ValueError as exc:
-        return json.dumps({
-            "error": f"Selector rejected: {exc}",
-            "selector": selector,
-        })
+        return json.dumps(
+            {
+                "error": f"Selector rejected: {exc}",
+                "selector": selector,
+            }
+        )
 
     namespace["__builtins__"] = make_restricted_builtins()
     try:
         result = eval(expression, namespace)  # noqa: S307
     except Exception as exc:
-        return json.dumps({
-            "error": f"Selector evaluation failed: {exc}",
-            "selector": selector,
-        })
+        return json.dumps(
+            {
+                "error": f"Selector evaluation failed: {exc}",
+                "selector": selector,
+            }
+        )
 
     # Build descriptor
     type_name = type(result).__name__
@@ -68,10 +82,11 @@ def resolve(session, object_name: str, selector: str, label: str = "") -> str:
     }
 
     try:
-        from build123d import Face as _Face, Edge as _Edge
+        from build123d import Edge as _Edge
+        from build123d import Face as _Face
+
         if isinstance(result, _Face):
             descriptor["area"] = round(result.area, 6)
-            bb = result.bounding_box()
             cen = result.center()
             descriptor["center"] = [round(cen.X, 6), round(cen.Y, 6), round(cen.Z, 6)]
             try:

--- a/src/build123d_mcp/tools/save_drawing_annotations.py
+++ b/src/build123d_mcp/tools/save_drawing_annotations.py
@@ -4,6 +4,7 @@ inspect_drawing(svg_path=...) reads this sidecar when present, restoring
 label text and measured-length metadata that would otherwise be lost because
 build123d renders Text as filled glyph paths (not SVG <text> elements).
 """
+
 import json
 import pathlib
 

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -10,8 +10,8 @@ def _is_imported_symbol(val) -> bool:
     """Return True if val is a class/function/module imported from build123d, not a user value."""
     if isinstance(val, types.ModuleType):
         return True
-    mod = getattr(val, '__module__', '') or ''
-    if mod.startswith('build123d') or mod.startswith('cadquery') or mod.startswith('OCP'):
+    mod = getattr(val, "__module__", "") or ""
+    if mod.startswith("build123d") or mod.startswith("cadquery") or mod.startswith("OCP"):
         if isinstance(val, type) or (callable(val) and not isinstance(val, type)):
             return True
     return False
@@ -20,6 +20,7 @@ def _is_imported_symbol(val) -> bool:
 def _build123d_public_names() -> set[str]:
     try:
         import build123d
+
         return set(dir(build123d))
     except ImportError:
         return set()
@@ -36,6 +37,7 @@ def _namespace_summary(namespace: dict) -> dict:
     _shape_cls: type | None = None
     try:
         from build123d import Shape
+
         _shape_cls = Shape
     except ImportError:
         pass

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -14,17 +14,22 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
     da, db = _shape_diag(sa), _shape_diag(sb)
 
     ca, cb = _center_of_mass(sa), _center_of_mass(sb)
-    offset = round(((cb["x"] - ca["x"])**2 + (cb["y"] - ca["y"])**2 + (cb["z"] - ca["z"])**2) ** 0.5, 4)
+    offset = round(
+        ((cb["x"] - ca["x"]) ** 2 + (cb["y"] - ca["y"]) ** 2 + (cb["z"] - ca["z"]) ** 2) ** 0.5, 4
+    )
 
-    return json.dumps({
-        "a": {"name": object_a, **da, "center": ca},
-        "b": {"name": object_b, **db, "center": cb},
-        "delta": {
-            "volume": round(db["volume"] - da["volume"], 4),
-            "faces": db["faces"] - da["faces"],
-            "edges": db["edges"] - da["edges"],
-            "vertices": db["vertices"] - da["vertices"],
-            "bbox": [round(db["bbox"][i] - da["bbox"][i], 4) for i in range(3)],
-            "center_offset": offset,
+    return json.dumps(
+        {
+            "a": {"name": object_a, **da, "center": ca},
+            "b": {"name": object_b, **db, "center": cb},
+            "delta": {
+                "volume": round(db["volume"] - da["volume"], 4),
+                "faces": db["faces"] - da["faces"],
+                "edges": db["edges"] - da["edges"],
+                "vertices": db["vertices"] - da["vertices"],
+                "bbox": [round(db["bbox"][i] - da["bbox"][i], 4) for i in range(3)],
+                "center_offset": offset,
+            },
         },
-    }, indent=2)
+        indent=2,
+    )

--- a/src/build123d_mcp/tools/suggest_view_layout.py
+++ b/src/build123d_mcp/tools/suggest_view_layout.py
@@ -23,9 +23,9 @@ _GAP = 12.0
 # Camera/up conventions per named view.
 _CAMERAS: dict[str, dict[str, Any]] = {
     "front": {"camera": (0, -100, 0), "up": (0, 0, 1)},
-    "plan":  {"camera": (0,    0, 100), "up": (0, 1, 0)},
-    "side":  {"camera": (100,  0,  0), "up": (0, 0, 1)},
-    "iso":   {"camera": (80,  80, 80), "up": (0, 0, 1)},
+    "plan": {"camera": (0, 0, 100), "up": (0, 1, 0)},
+    "side": {"camera": (100, 0, 0), "up": (0, 0, 1)},
+    "iso": {"camera": (80, 80, 80), "up": (0, 0, 1)},
 }
 
 # Page size catalogue for fit suggestions.
@@ -58,7 +58,9 @@ def _page_half_extents(
 
 
 def _layout(
-    x_size: float, y_size: float, z_size: float,
+    x_size: float,
+    y_size: float,
+    z_size: float,
     scale: float,
     views: list[str],
     margin: float,
@@ -109,13 +111,15 @@ def _layout(
 def _check_fits(
     pos: dict[str, tuple[float, float]],
     hw: dict[str, tuple[float, float]],
-    page_w: float, page_h: float,
+    page_w: float,
+    page_h: float,
     margin: float,
-    title_block_w: float, title_block_h: float,
+    title_block_w: float,
+    title_block_h: float,
 ) -> list[str]:
     warnings: list[str] = []
     tb_left = page_w - margin - title_block_w
-    tb_top  = margin + title_block_h
+    tb_top = margin + title_block_h
 
     for vname, (vx, vy) in pos.items():
         vhw, vhh = hw[vname]
@@ -125,11 +129,17 @@ def _check_fits(
         if left < margin:
             warnings.append(f"'{vname}' left edge ({left:.1f}) is inside left margin ({margin})")
         if right > page_w - margin:
-            warnings.append(f"'{vname}' right edge ({right:.1f}) exceeds right margin ({page_w - margin:.1f})")
+            warnings.append(
+                f"'{vname}' right edge ({right:.1f}) exceeds right margin ({page_w - margin:.1f})"
+            )
         if bottom < margin:
-            warnings.append(f"'{vname}' bottom edge ({bottom:.1f}) is inside bottom margin ({margin})")
+            warnings.append(
+                f"'{vname}' bottom edge ({bottom:.1f}) is inside bottom margin ({margin})"
+            )
         if top > page_h - margin:
-            warnings.append(f"'{vname}' top edge ({top:.1f}) exceeds top margin ({page_h - margin:.1f})")
+            warnings.append(
+                f"'{vname}' top edge ({top:.1f}) exceeds top margin ({page_h - margin:.1f})"
+            )
 
         # Overlap with title block (bottom-right rectangle)
         if right > tb_left and bottom < tb_top:
@@ -194,8 +204,7 @@ def suggest_view_layout(
         return json.dumps({"error": f"Could not measure '{object_name}': {exc}"})
 
     hw = {v: _page_half_extents(v, x_size, y_size, z_size, scale) for v in views}
-    pos = _layout(x_size, y_size, z_size, scale, views,
-                  margin, title_block_w, title_block_h)
+    pos = _layout(x_size, y_size, z_size, scale, views, margin, title_block_w, title_block_h)
     warnings = _check_fits(pos, hw, page_w, page_h, margin, title_block_w, title_block_h)
 
     # If the layout doesn't fit, suggest an alternative.
@@ -206,13 +215,19 @@ def suggest_view_layout(
             for pw, ph, pname in _PAGE_SIZES:
                 if pw < page_w and ph < page_h:
                     continue  # don't suggest smaller pages
-                try_pos = _layout(x_size, y_size, z_size, try_scale, views,
-                                  margin, title_block_w, title_block_h)
-                try_hw = {v: _page_half_extents(v, x_size, y_size, z_size, try_scale)
-                          for v in views}
+                try_pos = _layout(
+                    x_size, y_size, z_size, try_scale, views, margin, title_block_w, title_block_h
+                )
+                try_hw = {
+                    v: _page_half_extents(v, x_size, y_size, z_size, try_scale) for v in views
+                }
                 if not _check_fits(try_pos, try_hw, pw, ph, margin, title_block_w, title_block_h):
-                    suggestion = {"page_w": pw, "page_h": ph, "scale": round(try_scale, 4),
-                                  "page_size": pname}
+                    suggestion = {
+                        "page_w": pw,
+                        "page_h": ph,
+                        "scale": round(try_scale, 4),
+                        "page_size": pname,
+                    }
                     break
             if suggestion:
                 break
@@ -243,7 +258,9 @@ def suggest_view_layout(
         "page_h": page_h,
         "scale": scale,
         "part_size": {
-            "x": round(x_size, 3), "y": round(y_size, 3), "z": round(z_size, 3),
+            "x": round(x_size, 3),
+            "y": round(y_size, 3),
+            "z": round(z_size, 3),
             "centroid": [round(cx, 3), round(cy, 3), round(cz, 3)],
         },
         "warnings": warnings,

--- a/src/build123d_mcp/tools/validate_code.py
+++ b/src/build123d_mcp/tools/validate_code.py
@@ -1,7 +1,7 @@
 import ast
 import json
 
-from build123d_mcp.security import IMPORT_ALLOWLIST, _BLOCKED_CALL_NAMES
+from build123d_mcp.security import _BLOCKED_CALL_NAMES, IMPORT_ALLOWLIST
 
 
 def validate_code(code: str) -> str:
@@ -9,12 +9,15 @@ def validate_code(code: str) -> str:
     try:
         tree = ast.parse(code)
     except SyntaxError as e:
-        return json.dumps({
-            "syntax": f"SyntaxError at line {e.lineno}: {e.msg}",
-            "blocked": [],
-            "warnings": [],
-            "ok": False,
-        }, indent=2)
+        return json.dumps(
+            {
+                "syntax": f"SyntaxError at line {e.lineno}: {e.msg}",
+                "blocked": [],
+                "warnings": [],
+                "ok": False,
+            },
+            indent=2,
+        )
 
     blocked = []
     warnings = []
@@ -45,22 +48,30 @@ def validate_code(code: str) -> str:
         for n in ast.walk(tree)
     )
     if not has_b3d_import:
-        warnings.append("no build123d import in this snippet — ok if already imported in a prior execute()")
+        warnings.append(
+            "no build123d import in this snippet — ok if already imported in a prior execute()"
+        )
 
     # Advisory: no result variable or show() call
     has_output = any(
-        (isinstance(n, ast.Assign) and any(
-            isinstance(t, ast.Name) and t.id == "result" for t in n.targets
-        ))
+        (
+            isinstance(n, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "result" for t in n.targets)
+        )
         or (isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "show")
         for n in ast.walk(tree)
     )
     if not has_output:
-        warnings.append("no 'result' assignment or show() call — the session won't capture a shape unless current_shape is set by other means")
+        warnings.append(
+            "no 'result' assignment or show() call — the session won't capture a shape unless current_shape is set by other means"
+        )
 
-    return json.dumps({
-        "syntax": "ok",
-        "blocked": blocked,
-        "warnings": warnings,
-        "ok": len(blocked) == 0,
-    }, indent=2)
+    return json.dumps(
+        {
+            "syntax": "ok",
+            "blocked": blocked,
+            "warnings": warnings,
+            "ok": len(blocked) == 0,
+        },
+        indent=2,
+    )

--- a/src/build123d_mcp/tools/version.py
+++ b/src/build123d_mcp/tools/version.py
@@ -7,7 +7,8 @@ build123d worker subprocess is down (the stale-install case it diagnoses).
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError, version as _dist_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 
 # distribution names (as on PyPI); these double as the display labels
 _PACKAGES = ("build123d-mcp", "build123d", "build123d-drafting-helpers")

--- a/src/build123d_mcp/tools/view_axes.py
+++ b/src/build123d_mcp/tools/view_axes.py
@@ -5,25 +5,30 @@ often called before any execute() so the OCC kernel has not been loaded yet.
 Importing build123d_drafting here would trigger the OCC cold-start and breach
 the 10-second SHORT_TIMEOUT even though none of the math needs OCC.
 """
+
 import json
 import math
 
 
 def _dot3(a, b):
-    return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
 
 def _sub3(a, b):
-    return (a[0]-b[0], a[1]-b[1], a[2]-b[2])
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
 
 def _scale3(s, v):
-    return (s*v[0], s*v[1], s*v[2])
+    return (s * v[0], s * v[1], s * v[2])
+
 
 def _cross3(a, b):
-    return (a[1]*b[2]-a[2]*b[1], a[2]*b[0]-a[0]*b[2], a[0]*b[1]-a[1]*b[0])
+    return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
 
 def _norm3(v):
     mag = math.sqrt(_dot3(v, v))
-    return (v[0]/mag, v[1]/mag, v[2]/mag) if mag > 1e-10 else (0.0, 0.0, 0.0)
+    return (v[0] / mag, v[1] / mag, v[2] / mag) if mag > 1e-10 else (0.0, 0.0, 0.0)
 
 
 def _helper_expr(param: str, view_var: str, offset: float, sign: float) -> str:
@@ -109,7 +114,7 @@ def view_axes(
 
     # Ready-to-paste helper snippet — one function per active (non-depth) axis.
     _param = {"world_X": "x", "world_Y": "y", "world_Z": "z"}
-    _view  = {"page_X": "VIEW_X", "page_Y": "VIEW_Y"}
+    _view = {"page_X": "VIEW_X", "page_Y": "VIEW_Y"}
     lines = ["# Coordinate helpers (replace VIEW_X/VIEW_Y/SCALE with your values):"]
     for world_name in ("world_X", "world_Y", "world_Z"):
         page_axis, sign = axis_map[world_name]

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -33,6 +33,7 @@ def worker_main(
     """
     if allow_all_imports or extra_allowed_imports:
         import build123d_mcp.security as _sec
+
         if allow_all_imports:
             _sec.ALLOW_ALL_IMPORTS = True
         if extra_allowed_imports:
@@ -44,6 +45,7 @@ def worker_main(
     library_index = None
     if library_path:
         from build123d_mcp.tools.library import _LibraryIndex
+
         library_index = _LibraryIndex(library_path)
 
     conn.send({"ready": True})
@@ -70,33 +72,43 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
 
     if op == "render_view":
         from build123d_mcp.tools.render import render_view
+
         return render_view(session, **args)
 
     if op == "export_file":
         from build123d_mcp.tools.export import export_file
+
         return export_file(session, **args)
 
     if op == "interference":
         from build123d_mcp.tools.interference import interference
+
         return interference(session, **args)
 
     if op == "measure":
         from build123d_mcp.tools.measure import measure
+
         return measure(session, **args)
 
     if op == "clearance":
         from build123d_mcp.tools.measure import clearance
+
         return clearance(session, **args)
 
     if op == "cross_sections":
         from build123d_mcp.tools.cross_sections import cross_sections
+
         return cross_sections(session, **args)
 
     if op == "save_snapshot":
         name = args["name"]
         session.save_snapshot(name)
-        saved = (["current_shape"] if session.current_shape is not None else []) + list(session.snapshots[name]["objects"].keys())
-        return f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
+        saved = (["current_shape"] if session.current_shape is not None else []) + list(
+            session.snapshots[name]["objects"].keys()
+        )
+        return (
+            f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
+        )
 
     if op == "restore_snapshot":
         name = args["name"]
@@ -104,7 +116,9 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
             session.restore_snapshot(name)
         except KeyError as e:
             return f"Error: {e}"
-        restored = (["current_shape"] if session.current_shape is not None else []) + list(session.objects.keys())
+        restored = (["current_shape"] if session.current_shape is not None else []) + list(
+            session.objects.keys()
+        )
         return f"Snapshot '{name}' restored. Active geometry: {', '.join(restored) if restored else 'none'}."
 
     if op == "reset":
@@ -115,44 +129,56 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
         if library_index is None:
             return "No part library configured."
         from build123d_mcp.tools.library import search_library
+
         return search_library(library_index, args.get("query", ""))
 
     if op == "load_part":
         if library_index is None:
             return "No part library configured."
         from build123d_mcp.tools.library import load_part
+
         return load_part(session, library_index, args["name"], args.get("params", ""))
 
     if op == "diff_snapshot":
         from build123d_mcp.tools.diff import diff_snapshot
-        return diff_snapshot(session, args["snapshot_a"], args.get("snapshot_b", ""), args.get("format", "text"))
+
+        return diff_snapshot(
+            session, args["snapshot_a"], args.get("snapshot_b", ""), args.get("format", "text")
+        )
 
     if op == "session_state":
         from build123d_mcp.tools.session_state import session_state
+
         return session_state(session)
 
     if op == "health_check":
         from build123d_mcp.tools.health_check import health_check
+
         return health_check(session)
 
     if op == "last_error":
         from build123d_mcp.tools.last_error import last_error
+
         return last_error(session)
 
     if op == "shape_compare":
         from build123d_mcp.tools.shape_compare import shape_compare
+
         return shape_compare(session, args["object_a"], args["object_b"])
 
     if op == "import_cad_file":
         from build123d_mcp.tools.import_step import import_cad_file
+
         return import_cad_file(session, args["path"], args.get("name", ""))
 
     if op == "inspect_drawing":
         from build123d_mcp.tools.inspect_drawing import inspect_drawing
+
         return inspect_drawing(session, args.get("objects", ""), args.get("svg_path", ""))
 
     if op == "view_axes":
         from build123d_mcp.tools.view_axes import view_axes
+
         return view_axes(
             tuple(args["viewport_origin"]),
             tuple(args.get("viewport_up", (0.0, 1.0, 0.0))),
@@ -161,12 +187,17 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
 
     if op == "lint_drawing":
         from build123d_mcp.tools.lint_drawing import lint_drawing
-        return lint_drawing(session, args.get("svg_path", ""),
-                            args.get("drawing_scale", 1.0),
-                            args.get("view_shape_names"))
+
+        return lint_drawing(
+            session,
+            args.get("svg_path", ""),
+            args.get("drawing_scale", 1.0),
+            args.get("view_shape_names"),
+        )
 
     if op == "render_drawing":
         from build123d_mcp.tools.render_drawing import render_drawing
+
         return render_drawing(
             args["svg_path"],
             args.get("width", 0),
@@ -175,28 +206,43 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
 
     if op == "save_drawing_annotations":
         from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
+
         return save_drawing_annotations(session, args["svg_path"])
 
     if op == "align_check":
         from build123d_mcp.tools.align_check import align_check
-        return align_check(session, args["object_a"], args["object_b"],
-                           axis=args.get("axis", "Z"), mode=args.get("mode", "flush"))
+
+        return align_check(
+            session,
+            args["object_a"],
+            args["object_b"],
+            axis=args.get("axis", "Z"),
+            mode=args.get("mode", "flush"),
+        )
 
     if op == "resolve":
         from build123d_mcp.tools.resolve import resolve
+
         return resolve(session, args["object_name"], args["selector"], label=args.get("label", ""))
 
     if op == "suggest_view_layout":
         from build123d_mcp.tools.suggest_view_layout import suggest_view_layout
+
         return suggest_view_layout(
-            session, args["object_name"], args.get("page_w", 297.0),
-            args.get("page_h", 210.0), args.get("scale", 1.0), args.get("views"),
-            args.get("title_block_w", 150.0), args.get("title_block_h", 30.0),
+            session,
+            args["object_name"],
+            args.get("page_w", 297.0),
+            args.get("page_h", 210.0),
+            args.get("scale", 1.0),
+            args.get("views"),
+            args.get("title_block_w", 150.0),
+            args.get("title_block_h", 30.0),
             args.get("margin", 10.0),
         )
 
     if op == "script":
         from build123d_mcp.tools.script import script
+
         return script(session, save_to=args.get("save_to", ""))
 
     raise ValueError(f"Unknown operation: '{op}'")
@@ -270,6 +316,7 @@ class WorkerSession:
             self._kill_worker()
             self._start_worker()
             from build123d_mcp.security import ExecutionTimeout
+
             if op == "execute":
                 raise ExecutionTimeout(
                     f"Code exceeded the {timeout}s execution time limit. "
@@ -298,6 +345,7 @@ class WorkerSession:
 
     def execute(self, code: str) -> str:
         from build123d_mcp.security import ExecutionTimeout
+
         try:
             return self._call("execute", {"code": code}, self._exec_timeout)
         except (RuntimeError, ExecutionTimeout) as e:
@@ -357,7 +405,9 @@ class WorkerSession:
         return self._call("measure", {"object_name": object_name}, self._SHORT_TIMEOUT)
 
     def clearance(self, object_a: str, object_b: str) -> str:
-        return self._call("clearance", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT)
+        return self._call(
+            "clearance", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT
+        )
 
     def cross_sections(self, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
         return self._call(
@@ -379,7 +429,11 @@ class WorkerSession:
         return self._call("reset", {}, self._SHORT_TIMEOUT)
 
     def diff_snapshot(self, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
-        return self._call("diff_snapshot", {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b, "format": format}, self._SHORT_TIMEOUT)
+        return self._call(
+            "diff_snapshot",
+            {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b, "format": format},
+            self._SHORT_TIMEOUT,
+        )
 
     def session_state(self) -> str:
         return self._call("session_state", {}, self._SHORT_TIMEOUT)
@@ -391,7 +445,9 @@ class WorkerSession:
         return self._call("last_error", {}, self._SHORT_TIMEOUT)
 
     def shape_compare(self, object_a: str, object_b: str) -> str:
-        return self._call("shape_compare", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT)
+        return self._call(
+            "shape_compare", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT
+        )
 
     def import_cad_file(self, path: str, name: str = "") -> str:
         return self._call("import_cad_file", {"path": path, "name": name}, self._EXPORT_TIMEOUT)
@@ -416,13 +472,18 @@ class WorkerSession:
         )
 
     def lint_drawing(
-        self, svg_path: str = "", drawing_scale: float = 1.0,
+        self,
+        svg_path: str = "",
+        drawing_scale: float = 1.0,
         view_shape_names: list[str] | None = None,
     ) -> str:
         return self._call(
             "lint_drawing",
-            {"svg_path": svg_path, "drawing_scale": drawing_scale,
-             "view_shape_names": view_shape_names},
+            {
+                "svg_path": svg_path,
+                "drawing_scale": drawing_scale,
+                "view_shape_names": view_shape_names,
+            },
             self._SHORT_TIMEOUT,
         )
 
@@ -440,7 +501,9 @@ class WorkerSession:
             self._SHORT_TIMEOUT,
         )
 
-    def align_check(self, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush") -> str:
+    def align_check(
+        self, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush"
+    ) -> str:
         return self._call(
             "align_check",
             {"object_a": object_a, "object_b": object_b, "axis": axis, "mode": mode},
@@ -467,9 +530,16 @@ class WorkerSession:
     ) -> str:
         return self._call(
             "suggest_view_layout",
-            {"object_name": object_name, "page_w": page_w, "page_h": page_h,
-             "scale": scale, "views": views, "title_block_w": title_block_w,
-             "title_block_h": title_block_h, "margin": margin},
+            {
+                "object_name": object_name,
+                "page_w": page_w,
+                "page_h": page_h,
+                "scale": scale,
+                "views": views,
+                "title_block_w": title_block_w,
+                "title_block_h": title_block_h,
+                "margin": margin,
+            },
             self._SHORT_TIMEOUT,
         )
 

--- a/tests/test_align_check.py
+++ b/tests/test_align_check.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from build123d_mcp.session import Session
@@ -16,9 +17,7 @@ def session():
 def two_boxes_stacked(session):
     """Two boxes: box_a at Z=0..10, box_b at Z=10..20 (flush in Z)."""
     session.execute("box_a = Box(10, 10, 10); show(box_a, 'box_a')")
-    session.execute(
-        "box_b = Box(10, 10, 10).move(Location((0, 0, 10))); show(box_b, 'box_b')"
-    )
+    session.execute("box_b = Box(10, 10, 10).move(Location((0, 0, 10))); show(box_b, 'box_b')")
     return session
 
 

--- a/tests/test_bd_warehouse_resource.py
+++ b/tests/test_bd_warehouse_resource.py
@@ -1,4 +1,5 @@
 """Tests for the build123d://bd_warehouse resource."""
+
 from build123d_mcp.bd_warehouse_resource import build_bd_warehouse_text
 
 
@@ -22,8 +23,8 @@ def test_bd_warehouse_resource_lists_common_classes():
 def test_bd_warehouse_resource_shows_sizes_and_types():
     text = build_bd_warehouse_text()
     # Fastener types and sizes should be present
-    assert "iso4762" in text   # SocketHeadCapScrew default type
-    assert "M6-1" in text      # Common metric size
+    assert "iso4762" in text  # SocketHeadCapScrew default type
+    assert "M6-1" in text  # Common metric size
 
 
 def test_bd_warehouse_resource_no_double_quoted_defaults():
@@ -34,5 +35,6 @@ def test_bd_warehouse_resource_no_double_quoted_defaults():
 
 def test_bd_warehouse_resource_registered_in_server():
     from build123d_mcp.server import build123d_bd_warehouse
+
     text = build123d_bd_warehouse()
     assert "BD_WAREHOUSE" in text

--- a/tests/test_drafting_cookbook.py
+++ b/tests/test_drafting_cookbook.py
@@ -1,4 +1,5 @@
 """Verify every runnable drafting cookbook example executes and produces a shape."""
+
 import pytest
 
 from build123d_mcp.drafting_cookbook import RUNNABLE_EXAMPLES, build_drafting_cookbook_text
@@ -18,12 +19,11 @@ def fresh_session():
 def test_drafting_cookbook_example_runs(fresh_session, label, code):
     result = fresh_session.execute(code)
     assert not result.startswith("Error:"), f"Example '{label}' failed:\n{result}"
-    assert fresh_session.current_shape is not None, (
-        f"Example '{label}' produced no shape"
-    )
+    assert fresh_session.current_shape is not None, f"Example '{label}' produced no shape"
 
 
 def test_drafting_cookbook_resource_uses_generated_text():
     """Confirm the MCP resource returns exactly what build_drafting_cookbook_text() produces."""
     from build123d_mcp.server import build123d_drafting_cookbook
+
     assert build123d_drafting_cookbook() == build_drafting_cookbook_text()

--- a/tests/test_drawing_tooling.py
+++ b/tests/test_drawing_tooling.py
@@ -1,9 +1,9 @@
 """Tests for the #108 pass-1 drawing-side tools:
 view_axes, lint_drawing, render_drawing, inspect_drawing(svg_path=...).
 """
+
 import json
 import os
-from pathlib import Path
 
 import pytest
 
@@ -19,9 +19,11 @@ def session():
 # view_axes
 # ---------------------------------------------------------------------------
 
+
 class TestViewAxes:
     def test_top_view_identity_mapping(self):
         from build123d_mcp.tools.view_axes import view_axes
+
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
         assert result["world_X"][0] == "page_X"
         assert result["world_X"][1] == 1.0
@@ -31,12 +33,14 @@ class TestViewAxes:
     def test_bottom_view_flips_world_x(self):
         """The bottom-view axis swap that the gramel shank drawing hit."""
         from build123d_mcp.tools.view_axes import view_axes
+
         result = json.loads(view_axes((0, 0, -100), (0, 1, 0), (0, 0, 0)))
         assert result["world_X"][0] == "page_X"
         assert result["world_X"][1] == -1.0
 
     def test_look_at_offset_zero_at_origin(self):
         from build123d_mcp.tools.view_axes import view_axes
+
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
         assert "look_at_offset" in result
         assert result["look_at_offset"]["page_X"] == 0.0
@@ -45,6 +49,7 @@ class TestViewAxes:
     def test_look_at_offset_front_view_z_centroid(self):
         """Front view with part centroid at z=-4.65: page_Y offset should be -4.65."""
         from build123d_mcp.tools.view_axes import view_axes
+
         # camera on -Y axis, up=+Z → world_Z maps to page_Y
         result = json.loads(view_axes((0, -100, 0), (0, 0, 1), (0, 0, -4.65)))
         assert result["look_at_offset"]["page_Y"] == -4.65
@@ -52,6 +57,7 @@ class TestViewAxes:
     def test_look_at_offset_top_view_y_centroid(self):
         """Top view (camera +Z, up +Y): world_Y → page_Y. look_at y=3.0 offset captured."""
         from build123d_mcp.tools.view_axes import view_axes
+
         # Camera on +Z axis, look_at Y=3 → world_Y maps to page_Y → offset = 3.0
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 3.0, 0)))
         assert result["look_at_offset"]["page_Y"] == 3.0
@@ -59,6 +65,7 @@ class TestViewAxes:
 
     def test_helper_snippet_present_and_non_empty(self):
         from build123d_mcp.tools.view_axes import view_axes
+
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
         assert "helper_snippet" in result
         assert "VIEW_X" in result["helper_snippet"]
@@ -67,6 +74,7 @@ class TestViewAxes:
     def test_helper_snippet_includes_offset_when_nonzero(self):
         """When look_at has a non-zero component, the snippet incorporates the offset."""
         from build123d_mcp.tools.view_axes import view_axes
+
         # Top view: world_X → page_X, world_Y → page_Y, look_at x=3.0
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (3.0, 0, 0)))
         assert "3.0" in result["helper_snippet"]
@@ -74,6 +82,7 @@ class TestViewAxes:
     def test_helper_snippet_clean_when_offset_zero(self):
         """No offset terms when look_at is at origin."""
         from build123d_mcp.tools.view_axes import view_axes
+
         result = json.loads(view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
         # Clean form: def X(x): return VIEW_X + x * SCALE  (no subtraction)
         snippet = result["helper_snippet"]
@@ -85,9 +94,11 @@ class TestViewAxes:
 # lint_drawing (session mode)
 # ---------------------------------------------------------------------------
 
+
 class TestLintDrawingSession:
     def _run(self, session):
         from build123d_mcp.tools.lint_drawing import lint_drawing
+
         return json.loads(lint_drawing(session))
 
     def test_empty_session_no_violations(self, session):
@@ -201,7 +212,9 @@ annotate(d, "dim")
 set_page(297, 210, margin=5)
 """)
         out = self._run(session)
-        bounds_violations = [v for v in out["violations"] if v["check"] == "annotation_out_of_bounds"]
+        bounds_violations = [
+            v for v in out["violations"] if v["check"] == "annotation_out_of_bounds"
+        ]
         assert bounds_violations == []
 
     def test_no_page_bounds_check_without_set_page(self, session):
@@ -214,7 +227,9 @@ d = Dimension((-10, 0, 0), (10, 0, 0), "above", 8, draft, label="20")
 annotate(d, "dim")
 """)
         out = self._run(session)
-        bounds_violations = [v for v in out["violations"] if v["check"] == "annotation_out_of_bounds"]
+        bounds_violations = [
+            v for v in out["violations"] if v["check"] == "annotation_out_of_bounds"
+        ]
         assert bounds_violations == []
 
     def test_set_page_resets_on_session_reset(self, session):
@@ -237,6 +252,7 @@ annotate(w, "scaled_dim")
 
     def _run_scaled(self, session, drawing_scale):
         from build123d_mcp.tools.lint_drawing import lint_drawing
+
         return json.loads(lint_drawing(session, drawing_scale=drawing_scale))
 
     def test_scaled_dim_with_real_label_is_clean(self, session):
@@ -263,16 +279,18 @@ annotate(w, "scaled_dim")
 # lint_drawing (SVG mode)
 # ---------------------------------------------------------------------------
 
+
 class TestLintDrawingSvg:
     def test_flags_native_text(self, tmp_path):
         # build123d never emits <text> (it renders glyph paths), so any <text>
         # means native SVG text that won't DXF-export — flagged regardless of fill.
         from build123d_mcp.tools.lint_drawing import lint_drawing
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
   <g id="dims" fill="none">
     <text id="bad_label" x="10" y="20">40</text>
   </g>
-</svg>'''
+</svg>"""
         p = tmp_path / "bad.svg"
         p.write_text(svg)
         out = json.loads(lint_drawing(None, str(p)))
@@ -281,11 +299,12 @@ class TestLintDrawingSvg:
     def test_clean_svg_no_violations(self, tmp_path):
         # A real build123d export uses <path> glyphs, not <text> — clean.
         from build123d_mcp.tools.lint_drawing import lint_drawing
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
   <g id="dims" fill="black">
     <path id="glyph" d="M10,10 L20,10 L20,20 Z"/>
   </g>
-</svg>'''
+</svg>"""
         p = tmp_path / "good.svg"
         p.write_text(svg)
         out = json.loads(lint_drawing(None, str(p)))
@@ -293,6 +312,7 @@ class TestLintDrawingSvg:
 
     def test_missing_file_returns_error(self, tmp_path):
         from build123d_mcp.tools.lint_drawing import lint_drawing
+
         out = json.loads(lint_drawing(None, str(tmp_path / "does_not_exist.svg")))
         assert any(v["check"] == "svg_parse" for v in out["violations"])
 
@@ -301,17 +321,19 @@ class TestLintDrawingSvg:
 # inspect_drawing(svg_path=...)
 # ---------------------------------------------------------------------------
 
+
 class TestInspectDrawingSvg:
     def test_reports_page_layers_text(self, tmp_path):
         from build123d_mcp.tools.inspect_drawing import inspect_drawing
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="297mm" height="210mm" viewBox="0 0 297 210">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="297mm" height="210mm" viewBox="0 0 297 210">
   <g id="part" fill="black">
     <path d="M10,10 L100,10"/>
   </g>
   <g id="dims" fill="blue">
     <text id="w_label" x="50" y="40">40</text>
   </g>
-</svg>'''
+</svg>"""
         p = tmp_path / "sheet.svg"
         p.write_text(svg)
         out = json.loads(inspect_drawing(None, "", str(p)))
@@ -328,6 +350,7 @@ class TestInspectDrawingSvg:
 
     def test_missing_file_returns_error(self, tmp_path):
         from build123d_mcp.tools.inspect_drawing import inspect_drawing
+
         out = json.loads(inspect_drawing(None, "", str(tmp_path / "missing.svg")))
         assert "error" in out
 
@@ -336,12 +359,14 @@ class TestInspectDrawingSvg:
 # render_drawing
 # ---------------------------------------------------------------------------
 
+
 class TestRenderDrawing:
     def test_rasterises_simple_svg(self, tmp_path):
         from build123d_mcp.tools.render_drawing import render_drawing
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="50mm" viewBox="0 0 100 50">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="50mm" viewBox="0 0 100 50">
   <rect x="10" y="10" width="80" height="30" fill="blue"/>
-</svg>'''
+</svg>"""
         p = tmp_path / "tile.svg"
         p.write_text(svg)
         result = render_drawing(str(p), width=400)
@@ -353,14 +378,16 @@ class TestRenderDrawing:
 
     def test_missing_file_error(self, tmp_path):
         from build123d_mcp.tools.render_drawing import render_drawing
+
         result = render_drawing(str(tmp_path / "missing.svg"))
         assert "error" in result
 
     def test_save_to_writes_file(self, tmp_path):
         from build123d_mcp.tools.render_drawing import render_drawing
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">
   <circle cx="25" cy="25" r="10" fill="red"/>
-</svg>'''
+</svg>"""
         src = tmp_path / "circle.svg"
         src.write_text(svg)
         out_path = tmp_path / "out.png"
@@ -376,9 +403,11 @@ class TestRenderDrawing:
 # End-to-end through WorkerSession — proves IPC routing for all four tools
 # ---------------------------------------------------------------------------
 
+
 class TestDrawingToolsViaWorker:
     def test_view_axes_through_worker(self):
         from build123d_mcp.worker import WorkerSession
+
         ws = WorkerSession(exec_timeout=30)
         try:
             result = json.loads(ws.view_axes((0, 0, 100), (0, 1, 0), (0, 0, 0)))
@@ -388,6 +417,7 @@ class TestDrawingToolsViaWorker:
 
     def test_lint_drawing_through_worker(self):
         from build123d_mcp.worker import WorkerSession
+
         ws = WorkerSession(exec_timeout=30)
         try:
             result = json.loads(ws.lint_drawing())
@@ -399,6 +429,7 @@ class TestDrawingToolsViaWorker:
         # #147: drawing_scale must survive the IPC round-trip (client -> dispatch
         # -> tool). A 20 mm dim labelled "10" is clean at 2:1, flagged at 1:1.
         from build123d_mcp.worker import WorkerSession
+
         ws = WorkerSession(exec_timeout=30)
         try:
             ws.execute(
@@ -417,9 +448,10 @@ class TestDrawingToolsViaWorker:
 
     def test_render_drawing_through_worker(self, tmp_path):
         from build123d_mcp.worker import WorkerSession
-        svg = '''<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">
+
+        svg = """<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">
   <rect x="5" y="5" width="40" height="40" fill="green"/>
-</svg>'''
+</svg>"""
         p = tmp_path / "g.svg"
         p.write_text(svg)
         ws = WorkerSession(exec_timeout=30)
@@ -435,39 +467,55 @@ class TestDrawingToolsViaWorker:
 # lint_drawing SVG mode — sidecar annotation checks (#118)
 # ---------------------------------------------------------------------------
 
+
 class TestLintDrawingSvgSidecar:
     def _write_svg(self, path):
         path.write_text('<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"/>')
 
     def test_sidecar_label_mismatch_flagged(self, tmp_path):
-        from build123d_mcp.tools.lint_drawing import lint_drawing
         import json as _json
+
+        from build123d_mcp.tools.lint_drawing import lint_drawing
+
         svg = tmp_path / "drawing.svg"
         self._write_svg(svg)
         sidecar = tmp_path / "drawing.dims.json"
         # 30 mm path labelled "99" — clear axis-swap mismatch
-        sidecar.write_text(_json.dumps({
-            "axis_swap_bug": {"type": "ExtensionLine", "label_str": "99", "measured_length": 30.0}
-        }))
+        sidecar.write_text(
+            _json.dumps(
+                {
+                    "axis_swap_bug": {
+                        "type": "ExtensionLine",
+                        "label_str": "99",
+                        "measured_length": 30.0,
+                    }
+                }
+            )
+        )
         out = json.loads(lint_drawing(None, str(svg)))
         assert any(v["check"] == "label_vs_measured" for v in out["violations"])
         assert any("99" in v["message"] for v in out["violations"])
 
     def test_sidecar_correct_label_no_violation(self, tmp_path):
-        from build123d_mcp.tools.lint_drawing import lint_drawing
         import json as _json
+
+        from build123d_mcp.tools.lint_drawing import lint_drawing
+
         svg = tmp_path / "drawing.svg"
         self._write_svg(svg)
         sidecar = tmp_path / "drawing.dims.json"
-        sidecar.write_text(_json.dumps({
-            "width": {"type": "ExtensionLine", "label_str": "20", "measured_length": 20.0}
-        }))
+        sidecar.write_text(
+            _json.dumps(
+                {"width": {"type": "ExtensionLine", "label_str": "20", "measured_length": 20.0}}
+            )
+        )
         out = json.loads(lint_drawing(None, str(svg)))
         label_violations = [v for v in out["violations"] if v["check"] == "label_vs_measured"]
         assert label_violations == []
 
     def test_no_sidecar_no_annotation_violations(self, tmp_path):
         from build123d_mcp.tools.lint_drawing import lint_drawing
+
         svg = tmp_path / "drawing.svg"
         self._write_svg(svg)
         out = json.loads(lint_drawing(None, str(svg)))

--- a/tests/test_failure_class.py
+++ b/tests/test_failure_class.py
@@ -1,5 +1,7 @@
 """Tests for failure_class classification in execute() error responses."""
+
 import json
+
 import pytest
 
 from build123d_mcp.session import Session

--- a/tests/test_inspect_drawing.py
+++ b/tests/test_inspect_drawing.py
@@ -1,5 +1,7 @@
 """Tests for inspect_drawing tool and annotate() session helper."""
+
 import json
+
 import pytest
 
 from build123d_mcp.session import Session
@@ -13,6 +15,7 @@ def session():
 # ---------------------------------------------------------------------------
 # annotate() helper
 # ---------------------------------------------------------------------------
+
 
 class TestAnnotate:
     def test_annotate_registers_shape(self, session):
@@ -140,8 +143,10 @@ draft = Draft(font_size=2.5, decimal_precision=1, arrow_length=1.0, line_width=0
 bad = ExtensionLine(border=[(-15, -30, 0), (15, -30, 0)], offset=-6, draft=draft, label="99")
 annotate(bad, "axis_swap_bug", label="99")
 """)
-        from build123d_mcp.tools.lint_drawing import lint_drawing
         import json
+
+        from build123d_mcp.tools.lint_drawing import lint_drawing
+
         out = json.loads(lint_drawing(session))
         assert any(v["check"] == "label_vs_measured" for v in out["violations"]), (
             "lint must flag 99 vs 30mm mismatch when label= is passed explicitly"
@@ -180,9 +185,11 @@ annotate(w, "width", label="WRONG")
 # inspect_drawing tool
 # ---------------------------------------------------------------------------
 
+
 class TestInspectDrawing:
     def _run(self, session, objects=""):
         from build123d_mcp.tools.inspect_drawing import inspect_drawing
+
         return json.loads(inspect_drawing(session, objects))
 
     def test_empty_session_returns_error(self, session):
@@ -295,6 +302,7 @@ annotate(w, "width")
 # uses WorkerSession, a parent-side IPC proxy whose state lives in a subprocess.
 # ---------------------------------------------------------------------------
 
+
 class TestInspectDrawingViaWorker:
     def test_inspect_drawing_through_worker(self):
         from build123d_mcp.worker import WorkerSession
@@ -322,6 +330,7 @@ annotate(w, "width")
 # ---------------------------------------------------------------------------
 # annotate() label auto-derivation (#115)
 # ---------------------------------------------------------------------------
+
 
 class TestAnnotateLabelFallback:
     def test_vanilla_extension_line_without_kwarg_has_no_label_str(self, session):
@@ -369,13 +378,16 @@ annotate(w, "width")
 # save_drawing_annotations / sidecar (#116)
 # ---------------------------------------------------------------------------
 
+
 class TestSaveDrawingAnnotations:
     def _run(self, session, objects=""):
         from build123d_mcp.tools.inspect_drawing import inspect_drawing
+
         return json.loads(inspect_drawing(session, objects))
 
     def test_save_writes_dims_json(self, session, tmp_path):
         from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
+
         session.execute("""
 from build123d import *
 from build123d import Draft
@@ -391,8 +403,9 @@ annotate(w, "width")
         assert "1 annotation" in result
 
     def test_sidecar_loaded_by_inspect_svg_mode(self, session, tmp_path):
-        from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
         from build123d_mcp.tools.inspect_drawing import _inspect_svg
+        from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
+
         session.execute("""
 from build123d import *
 from build123d import Draft
@@ -416,6 +429,7 @@ annotate(w, "width")
 
     def test_no_sidecar_gives_guidance_note(self, tmp_path):
         from build123d_mcp.tools.inspect_drawing import _inspect_svg
+
         svg_path = tmp_path / "bare.svg"
         svg_path.write_text('<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"/>')
         result = json.loads(_inspect_svg(str(svg_path)))

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -3,19 +3,19 @@
 from pathlib import Path
 
 from build123d_mcp.tools.install_skill import (
-    TARGETS,
     _END,
     _START,
+    TARGETS,
     _dest_exists,
     _load_raw,
     _strip_claude_markers,
     install_skill,
 )
 
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
@@ -24,6 +24,7 @@ def _read(path: Path) -> str:
 # ---------------------------------------------------------------------------
 # _load_raw
 # ---------------------------------------------------------------------------
+
 
 def test_load_raw_returns_skill_content():
     content = _load_raw()
@@ -34,6 +35,7 @@ def test_load_raw_returns_skill_content():
 # ---------------------------------------------------------------------------
 # _strip_claude_markers
 # ---------------------------------------------------------------------------
+
 
 def test_strip_send_marker():
     out = _strip_claude_markers("See [SEND: /tmp/foo.png] for the result.")
@@ -57,6 +59,7 @@ def test_strip_ask_marker_no_options():
 # ---------------------------------------------------------------------------
 # target: claude
 # ---------------------------------------------------------------------------
+
 
 def test_install_claude(tmp_path):
     result = install_skill(target="claude", cwd=tmp_path)
@@ -89,6 +92,7 @@ def test_install_claude_preserves_claude_markers(tmp_path):
 # ---------------------------------------------------------------------------
 # target: agents-md
 # ---------------------------------------------------------------------------
+
 
 def test_install_agents_md_creates_file(tmp_path):
     result = install_skill(target="agents-md", cwd=tmp_path)
@@ -133,6 +137,7 @@ def test_install_agents_md_force_replaces_section(tmp_path):
 # target: cursor
 # ---------------------------------------------------------------------------
 
+
 def test_install_cursor_creates_mdc(tmp_path):
     result = install_skill(target="cursor", cwd=tmp_path)
     dest = tmp_path / ".cursor" / "rules" / "b123d-drawing.mdc"
@@ -164,6 +169,7 @@ def test_install_cursor_force(tmp_path):
 # target: windsurf
 # ---------------------------------------------------------------------------
 
+
 def test_install_windsurf_creates_file(tmp_path):
     result = install_skill(target="windsurf", cwd=tmp_path)
     dest = tmp_path / ".windsurfrules"
@@ -194,6 +200,7 @@ def test_install_windsurf_force_replaces_section(tmp_path):
 # _dest_exists
 # ---------------------------------------------------------------------------
 
+
 def test_dest_exists_false_before_install(tmp_path):
     for target in TARGETS:
         assert not _dest_exists(target, cwd=tmp_path)
@@ -212,6 +219,7 @@ def test_dest_exists_unknown_target():
 # ---------------------------------------------------------------------------
 # unknown target
 # ---------------------------------------------------------------------------
+
 
 def test_unknown_target_returns_error():
     result = install_skill(target="unknown-agent")

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,6 +1,4 @@
 import json
-import os
-import time
 
 import pytest
 
@@ -77,6 +75,7 @@ def session():
 
 # --- scanning ---
 
+
 def test_scan_finds_root_parts(index):
     index.ensure_fresh()
     assert "box" in index._index
@@ -116,6 +115,7 @@ def test_scan_part_without_part_info(index):
 
 # --- mtime invalidation ---
 
+
 def test_mtime_triggers_rescan(tmp_path):
     (tmp_path / "box.py").write_text(PART_BOX)
     idx = _LibraryIndex(str(tmp_path))
@@ -139,6 +139,7 @@ def test_no_rescan_when_nothing_changed(tmp_path):
 
 
 # --- search ---
+
 
 def test_search_empty_returns_all(index):
     results = index.search("")
@@ -196,8 +197,9 @@ def test_search_library_returns_json(index):
 
 # --- load_part ---
 
+
 def test_load_part_default_params(session, index):
-    result = load_part(session, index, "box")
+    load_part(session, index, "box")
     assert "box" in session.objects
     assert abs(session.objects["box"].volume - 500.0) < 1.0  # 10*10*5
 
@@ -221,7 +223,7 @@ def test_load_part_returns_feedback(session, index):
 
 
 def test_load_part_bare_no_params(session, index):
-    result = load_part(session, index, "hardware/bare")
+    load_part(session, index, "hardware/bare")
     assert "hardware/bare" in session.objects
     assert abs(session.objects["hardware/bare"].volume - 8.0) < 0.1  # 2*2*2
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -2,6 +2,7 @@
 Outcome-focused tests: verify what the server actually produces,
 not just that functions return without error.
 """
+
 import asyncio
 import base64
 import json
@@ -31,6 +32,7 @@ def session():
 # ---------------------------------------------------------------------------
 # Multi-step workflow: does state build up correctly across execute calls?
 # ---------------------------------------------------------------------------
+
 
 def test_incremental_construction_extends_geometry(session):
     """Second execute can reference and extend geometry from the first."""
@@ -125,6 +127,7 @@ def test_error_in_execute_preserves_current_shape(session):
 # Security: injection resistance
 # ---------------------------------------------------------------------------
 
+
 def test_shell_injection_attempt_blocked(session):
     """A prompt-injection payload trying to run a shell command is rejected."""
     execute_code(session, "result = Box(10, 10, 10)")
@@ -157,7 +160,9 @@ def test_normal_workflow_unaffected_by_security(session):
 
 def test_dunder_name_allowed(session):
     """type(x).__name__ is a common debugging pattern and must be allowed."""
-    result = execute_code(session, "from build123d import Box\nb = Box(1,1,1)\nname = type(b).__name__")
+    result = execute_code(
+        session, "from build123d import Box\nb = Box(1,1,1)\nname = type(b).__name__"
+    )
     assert "Error" not in result
     assert session.namespace.get("name") == "Box"
 
@@ -193,6 +198,7 @@ def test_builtins_import_restriction_independent_of_ast(session):
 # ---------------------------------------------------------------------------
 # Session snapshots
 # ---------------------------------------------------------------------------
+
 
 def test_snapshot_restores_geometry_after_bad_experiment(session):
     """save_snapshot / restore_snapshot recovers known-good geometry."""
@@ -237,6 +243,7 @@ def test_namespace_not_restored_by_snapshot(session):
 # ---------------------------------------------------------------------------
 # Multi-object session: show(), per-object measure/export/render
 # ---------------------------------------------------------------------------
+
 
 def test_named_objects_have_independent_bounding_boxes(session):
     """show() isolates shapes: each named object reports its own dimensions."""
@@ -317,6 +324,7 @@ def test_reset_clears_show_registry(session):
 # Richer measurements
 # ---------------------------------------------------------------------------
 
+
 def test_volume_detects_missing_boolean(session):
     """volume() exposes the difference between a solid and a hollowed part."""
     execute_code(session, "show(Box(20, 20, 20), 'full')")
@@ -339,9 +347,10 @@ def test_area_increases_after_adding_surface(session):
 def test_clearance_between_assembly_parts(session):
     """Clearance between two registered bodies."""
     from build123d_mcp.tools.measure import clearance as _clearance
-    execute_code(session,
-        "show(Cylinder(4, 30), 'shaft')\n"
-        "show(Box(30, 30, 30) - Cylinder(5, 32), 'bore_housing')"
+
+    execute_code(
+        session,
+        "show(Cylinder(4, 30), 'shaft')\nshow(Box(30, 30, 30) - Cylinder(5, 32), 'bore_housing')",
     )
     data = json.loads(_clearance(session, "shaft", "bore_housing"))
     # shaft radius 4, bore radius 5 — clearance should be ~1mm
@@ -352,9 +361,9 @@ def test_clearance_between_assembly_parts(session):
 def test_clearance_zero_for_touching_shapes(session):
     """Touching shapes report zero clearance."""
     from build123d_mcp.tools.measure import clearance as _clearance
-    execute_code(session,
-        "show(Box(10, 10, 10), 'a')\n"
-        "show(Box(10, 10, 10).move(Location((10, 0, 0))), 'b')"
+
+    execute_code(
+        session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((10, 0, 0))), 'b')"
     )
     data = json.loads(_clearance(session, "a", "b"))
     assert data["clearance"] < 0.01
@@ -363,6 +372,7 @@ def test_clearance_zero_for_touching_shapes(session):
 # ---------------------------------------------------------------------------
 # measure(summary)
 # ---------------------------------------------------------------------------
+
 
 def test_measure_returns_all_fields(session):
     """measure() returns bbox, volume, area, topology, center_of_mass, inertia, face_inventory."""
@@ -382,10 +392,12 @@ def test_measure_returns_all_fields(session):
 # last_error()
 # ---------------------------------------------------------------------------
 
+
 def test_last_error_captures_type_message_and_line(session):
     """After a failed execute(), last_error() returns the exception type, message,
     and the 1-based line number within the submitted code."""
     from build123d_mcp.tools.last_error import last_error as get_last_error
+
     session.execute("x = 1\ny = 2\nraise ValueError('boom')\nz = 3")
     data = json.loads(get_last_error(session))
     assert data["type"] == "ValueError"
@@ -398,6 +410,7 @@ def test_last_error_captures_type_message_and_line(session):
 def test_last_error_cleared_after_success(session):
     """A successful execute() clears last_error."""
     from build123d_mcp.tools.last_error import last_error as get_last_error
+
     session.execute("raise RuntimeError('oops')")
     assert json.loads(get_last_error(session))["type"] == "RuntimeError"
     session.execute("result = Box(5, 5, 5)")
@@ -407,6 +420,7 @@ def test_last_error_cleared_after_success(session):
 def test_last_error_null_before_any_failure(session):
     """last_error() returns {error: null} when no execute() has failed."""
     from build123d_mcp.tools.last_error import last_error as get_last_error
+
     session.execute("result = Box(1, 1, 1)")
     assert json.loads(get_last_error(session))["error"] is None
 
@@ -415,14 +429,12 @@ def test_last_error_null_before_any_failure(session):
 # session_state() namespace variables
 # ---------------------------------------------------------------------------
 
+
 def test_session_state_includes_namespace_variables(session):
     """session_state() variables key summarises Python namespace: scalars, lists, Shapes."""
     from build123d_mcp.tools.session_state import session_state as get_state
-    execute_code(session,
-        "width = 40.0\n"
-        "tags = ['a', 'b', 'c']\n"
-        "result = Box(width, 10, 10)"
-    )
+
+    execute_code(session, "width = 40.0\ntags = ['a', 'b', 'c']\nresult = Box(width, 10, 10)")
     data = json.loads(get_state(session))
     assert "variables" in data
     vs = data["variables"]
@@ -436,9 +448,11 @@ def test_session_state_includes_namespace_variables(session):
 # validate_code()
 # ---------------------------------------------------------------------------
 
+
 def test_validate_code_clean_script_is_ok():
     """Well-formed build123d code returns ok=True with no blocked items."""
     from build123d_mcp.tools.validate_code import validate_code
+
     result = json.loads(validate_code("from build123d import *\nresult = Box(10, 10, 10)"))
     assert result["ok"] is True
     assert result["syntax"] == "ok"
@@ -448,6 +462,7 @@ def test_validate_code_clean_script_is_ok():
 def test_validate_code_catches_syntax_error():
     """A syntax error is reported and ok=False."""
     from build123d_mcp.tools.validate_code import validate_code
+
     result = json.loads(validate_code("def foo(\n  pass"))
     assert result["ok"] is False
     assert "SyntaxError" in result["syntax"]
@@ -456,6 +471,7 @@ def test_validate_code_catches_syntax_error():
 def test_validate_code_catches_blocked_import():
     """Importing os is flagged as blocked."""
     from build123d_mcp.tools.validate_code import validate_code
+
     result = json.loads(validate_code("import os\nresult = Box(10,10,10)"))
     assert result["ok"] is False
     assert any("os" in b for b in result["blocked"])
@@ -464,6 +480,7 @@ def test_validate_code_catches_blocked_import():
 def test_validate_code_warns_no_output():
     """Code with no result assignment or show() call gets a warning."""
     from build123d_mcp.tools.validate_code import validate_code
+
     result = json.loads(validate_code("from build123d import *\nx = 1 + 2"))
     assert result["ok"] is True  # not blocked, just a warning
     assert any("result" in w or "show" in w for w in result["warnings"])
@@ -473,9 +490,11 @@ def test_validate_code_warns_no_output():
 # shape_compare()
 # ---------------------------------------------------------------------------
 
+
 def test_shape_compare_reports_volume_delta(session):
     """shape_compare() reports the correct volume difference between two named shapes."""
     from build123d_mcp.tools.shape_compare import shape_compare
+
     execute_code(session, "show(Box(10, 10, 10), 'small')\nshow(Box(20, 20, 20), 'large')")
     data = json.loads(shape_compare(session, "small", "large"))
     assert abs(data["a"]["volume"] - 1000) < 1
@@ -486,6 +505,7 @@ def test_shape_compare_reports_volume_delta(session):
 def test_shape_compare_identical_shapes_zero_delta(session):
     """Comparing two identical shapes gives zero volume delta and zero center offset."""
     from build123d_mcp.tools.shape_compare import shape_compare
+
     execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10), 'b')")
     data = json.loads(shape_compare(session, "a", "b"))
     assert abs(data["delta"]["volume"]) < 0.001
@@ -496,9 +516,11 @@ def test_shape_compare_identical_shapes_zero_delta(session):
 # repair_hints()
 # ---------------------------------------------------------------------------
 
+
 def test_repair_hints_matches_nonetype_error():
     """NoneType attribute error gets the .part hint."""
     from build123d_mcp.tools.repair_hints import repair_hints
+
     result = json.loads(repair_hints("AttributeError: 'NoneType' has no attribute 'volume'"))
     assert any(".part" in h or "None" in h for h in result["hints"])
 
@@ -506,6 +528,7 @@ def test_repair_hints_matches_nonetype_error():
 def test_repair_hints_matches_cq_idiom():
     """CadQuery-style error text gets the API mismatch hint."""
     from build123d_mcp.tools.repair_hints import repair_hints
+
     result = json.loads(repair_hints("NameError: cq is not defined"))
     assert any("CadQuery" in h or "build123d" in h for h in result["hints"])
 
@@ -513,6 +536,7 @@ def test_repair_hints_matches_cq_idiom():
 def test_repair_hints_fallback_for_unknown_error():
     """Unrecognised error text returns the generic fallback hint."""
     from build123d_mcp.tools.repair_hints import repair_hints
+
     result = json.loads(repair_hints("some totally unknown error xyz"))
     assert len(result["hints"]) == 1
     assert "last_error" in result["hints"][0]
@@ -521,6 +545,7 @@ def test_repair_hints_fallback_for_unknown_error():
 # ---------------------------------------------------------------------------
 # Rendering quality and clip plane
 # ---------------------------------------------------------------------------
+
 
 def test_high_quality_render_differs_from_standard(session):
     """High quality tessellation produces a different image than standard."""
@@ -578,14 +603,39 @@ def test_mcp_lists_all_tools():
         return {t.name for t in result.tools}
 
     names = asyncio.run(_mcp_session(run))
-    assert names == {"execute", "render_view", "measure", "export", "reset",
-                     "save_snapshot", "restore_snapshot", "diff_snapshot", "interference",
-                     "search_library", "load_part", "workflow_hints", "session_state", "health_check",
-                     "version", "last_error", "shape_compare", "repair_hints",
-                     "import_cad_file", "cross_sections", "clearance", "inspect_drawing",
-                     "view_axes", "lint_drawing", "render_drawing", "save_drawing_annotations",
-                     "align_check", "resolve", "script", "install_skill",
-                     "suggest_view_layout"}
+    assert names == {
+        "execute",
+        "render_view",
+        "measure",
+        "export",
+        "reset",
+        "save_snapshot",
+        "restore_snapshot",
+        "diff_snapshot",
+        "interference",
+        "search_library",
+        "load_part",
+        "workflow_hints",
+        "session_state",
+        "health_check",
+        "version",
+        "last_error",
+        "shape_compare",
+        "repair_hints",
+        "import_cad_file",
+        "cross_sections",
+        "clearance",
+        "inspect_drawing",
+        "view_axes",
+        "lint_drawing",
+        "render_drawing",
+        "save_drawing_annotations",
+        "align_check",
+        "resolve",
+        "script",
+        "install_skill",
+        "suggest_view_layout",
+    }
 
 
 @_skip_mcp_on_win
@@ -620,7 +670,6 @@ def test_mcp_render_returns_image_and_file_path():
     # ImageContent with base64 PNG
     assert img_type == "image"
     assert mime == "image/png"
-    import base64
     png_bytes = base64.b64decode(img_data)
     assert png_bytes[:8] == PNG_MAGIC
     # TextContent with file path for [SEND:] delivery
@@ -652,6 +701,7 @@ def test_mcp_reset_clears_state():
 def test_mcp_injection_attempt_returns_error_not_executes():
     """A shell-injection payload through the MCP wire returns an error and does
     not produce side-effects (geometry is still None at the start of the session)."""
+
     async def run(mcp):
         result = await mcp.call_tool(
             "execute",
@@ -666,8 +716,11 @@ def test_mcp_injection_attempt_returns_error_not_executes():
 @_skip_mcp_on_win
 def test_mcp_snapshot_save_and_restore():
     """save_snapshot / restore_snapshot round-trip through the MCP wire restores geometry."""
+
     async def run(mcp):
-        await mcp.call_tool("execute", {"code": "from build123d import *\nresult = Box(10, 10, 10)"})
+        await mcp.call_tool(
+            "execute", {"code": "from build123d import *\nresult = Box(10, 10, 10)"}
+        )
         await mcp.call_tool("save_snapshot", {"name": "v1"})
         await mcp.call_tool("execute", {"code": "result = Box(99, 99, 99)"})
         await mcp.call_tool("restore_snapshot", {"name": "v1"})
@@ -681,8 +734,11 @@ def test_mcp_snapshot_save_and_restore():
 @_skip_mcp_on_win
 def test_mcp_multi_format_export(tmp_path):
     """export with format='step,stl' reports both paths over the MCP wire."""
+
     async def run(mcp):
-        await mcp.call_tool("execute", {"code": "from build123d import *\nresult = Box(10, 10, 10)"})
+        await mcp.call_tool(
+            "execute", {"code": "from build123d import *\nresult = Box(10, 10, 10)"}
+        )
         result = await mcp.call_tool("export", {"filename": "mcp_test_out", "format": "step,stl"})
         return result.content[0].text
 
@@ -694,12 +750,18 @@ def test_mcp_multi_format_export(tmp_path):
 @_skip_mcp_on_win
 def test_mcp_volume_and_clearance():
     """volume and clearance round-trip through the MCP wire."""
+
     async def run(mcp):
-        await mcp.call_tool("execute", {"code": (
-            "from build123d import *\n"
-            "show(Box(10, 10, 10), 'a')\n"
-            "show(Box(10, 10, 10).move(Location((15, 0, 0))), 'b')"
-        )})
+        await mcp.call_tool(
+            "execute",
+            {
+                "code": (
+                    "from build123d import *\n"
+                    "show(Box(10, 10, 10), 'a')\n"
+                    "show(Box(10, 10, 10).move(Location((15, 0, 0))), 'b')"
+                )
+            },
+        )
         r_vol = await mcp.call_tool("measure", {"object_name": "a"})
         r_cl = await mcp.call_tool("clearance", {"object_a": "a", "object_b": "b"})
         return r_vol.content[0].text, r_cl.content[0].text
@@ -712,10 +774,13 @@ def test_mcp_volume_and_clearance():
 @_skip_mcp_on_win
 def test_mcp_show_and_measure_named_object():
     """show() + per-object measure round-trip through the MCP wire."""
+
     async def run(mcp):
         await mcp.call_tool(
             "execute",
-            {"code": "from build123d import *\nshow(Box(40, 5, 5), 'wide')\nshow(Box(5, 5, 40), 'tall')"},
+            {
+                "code": "from build123d import *\nshow(Box(40, 5, 5), 'wide')\nshow(Box(5, 5, 40), 'tall')"
+            },
         )
         r_wide = await mcp.call_tool("measure", {"object_name": "wide"})
         r_tall = await mcp.call_tool("measure", {"object_name": "tall"})

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,6 +3,7 @@
 These tests guard against changes that would break installation or runtime
 behaviour for end users without surfacing in the in-process tests.
 """
+
 from importlib.metadata import requires
 
 
@@ -19,7 +20,11 @@ def test_build123d_drafting_helpers_is_runtime_dependency():
     deps = requires("build123d-mcp") or []
     # Each entry is a PEP 508 requirement string. Match by leading name segment
     # so version markers and extras don't break this.
-    runtime_deps = {req.split()[0].split(";")[0].split(">")[0].split("<")[0].split("=")[0].split("[")[0].strip() for req in deps if "extra ==" not in req}
+    runtime_deps = {
+        req.split()[0].split(";")[0].split(">")[0].split("<")[0].split("=")[0].split("[")[0].strip()
+        for req in deps
+        if "extra ==" not in req
+    }
     assert "build123d-drafting-helpers" in runtime_deps, (
         f"build123d-drafting-helpers must be in runtime dependencies "
         f"(issue #106). Got: {sorted(runtime_deps)}"

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -11,6 +11,7 @@ inspect_drawing(svg_path=...), and lint_drawing(svg_path=...) (plus their
 tests assert ``safe_input_path`` rejects traversal, outside-root, and
 symlink-escape paths, with a happy-path read from a temp root.
 """
+
 import json
 import os
 import sys
@@ -26,9 +27,7 @@ from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotation
 from build123d_mcp.tools.script import script
 
 _OUTSIDE_ROOT_PATH = (
-    r"C:\Windows\System32\drivers\etc\hosts"
-    if sys.platform == "win32"
-    else "/etc/passwd"
+    r"C:\Windows\System32\drivers\etc\hosts" if sys.platform == "win32" else "/etc/passwd"
 )
 _TRAVERSAL = "../../etc/passwd"
 _VALID_SVG = (
@@ -44,6 +43,7 @@ def session():
 
 
 # --- script(save_to=...) ---------------------------------------------------
+
 
 def test_script_save_to_path_traversal_rejected(session):
     session.execute("from build123d import *\nresult = Box(5, 5, 5)")
@@ -66,6 +66,7 @@ def test_script_save_to_tmp_allowed(session, tmp_path):
 
 
 # --- render_drawing(save_to=...) -------------------------------------------
+
 
 def test_render_drawing_save_to_path_traversal_rejected(tmp_path):
     svg = tmp_path / "in.svg"
@@ -91,6 +92,7 @@ def test_render_drawing_save_to_tmp_allowed(tmp_path):
 
 
 # --- save_drawing_annotations(svg_path -> sidecar) -------------------------
+
 
 def test_save_drawing_annotations_path_traversal_rejected(session):
     with pytest.raises(ValueError, match="outside the allowed write roots"):
@@ -129,6 +131,7 @@ def _write_valid_svg(tmp_path) -> str:
 
 # --- import_cad_file(path=...) ---------------------------------------------
 
+
 def test_import_cad_file_path_traversal_rejected(session):
     with pytest.raises(ValueError, match=_READ_REJECT):
         import_cad_file(session, _TRAVERSAL + ".step")
@@ -163,6 +166,7 @@ def test_import_cad_file_tmp_allowed(session, tmp_path):
 
 # --- render_drawing(svg_path=...) ------------------------------------------
 
+
 def test_render_drawing_svg_path_traversal_rejected():
     with pytest.raises(ValueError, match=_READ_REJECT):
         render_drawing(_TRAVERSAL + ".svg")
@@ -181,6 +185,7 @@ def test_render_drawing_svg_path_tmp_allowed(tmp_path):
 
 # --- inspect_drawing(svg_path=...) -----------------------------------------
 
+
 def test_inspect_drawing_svg_path_traversal_rejected(session):
     with pytest.raises(ValueError, match=_READ_REJECT):
         inspect_drawing(session, svg_path=_TRAVERSAL + ".svg")
@@ -197,6 +202,7 @@ def test_inspect_drawing_svg_path_tmp_allowed(session, tmp_path):
 
 
 # --- lint_drawing(svg_path=...) --------------------------------------------
+
 
 def test_lint_drawing_svg_path_traversal_rejected(session):
     with pytest.raises(ValueError, match=_READ_REJECT):

--- a/tests/test_presentation_cookbook.py
+++ b/tests/test_presentation_cookbook.py
@@ -1,4 +1,5 @@
 """Verify every runnable presentation cookbook example executes and produces a shape."""
+
 import pytest
 
 from build123d_mcp.presentation_cookbook import (
@@ -21,12 +22,11 @@ def fresh_session():
 def test_presentation_cookbook_example_runs(fresh_session, label, code):
     result = fresh_session.execute(code)
     assert not result.startswith("Error:"), f"Example '{label}' failed:\n{result}"
-    assert fresh_session.current_shape is not None, (
-        f"Example '{label}' produced no shape"
-    )
+    assert fresh_session.current_shape is not None, f"Example '{label}' produced no shape"
 
 
 def test_presentation_cookbook_resource_uses_generated_text():
     """Confirm the MCP resource returns exactly what build_presentation_cookbook_text() produces."""
     from build123d_mcp.server import build123d_presentation_cookbook
+
     assert build123d_presentation_cookbook() == build_presentation_cookbook_text()

--- a/tests/test_quickref.py
+++ b/tests/test_quickref.py
@@ -1,4 +1,5 @@
 """Verify every runnable quickref example executes without error and produces a shape."""
+
 import pytest
 
 from build123d_mcp.quickref import RUNNABLE_EXAMPLES, build_quickref_text
@@ -18,12 +19,11 @@ def fresh_session():
 def test_quickref_example_runs(fresh_session, label, code):
     result = fresh_session.execute(code)
     assert not result.startswith("Error:"), f"Example '{label}' failed:\n{result}"
-    assert fresh_session.current_shape is not None, (
-        f"Example '{label}' produced no shape"
-    )
+    assert fresh_session.current_shape is not None, f"Example '{label}' produced no shape"
 
 
 def test_quickref_resource_uses_generated_text():
     """Confirm the MCP resource returns exactly what build_quickref_text() produces."""
     from build123d_mcp.server import build123d_quickref
+
     assert build123d_quickref() == build_quickref_text()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,5 +1,7 @@
 """Tests for the resolve() tool."""
+
 import json
+
 import pytest
 
 from build123d_mcp.session import Session
@@ -82,9 +84,7 @@ def test_dunder_traversal_rejected(box_session):
 
 def test_subclasses_escape_rejected(box_session):
     """The classic __subclasses__() escape chain is blocked (issue #186)."""
-    result = json.loads(
-        resolve(box_session, "box", ".__class__.__base__.__subclasses__()")
-    )
+    result = json.loads(resolve(box_session, "box", ".__class__.__base__.__subclasses__()"))
     assert "error" in result
     assert "type" not in result
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,7 +1,9 @@
 """Tests for the script() tool."""
+
 import json
 import os
 import tempfile
+
 import pytest
 
 from build123d_mcp.session import Session
@@ -69,7 +71,7 @@ def test_save_to_writes_file(session):
         assert "script_path" in result
         assert result["blocks"] == 2
         assert os.path.exists(path)
-        with open(path, "r") as f:
+        with open(path) as f:
             content = f.read()
         assert "Box(5, 5, 5)" in content
     finally:

--- a/tests/test_selectors_cookbook.py
+++ b/tests/test_selectors_cookbook.py
@@ -1,4 +1,5 @@
 """Verify every runnable selectors cookbook example executes and produces a shape."""
+
 import pytest
 
 from build123d_mcp.selectors_cookbook import RUNNABLE_EXAMPLES, build_selectors_cookbook_text
@@ -18,12 +19,11 @@ def fresh_session():
 def test_selectors_cookbook_example_runs(fresh_session, label, code):
     result = fresh_session.execute(code)
     assert not result.startswith("Error:"), f"Example '{label}' failed:\n{result}"
-    assert fresh_session.current_shape is not None, (
-        f"Example '{label}' produced no shape"
-    )
+    assert fresh_session.current_shape is not None, f"Example '{label}' produced no shape"
 
 
 def test_selectors_cookbook_resource_uses_generated_text():
     """Confirm the MCP resource returns exactly what build_selectors_cookbook_text() produces."""
     from build123d_mcp.server import build123d_selectors_cookbook
+
     assert build123d_selectors_cookbook() == build_selectors_cookbook_text()

--- a/tests/test_session_resource.py
+++ b/tests/test_session_resource.py
@@ -4,6 +4,7 @@ The resource dispatches through the production session proxy, so it is
 exercised against a real WorkerSession — the object server.py uses in
 production — rather than an in-process Session (issue #179).
 """
+
 import json
 
 import pytest
@@ -15,6 +16,7 @@ from build123d_mcp.worker import WorkerSession
 def patched_server(monkeypatch):
     """Return the server module with _session set to a real WorkerSession."""
     import build123d_mcp.server as srv
+
     s = WorkerSession(exec_timeout=30)
     monkeypatch.setattr(srv, "_session", s, raising=False)
     try:

--- a/tests/test_suggest_view_layout.py
+++ b/tests/test_suggest_view_layout.py
@@ -1,7 +1,9 @@
 """Tests for the suggest_view_layout tool."""
 
 import json
+
 import pytest
+
 from build123d_mcp.session import Session
 from build123d_mcp.tools.suggest_view_layout import suggest_view_layout
 
@@ -21,6 +23,7 @@ def session_with_named_box():
 
 
 # --- basic structure ---
+
 
 def test_returns_valid_json(session_with_box):
     r = json.loads(suggest_view_layout(session_with_box, "shape"))
@@ -64,10 +67,12 @@ def test_unknown_view_returns_error(session_with_box):
 
 # --- layout geometry ---
 
+
 def test_front_view_above_title_block(session_with_box):
     margin, tb_h = 10.0, 30.0
-    r = json.loads(suggest_view_layout(session_with_box, "shape",
-                                       margin=margin, title_block_h=tb_h))
+    r = json.loads(
+        suggest_view_layout(session_with_box, "shape", margin=margin, title_block_h=tb_h)
+    )
     fv = r["views"]["front"]
     assert fv["VIEW_Y"] - fv["half_h"] > margin + tb_h
 
@@ -106,6 +111,7 @@ def test_subset_views(session_with_box):
 
 # --- fit checking and suggestions ---
 
+
 def test_no_warnings_for_small_part_a4(session_with_box):
     r = json.loads(suggest_view_layout(session_with_box, "shape", scale=1.0))
     assert r["warnings"] == []
@@ -129,6 +135,7 @@ def test_suggestion_scale_smaller_than_requested(session_with_box):
 
 
 # --- look_at ---
+
 
 def test_iso_look_at_unscaled(session_with_box):
     """Iso view uses unscaled world centroid as look_at."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,13 +5,13 @@ import sys
 import pytest
 
 from build123d_mcp.session import Session
+from build123d_mcp.tools.diff import diff_snapshot
 from build123d_mcp.tools.execute import execute_code
 from build123d_mcp.tools.export import export_file
-from build123d_mcp.tools.interference import interference
-from build123d_mcp.tools.measure import measure
-from build123d_mcp.tools.diff import diff_snapshot
 from build123d_mcp.tools.health_check import health_check
+from build123d_mcp.tools.interference import interference
 from build123d_mcp.tools.list_objects import list_objects
+from build123d_mcp.tools.measure import measure
 from build123d_mcp.tools.render import render_view
 from build123d_mcp.tools.session_state import session_state
 
@@ -19,9 +19,7 @@ from build123d_mcp.tools.session_state import session_state
 # on each platform. /etc/passwd on POSIX; on Windows we use the system hosts file,
 # which is always present and lives under C:\Windows so realpath stays under C:\Windows.
 _OUTSIDE_ROOT_PATH = (
-    r"C:\Windows\System32\drivers\etc\hosts"
-    if sys.platform == "win32"
-    else "/etc/passwd"
+    r"C:\Windows\System32\drivers\etc\hosts" if sys.platform == "win32" else "/etc/passwd"
 )
 
 
@@ -41,6 +39,7 @@ def fast_session():
 
 
 # --- execute ---
+
 
 def test_execute_persists_state(session):
     execute_code(session, "x = 42")
@@ -71,6 +70,7 @@ def test_execute_success_has_no_hint(session):
 
 
 # --- var summary ---
+
 
 def test_execute_var_summary_shows_new_scalar(session):
     result = execute_code(session, "FV_Y = 35.0")
@@ -144,6 +144,7 @@ def test_execute_detects_buildpart(session):
 
 # --- execute() diagnostics: deltas + anomaly warnings ---
 
+
 def test_execute_first_shape_shows_absolutes_no_warnings(session):
     """First shape ever: no previous to diff against, so no delta and no warnings."""
     out = execute_code(session, "result = Box(10, 10, 5)")
@@ -161,7 +162,7 @@ def test_execute_real_cut_shows_deltas(session):
     # Volume dropped, faces increased — delta markers should appear
     assert "(-" in out  # volume decreased
     assert "(+" in out  # faces increased
-    assert "%" in out   # percentage delta on volume
+    assert "%" in out  # percentage delta on volume
     assert "Warning:" not in out
 
 
@@ -208,6 +209,7 @@ def test_execute_no_warnings_when_shape_unchanged(session):
 
 
 # --- security ---
+
 
 def test_show_objects_persist_across_execute_calls(session):
     """Objects registered with show() in one execute call are accessible in later calls."""
@@ -266,11 +268,13 @@ def test_open_removed_from_builtins(session):
 
 # --- --allow-imports flag (granular allowlist extension) ---
 
+
 def test_extra_allowed_import_permits_specified_module(monkeypatch):
     """Modules added via --allow-imports become importable (using a stdlib
     module that's normally blocked, so the test doesn't depend on optional
     third-party packages being installed)."""
     import build123d_mcp.security as _sec
+
     monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
     _sec.EXTRA_ALLOWED_IMPORTS.add("os")
     s = Session()
@@ -283,6 +287,7 @@ def test_extra_allowed_import_permits_submodules(monkeypatch):
     """Allowing a root module also permits its submodules (e.g. allowing
     'os' lets 'os.path' through)."""
     import build123d_mcp.security as _sec
+
     monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
     _sec.EXTRA_ALLOWED_IMPORTS.add("os")
     s = Session()
@@ -294,6 +299,7 @@ def test_extra_allowed_import_permits_submodules(monkeypatch):
 def test_unspecified_module_still_blocked_when_extras_used(monkeypatch):
     """Adding 'foo' to extras must NOT allow 'bar'."""
     import build123d_mcp.security as _sec
+
     monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
     _sec.EXTRA_ALLOWED_IMPORTS.add("os")
     s = Session()
@@ -305,6 +311,7 @@ def test_extras_message_lists_added_modules(monkeypatch):
     """Error message for blocked imports should include user-added extras
     in the 'Permitted' list so the LLM sees the current state."""
     import build123d_mcp.security as _sec
+
     monkeypatch.setattr(_sec, "EXTRA_ALLOWED_IMPORTS", set(_sec.EXTRA_ALLOWED_IMPORTS))
     _sec.EXTRA_ALLOWED_IMPORTS.add("os")
     s = Session()
@@ -332,8 +339,7 @@ def test_pythonpath_package_importable_when_allowlisted(monkeypatch, tmp_path):
 
     s = Session()
     result = s.execute(
-        "from my_test_parts import VALUE\n"
-        "assert VALUE == 42, f'expected 42, got {VALUE}'"
+        "from my_test_parts import VALUE\nassert VALUE == 42, f'expected 42, got {VALUE}'"
     )
     assert "Error" not in result, f"PYTHONPATH package import failed: {result}"
     assert "not allowed" not in result.lower()
@@ -353,6 +359,7 @@ def test_runtime_blocked_import_message_mentions_allow_imports():
     """The Layer-2 _safe_import error message should also mention --allow-imports.
     Exercises _safe_import directly, bypassing the AST check (Layer 1)."""
     from build123d_mcp.security import make_restricted_builtins
+
     builtins = make_restricted_builtins()
     safe_import = builtins["__import__"]
     with pytest.raises(ImportError, match="--allow-imports|BUILD123D_ALLOW_IMPORTS"):
@@ -376,7 +383,9 @@ def test_inspect_import_allowed(session):
 
 
 def test_inspect_signature_works(session):
-    result = execute_code(session, "import inspect\nfrom build123d import Box\nsig = str(inspect.signature(Box))")
+    result = execute_code(
+        session, "import inspect\nfrom build123d import Box\nsig = str(inspect.signature(Box))"
+    )
     assert "Error" not in result
 
 
@@ -405,6 +414,7 @@ def test_worker_execution_timeout():
     SIGALRM guard is a no-op. A `while True: pass` must return a timeout error,
     not hang the test."""
     from build123d_mcp.worker import WorkerSession
+
     ws = WorkerSession(exec_timeout=2)
     try:
         result = ws.execute("while True: pass")
@@ -422,17 +432,21 @@ def test_blocked_import_does_not_corrupt_shape(session):
 
 # --- OCP import allowlist ---
 
+
 def test_ocp_safe_module_allowed(session):
     result = execute_code(session, "from OCP.BRepGProp import BRepGProp")
     assert "not allowed" not in result.lower() and "Error" not in result
 
 
 def test_ocp_topology_modules_allowed(session):
-    result = execute_code(session, (
-        "from OCP.TopExp import TopExp_Explorer\n"
-        "from OCP.TopAbs import TopAbs_FACE\n"
-        "from OCP.TopoDS import TopoDS"
-    ))
+    result = execute_code(
+        session,
+        (
+            "from OCP.TopExp import TopExp_Explorer\n"
+            "from OCP.TopAbs import TopAbs_FACE\n"
+            "from OCP.TopoDS import TopoDS"
+        ),
+    )
     assert "not allowed" not in result.lower() and "Error" not in result
 
 
@@ -599,6 +613,7 @@ def test_render_view_save_to_both_writes_two_files(session, tmp_path, monkeypatc
 
 # --- render_view DXF ---
 
+
 def test_render_view_dxf_returns_dxf_bytes(session):
     execute_code(session, "result = Box(20, 10, 5)")
     out = render_view(session, "top", format="dxf")
@@ -672,16 +687,20 @@ def test_render_view_dxf_invalid_format_message_lists_dxf(session):
 
 # --- render_view 2D drafting (Sketch/Compound) ---
 
+
 def _build_2d_drawing(session):
     """Set up a session with a dimensioned 2D drawing as a named object."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 plate = Box(40, 20, 5) - Cylinder(3, 5).move(Location((10, 0, 0)))
 visible, _ = plate.project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 draft = Draft(font_size=2.5, decimal_precision=1)
 length = ExtensionLine(border=[(-20, -10, 0), (20, -10, 0)], offset=8, draft=draft, label='40')
 drawing = Compound(children=list(visible) + [length])
 show(drawing, 'top_view')
-""")
+""",
+    )
 
 
 def test_render_view_2d_returns_png(session):
@@ -721,13 +740,16 @@ def test_render_view_2d_multi_object_uses_2d_path(session):
     composed via build123d.drafting) must render through the 2D pipeline,
     not fall back to 3D VTK. The detection is: every shape has no solids
     AND lies flat in Z."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 plate_a, _ = (Box(20, 20, 5)).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0)), None
 visible_a, _ = Box(20, 20, 5).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 visible_b, _ = Box(15, 15, 3).move(Location((25, 0, 0))).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 show(Compound(children=list(visible_a)), 'plate_a')
 show(Compound(children=list(visible_b)), 'plate_b')
-""")
+""",
+    )
     out = render_view(session, objects="plate_a,plate_b", format="dxf")
     text = out["dxf"].decode("utf-8", errors="ignore")
     # Multi-object 2D path produces per-object _part layers
@@ -738,12 +760,15 @@ show(Compound(children=list(visible_b)), 'plate_b')
 def test_render_view_2d_multi_object_honours_per_object_colour(session):
     """F3: name:color syntax should propagate through the 2D path so
     visualisations of multi-part 2D drawings render in the requested hues."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 visible_a, _ = Box(20, 20, 5).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 visible_b, _ = Box(15, 15, 3).move(Location((25, 0, 0))).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 show(Compound(children=list(visible_a)), 'plate_a')
 show(Compound(children=list(visible_b)), 'plate_b')
-""")
+""",
+    )
     out = render_view(session, objects="plate_a:red,plate_b:blue", format="svg")
     text = out["svg"].decode("utf-8", errors="ignore")
     # Red ≈ 255,0,0; blue ≈ 0,0,255 — SVG embeds explicit RGB on each layer
@@ -753,15 +778,19 @@ show(Compound(children=list(visible_b)), 'plate_b')
 
 # --- #92 F4: colors= dict for fine-grained per-layer colour ---
 
+
 def test_render_view_2d_colors_dict_overrides_per_object(session):
     """colors={'plate_a': 'red'} should win over both the default palette
     and any name:color syntax."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 visible_a, _ = Box(20, 20, 5).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 visible_b, _ = Box(15, 15, 3).move(Location((25, 0, 0))).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 show(Compound(children=list(visible_a)), 'plate_a')
 show(Compound(children=list(visible_b)), 'plate_b')
-""")
+""",
+    )
     out = render_view(
         session,
         objects="plate_a,plate_b",  # no inline colours
@@ -775,10 +804,13 @@ show(Compound(children=list(visible_b)), 'plate_b')
 
 def test_render_view_2d_colors_overrides_inline_namecolor(session):
     """colors dict beats inline name:color when both specify the same object."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 visible_a, _ = Box(20, 20, 5).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 show(Compound(children=list(visible_a)), 'plate_a')
-""")
+""",
+    )
     # Inline says red; colors dict says green — green should win
     out = render_view(
         session,
@@ -803,6 +835,7 @@ def test_render_view_2d_colors_dims_layer(session):
 
 
 # --- #92 F8: explicit mode= parameter + render_mode in result ---
+
 
 def test_render_view_mode_auto_detects_3d(session):
     """mode='auto' (default) routes a 3D solid to the 3D pipeline."""
@@ -841,10 +874,13 @@ def test_render_view_mode_invalid_raises(session):
 def test_render_view_2d_colors_unknown_name_falls_back_to_palette(session):
     """A colors dict that doesn't mention the object should fall back to
     the inline colour or palette — not crash."""
-    execute_code(session, """
+    execute_code(
+        session,
+        """
 visible_a, _ = Box(20, 20, 5).project_to_viewport((0, 0, 100), (0, 1, 0), (0, 0, 0))
 show(Compound(children=list(visible_a)), 'plate_a')
-""")
+""",
+    )
     out = render_view(
         session,
         objects="plate_a:red",
@@ -857,6 +893,7 @@ show(Compound(children=list(visible_a)), 'plate_a')
 
 
 # --- export 2D drafting ---
+
 
 def test_export_2d_to_dxf(session, tmp_path, monkeypatch):
     """A 2D drawing exports cleanly to DXF via the export tool."""
@@ -896,6 +933,7 @@ def test_export_3d_rejects_dxf(session, tmp_path, monkeypatch):
 
 # --- render_view labels ---
 
+
 def test_render_view_label_objects_renders(session):
     execute_code(session, "show(Box(10, 10, 10), 'bracket')")
     execute_code(session, "show(Cylinder(3, 8).move(Location((20, 0, 0))), 'pin')")
@@ -914,7 +952,8 @@ def test_render_view_label_objects_skips_default_name(session):
 def test_render_view_highlights_face(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     out = render_view(
-        session, "iso",
+        session,
+        "iso",
         highlights=[{"object": "cube", "type": "face", "index": 0, "label": "top"}],
     )
     assert out["png"][:8] == PNG_MAGIC
@@ -923,7 +962,8 @@ def test_render_view_highlights_face(session):
 def test_render_view_highlights_edge_and_vertex(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     out = render_view(
-        session, "iso",
+        session,
+        "iso",
         highlights=[
             {"object": "cube", "type": "edge", "index": 2, "label": "e2"},
             {"object": "cube", "type": "vertex", "index": 0, "label": "v0"},
@@ -936,7 +976,8 @@ def test_render_view_highlight_unknown_object_raises(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     with pytest.raises(ValueError, match="unknown object 'ghost'"):
         render_view(
-            session, "iso",
+            session,
+            "iso",
             highlights=[{"object": "ghost", "type": "face", "index": 0, "label": "x"}],
         )
 
@@ -946,7 +987,9 @@ def test_render_view_highlight_object_not_in_render_set_raises(session):
     execute_code(session, "show(Cylinder(3, 5), 'pin')")
     with pytest.raises(ValueError, match="not in the rendered set"):
         render_view(
-            session, "iso", objects="cube",
+            session,
+            "iso",
+            objects="cube",
             highlights=[{"object": "pin", "type": "face", "index": 0, "label": "x"}],
         )
 
@@ -955,7 +998,8 @@ def test_render_view_highlight_index_out_of_range_raises(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     with pytest.raises(ValueError, match="out of range"):
         render_view(
-            session, "iso",
+            session,
+            "iso",
             highlights=[{"object": "cube", "type": "face", "index": 99, "label": "x"}],
         )
 
@@ -964,7 +1008,8 @@ def test_render_view_highlight_invalid_type_raises(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     with pytest.raises(ValueError, match="type must be"):
         render_view(
-            session, "iso",
+            session,
+            "iso",
             highlights=[{"object": "cube", "type": "wire", "index": 0, "label": "x"}],
         )
 
@@ -973,7 +1018,8 @@ def test_render_view_highlight_missing_key_raises(session):
     execute_code(session, "show(Box(10, 10, 10), 'cube')")
     with pytest.raises(ValueError, match="missing required key"):
         render_view(
-            session, "iso",
+            session,
+            "iso",
             highlights=[{"object": "cube", "type": "face", "index": 0}],  # no label
         )
 
@@ -987,6 +1033,7 @@ def test_render_view_labels_warn_in_svg(session):
 
 
 # --- measure ---
+
 
 def test_measure_bounding_box(session):
     execute_code(session, "result = Box(10, 20, 30)")
@@ -1019,13 +1066,17 @@ def test_measure_area(session):
 
 def test_measure_clearance(session):
     from build123d_mcp.tools.measure import clearance
-    execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10).move(Location((20,0,0))), 'b')")
+
+    execute_code(
+        session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10).move(Location((20,0,0))), 'b')"
+    )
     data = json.loads(clearance(session, "a", "b"))
     assert abs(data["clearance"] - 10) < 0.1
 
 
 def test_clearance_unknown_object_raises(session):
     from build123d_mcp.tools.measure import clearance
+
     execute_code(session, "show(Box(10,10,10), 'a')")
     with pytest.raises(ValueError, match="Unknown object"):
         clearance(session, "a", "missing")
@@ -1034,6 +1085,7 @@ def test_clearance_unknown_object_raises(session):
 def test_clearance_apart_status(session):
     """Two boxes with a gap: status=apart, clearance is the gap."""
     from build123d_mcp.tools.measure import clearance
+
     execute_code(session, "show(Box(10,10,10), 'a')")
     execute_code(session, "show(Box(5,5,5).move(Location((20,0,0))), 'b')")
     data = json.loads(clearance(session, "a", "b"))
@@ -1046,6 +1098,7 @@ def test_clearance_apart_status(session):
 def test_clearance_touching_status(session):
     """Two boxes sharing a face: status=touching, clearance=0, no overlap."""
     from build123d_mcp.tools.measure import clearance
+
     execute_code(session, "show(Box(10,10,10), 'a')")
     execute_code(session, "show(Box(10,10,10).move(Location((10,0,0))), 'b')")
     data = json.loads(clearance(session, "a", "b"))
@@ -1059,6 +1112,7 @@ def test_clearance_containing_reports_wall_thickness(session):
     clearance is the smallest gap from cylinder surface to plate exterior
     (= wall thickness in the worst direction)."""
     from build123d_mcp.tools.measure import clearance
+
     execute_code(session, "show(Box(40, 20, 10), 'plate')")
     execute_code(session, "show(Cylinder(3, 5).move(Location((10, 0, 0))), 'pocket')")
     data = json.loads(clearance(session, "pocket", "plate"))
@@ -1075,6 +1129,7 @@ def test_clearance_interpenetrating_flags_wall_pierce(session):
     matters is a_volume_outside_b > 0 — that's the volume of the pocket
     extending beyond the plate's outer surface."""
     from build123d_mcp.tools.measure import clearance
+
     execute_code(session, "show(Box(40, 20, 5), 'plate')")
     execute_code(session, "show(Cylinder(3, 10).move(Location((10, 0, 0))), 'pocket')")
     data = json.loads(clearance(session, "pocket", "plate"))
@@ -1086,6 +1141,7 @@ def test_clearance_interpenetrating_flags_wall_pierce(session):
 
 
 # --- export ---
+
 
 def test_export_step(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -1099,7 +1155,7 @@ def test_export_step(session, tmp_path, monkeypatch):
 def test_export_stl(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     execute_code(session, "result = Box(10, 10, 10)")
-    result = export_file(session, "out", "stl")
+    export_file(session, "out", "stl")
     assert os.path.exists("out.stl")
     assert os.path.getsize("out.stl") > 0
 
@@ -1142,10 +1198,14 @@ def test_export_to_tmp_allowed(session, tmp_path):
     assert str(target) in result
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="/tmp does not exist on Windows; tempfile.gettempdir() coverage in test_export_to_tmp_allowed already runs there")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="/tmp does not exist on Windows; tempfile.gettempdir() coverage in test_export_to_tmp_allowed already runs there",
+)
 def test_export_to_slash_tmp_allowed(session):
     execute_code(session, "result = Box(10, 10, 10)")
     import tempfile as _tempfile
+
     with _tempfile.NamedTemporaryFile(
         prefix="build123d_mcp_test_", suffix=".step", dir="/tmp", delete=False
     ) as f:
@@ -1202,6 +1262,7 @@ def test_export_symlink_escape_rejected(session, tmp_path):
 
 # --- reset ---
 
+
 def test_reset_clears_shape(session):
     execute_code(session, "result = Box(10, 10, 10)")
     assert session.current_shape is not None
@@ -1217,6 +1278,7 @@ def test_reset_clears_namespace(session):
 
 
 # --- multi-object / show() ---
+
 
 def test_show_registers_object(session):
     execute_code(session, "box = Box(10, 10, 10)")
@@ -1287,6 +1349,7 @@ def test_export_unknown_object_raises(session):
 
 # --- snapshots ---
 
+
 def test_save_and_restore_snapshot(session):
     execute_code(session, "result = Box(10, 10, 10)")
     vol_before = session.current_shape.volume
@@ -1330,6 +1393,7 @@ def test_reset_clears_snapshots(session):
 def test_dispatch_save_snapshot_no_shape_omits_current_shape():
     from build123d_mcp.session import Session
     from build123d_mcp.worker import _dispatch
+
     s = Session()
     msg = _dispatch(s, "save_snapshot", {"name": "empty"}, None)
     assert "current_shape" not in msg
@@ -1339,6 +1403,7 @@ def test_dispatch_save_snapshot_no_shape_omits_current_shape():
 def test_dispatch_restore_snapshot_no_shape_omits_current_shape():
     from build123d_mcp.session import Session
     from build123d_mcp.worker import _dispatch
+
     s = Session()
     _dispatch(s, "save_snapshot", {"name": "empty"}, None)
     msg = _dispatch(s, "restore_snapshot", {"name": "empty"}, None)
@@ -1356,6 +1421,7 @@ def test_namespace_preserved_after_restore(session):
 
 
 # --- show() API: shape first, optional name second (issue #11) ---
+
 
 def test_show_with_explicit_name(session):
     execute_code(session, "box = Box(10, 10, 10)")
@@ -1375,6 +1441,7 @@ def test_show_without_name_defaults_to_shape(session):
 
 # --- render_view per-object color (issue #12) ---
 
+
 def test_render_view_per_object_color(session):
     execute_code(session, "show(Box(10, 10, 10), 'a')\nshow(Cylinder(5, 20), 'b')")
     out = render_view(session, "iso", "a:blue,b:red")
@@ -1389,22 +1456,29 @@ def test_render_view_mixed_color_and_palette(session):
 
 # --- interference check (issue #13) ---
 
+
 def test_interference_overlapping(session):
-    execute_code(session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((5, 0, 0))), 'b')")
+    execute_code(
+        session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((5, 0, 0))), 'b')"
+    )
     data = json.loads(interference(session, "a", "b"))
     assert data["interferes"] is True
     assert data["volume"] > 0
 
 
 def test_interference_non_overlapping(session):
-    execute_code(session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((20, 0, 0))), 'b')")
+    execute_code(
+        session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((20, 0, 0))), 'b')"
+    )
     data = json.loads(interference(session, "a", "b"))
     assert data["interferes"] is False
     assert data["volume"] == 0.0
 
 
 def test_interference_returns_bounds(session):
-    execute_code(session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((5, 0, 0))), 'b')")
+    execute_code(
+        session, "show(Box(10, 10, 10), 'a')\nshow(Box(10, 10, 10).move(Location((5, 0, 0))), 'b')"
+    )
     data = json.loads(interference(session, "a", "b"))
     assert "bounds" in data
     bounds = data["bounds"]
@@ -1419,6 +1493,7 @@ def test_interference_unknown_object_raises(session):
 
 
 # --- measure topology ---
+
 
 def test_measure_topology_box(session):
     execute_code(session, "result = Box(10, 10, 10)")
@@ -1442,6 +1517,7 @@ def test_measure_topology_named_object(session):
 
 # --- render_view azimuth/elevation (new) ---
 
+
 def test_render_view_azimuth_returns_png(session):
     execute_code(session, "result = Box(10, 10, 10)")
     out = render_view(session, "iso", azimuth=45.0)
@@ -1462,6 +1538,7 @@ def test_render_view_azimuth_and_elevation_returns_png(session):
 
 # --- render_view clip_at (new) ---
 
+
 def test_render_view_clip_at_returns_png(session):
     execute_code(session, "result = Cylinder(5, 20)")
     out = render_view(session, "iso", clip_plane="z", clip_at=5.0)
@@ -1475,6 +1552,7 @@ def test_render_view_clip_at_negative_returns_png(session):
 
 
 # --- render_view save_to (new) ---
+
 
 def test_render_view_save_to_writes_png(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -1513,6 +1591,7 @@ def test_render_view_save_to_tmp_allowed(session, tmp_path):
 
 # --- show() feedback (new) ---
 
+
 def test_show_prints_volume_and_faces(session):
     output = execute_code(session, "show(Box(10, 10, 10), 'cube')")
     assert "cube" in output
@@ -1526,6 +1605,7 @@ def test_show_prints_feedback_without_name(session):
 
 # --- face() helper ---
 
+
 def test_face_top_returns_highest_z(session):
     execute_code(session, "from build123d import *\nb = Box(10, 10, 10)\nt = named_face(b, 'top')")
     # Top face center should be at z = +5
@@ -1534,7 +1614,9 @@ def test_face_top_returns_highest_z(session):
 
 
 def test_face_bottom_returns_lowest_z(session):
-    execute_code(session, "from build123d import *\nb = Box(10, 10, 10)\nt = named_face(b, 'bottom')")
+    execute_code(
+        session, "from build123d import *\nb = Box(10, 10, 10)\nt = named_face(b, 'bottom')"
+    )
     bottom = session.namespace["t"]
     assert abs(bottom.center_location.position.Z + 5) < 0.1
 
@@ -1555,24 +1637,31 @@ def test_face_all_names_work(session):
 
 
 def test_face_unknown_name_raises(session):
-    result = execute_code(session, "from build123d import *\nb = Box(10,10,10)\nnamed_face(b, 'diagonal')")
+    result = execute_code(
+        session, "from build123d import *\nb = Box(10,10,10)\nnamed_face(b, 'diagonal')"
+    )
     assert "Error" in result and "diagonal" in result
 
 
 def test_face_survives_rollback(session):
     # face() should still be available after a failed execute()
     execute_code(session, "raise ValueError('oops')")
-    result = execute_code(session, "from build123d import *\nb = Box(5,5,5)\nt = named_face(b, 'top')")
+    result = execute_code(
+        session, "from build123d import *\nb = Box(5,5,5)\nt = named_face(b, 'top')"
+    )
     assert "Error" not in result
 
 
 def test_face_available_without_import(session):
     # face() is a session built-in — no import needed
-    result = execute_code(session, "from build123d import Box\nb = Box(10,10,10)\nt = named_face(b, 'top')")
+    result = execute_code(
+        session, "from build123d import Box\nb = Box(10,10,10)\nt = named_face(b, 'top')"
+    )
     assert "Error" not in result
 
 
 # --- list_objects (new) ---
+
 
 def test_list_objects_empty(session):
     result = list_objects(session)
@@ -1598,6 +1687,7 @@ def test_list_objects_includes_geometry(session):
 
 
 # --- auto-diagnostics after execute ---
+
 
 def test_execute_auto_diagnostics_on_new_shape(session):
     result = execute_code(session, "result = Box(10, 10, 10)")
@@ -1630,6 +1720,7 @@ def test_execute_auto_diagnostics_not_repeated_when_shape_unchanged(session):
 
 # --- assertion / constraint support ---
 
+
 def test_assert_passing_does_not_error(session):
     result = execute_code(session, "result = Box(10, 10, 10)\nassert result.volume > 500")
     assert "Error" not in result
@@ -1637,7 +1728,9 @@ def test_assert_passing_does_not_error(session):
 
 
 def test_assert_failing_returns_constraint_failed(session):
-    result = execute_code(session, "result = Box(10, 10, 10)\nassert result.volume > 9999, 'volume too small'")
+    result = execute_code(
+        session, "result = Box(10, 10, 10)\nassert result.volume > 9999, 'volume too small'"
+    )
     assert result.startswith("Constraint failed")
     assert "volume too small" in result
 
@@ -1655,6 +1748,7 @@ def test_assert_failure_does_not_update_current_shape(session):
 
 
 # --- diff_snapshot ---
+
 
 def test_diff_snapshot_vs_current(session):
     execute_code(session, "result = Box(10, 10, 10)")
@@ -1717,6 +1811,7 @@ def test_diff_snapshot_unchanged_object_marked(session):
 
 # --- session_state ---
 
+
 def test_session_state_empty(session):
     data = json.loads(session_state(session))
     assert data["current_shape"] is None
@@ -1736,6 +1831,7 @@ def test_session_state_with_shape_and_objects(session):
 
 # --- diff_snapshot JSON mode ---
 
+
 def test_diff_snapshot_json_format(session):
     execute_code(session, "result = Box(10, 10, 10)")
     session.save_snapshot("s1")
@@ -1747,6 +1843,7 @@ def test_diff_snapshot_json_format(session):
 
 
 # --- measure extended fields (center_of_mass, inertia, face_inventory) ---
+
 
 def test_measure_center_of_mass_symmetric_box(session):
     execute_code(session, "result = Box(10, 10, 10)")
@@ -1808,8 +1905,10 @@ def test_measure_face_inventory_cylinder(session):
 
 # --- cross_sections ---
 
+
 def test_cross_sections_box(session):
     from build123d_mcp.tools.cross_sections import cross_sections
+
     execute_code(session, "result = Box(10, 10, 10)")
     data = json.loads(cross_sections(session, axis="Z", num_slices=5))
     assert isinstance(data, list)
@@ -1821,6 +1920,7 @@ def test_cross_sections_box(session):
 
 def test_cross_sections_named_object(session):
     from build123d_mcp.tools.cross_sections import cross_sections
+
     execute_code(session, "show(Box(20, 10, 10), 'wide')")
     data = json.loads(cross_sections(session, "wide", axis="X", num_slices=4))
     assert len(data) == 4
@@ -1830,9 +1930,11 @@ def test_cross_sections_named_object(session):
 
 # --- import_cad_file ---
 
+
 def test_import_step_round_trip(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(10, 10, 10)")
     export_file(session, "ref", "step")
     step_path = str(tmp_path / "ref.step")
@@ -1847,6 +1949,7 @@ def test_import_step_round_trip(session, tmp_path, monkeypatch):
 def test_import_step_default_name_from_filename(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(5, 5, 5)")
     export_file(session, "mypart", "step")
     step_path = str(tmp_path / "mypart.step")
@@ -1858,6 +1961,7 @@ def test_import_step_default_name_from_filename(session, tmp_path, monkeypatch):
 def test_import_stl_round_trip(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(10, 10, 10)")
     export_file(session, "ref", "stl")
     stl_path = str(tmp_path / "ref.stl")
@@ -1871,6 +1975,7 @@ def test_import_stl_round_trip(session, tmp_path, monkeypatch):
 
 def test_import_cad_file_missing_file_raises(session, tmp_path):
     from build123d_mcp.tools.import_step import import_cad_file
+
     # Missing file under an allowed root: passes the input-path policy check
     # and reaches the not-found check (an outside-root path would be rejected
     # earlier with "outside the allowed read roots" — see test_path_safety.py).
@@ -1880,6 +1985,7 @@ def test_import_cad_file_missing_file_raises(session, tmp_path):
 
 def test_import_cad_file_wrong_extension_raises(session, tmp_path):
     from build123d_mcp.tools.import_step import import_cad_file
+
     bad = tmp_path / "file.obj"
     bad.write_text("dummy")
     with pytest.raises(ValueError, match="Expected a .step"):
@@ -1889,6 +1995,7 @@ def test_import_cad_file_wrong_extension_raises(session, tmp_path):
 def test_import_step_becomes_current_shape(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(10, 10, 10)")
     export_file(session, "shape", "step")
     import_cad_file(session, str(tmp_path / "shape.step"), "imported")
@@ -1898,9 +2005,11 @@ def test_import_step_becomes_current_shape(session, tmp_path, monkeypatch):
 
 # --- render_view after import ---
 
+
 def test_render_view_after_step_import(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(10, 10, 10)")
     export_file(session, str(tmp_path / "ref"), "step")
     session.reset()
@@ -1913,6 +2022,7 @@ def test_render_view_after_step_import(session, tmp_path, monkeypatch):
 def test_render_view_after_stl_import(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(10, 10, 10)")
     export_file(session, str(tmp_path / "ref"), "stl")
     session.reset()
@@ -1926,6 +2036,7 @@ def test_render_view_imported_by_name(session, tmp_path, monkeypatch):
     """Rendering a specific imported object by name avoids Z-fighting with other shapes."""
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "show(Box(10, 10, 10), 'original')")
     export_file(session, str(tmp_path / "ref"), "step")
     import_cad_file(session, str(tmp_path / "ref.step"), "imported")
@@ -1938,6 +2049,7 @@ def test_render_view_stl_import_non_trivial(session, tmp_path, monkeypatch):
     The vtkPolyDataNormals fix ensures consistent face orientation on mesh shells."""
     monkeypatch.chdir(tmp_path)
     from build123d_mcp.tools.import_step import import_cad_file
+
     execute_code(session, "result = Box(20, 20, 20)")
     export_file(session, str(tmp_path / "box"), "stl")
     session.reset()
@@ -1953,6 +2065,7 @@ def test_render_view_stl_import_non_trivial(session, tmp_path, monkeypatch):
 
 # --- health_check ---
 
+
 def test_health_check_returns_json(session):
     data = json.loads(health_check(session))
     assert "ok" in data
@@ -1967,6 +2080,7 @@ def test_health_check_returns_json(session):
 def test_version_returns_package_versions():
     """version_info() reports build123d-mcp and its key deps, keyed by dist name."""
     from build123d_mcp.tools.version import version_info
+
     info = version_info()
     assert isinstance(info, dict)
     for key in ("build123d-mcp", "build123d", "build123d-drafting-helpers"):
@@ -1977,13 +2091,16 @@ def test_version_returns_package_versions():
 def test_version_build123d_mcp_matches_metadata():
     """The reported build123d-mcp version matches importlib metadata."""
     from importlib.metadata import version as _pkg_version
+
     from build123d_mcp.tools.version import version_info
+
     assert version_info()["build123d-mcp"] == _pkg_version("build123d-mcp")
 
 
 def test_version_unknown_package_reports_unknown(monkeypatch):
     """A package that isn't installed reports "unknown" rather than raising."""
     import build123d_mcp.tools.version as v
+
     monkeypatch.setattr(v, "_PACKAGES", ("build123d-mcp", "definitely-not-installed-xyz"))
     info = v.version_info()
     assert info["definitely-not-installed-xyz"] == "unknown"

--- a/tests/test_transitive_imports.py
+++ b/tests/test_transitive_imports.py
@@ -9,9 +9,8 @@ must still be blocked.
 import pytest
 
 import build123d_mcp.security as _sec
-from build123d_mcp.security import _is_transitively_safe, _clear_transitive_cache
+from build123d_mcp.security import _clear_transitive_cache, _is_transitively_safe
 from build123d_mcp.session import Session
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -56,109 +55,169 @@ def test_nonexistent_module_is_blocked():
 
 
 def test_safe_package_allowed(tmp_path, monkeypatch):
-    pkg = _make_pkg(tmp_path, "mypkg", {
-        "__init__.py": "from mypkg.utils import helper\n",
-        "utils.py": "import math\nimport collections\n\ndef helper(): pass\n",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "mypkg",
+        {
+            "__init__.py": "from mypkg.utils import helper\n",
+            "utils.py": "import math\nimport collections\n\ndef helper(): pass\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is True
 
 
 def test_safe_submodule_allowed(tmp_path, monkeypatch):
-    _make_pkg(tmp_path, "mypkg2", {
-        "__init__.py": "",
-        "core.py": "import math\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "mypkg2",
+        {
+            "__init__.py": "",
+            "core.py": "import math\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe("mypkg2.core") is True
 
 
 def test_package_importing_os_is_blocked(tmp_path, monkeypatch):
-    pkg = _make_pkg(tmp_path, "badpkg", {
-        "__init__.py": "import os\n",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "badpkg",
+        {
+            "__init__.py": "import os\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is False
 
 
 def test_transitive_unsafe_dep_is_blocked(tmp_path, monkeypatch):
     """A package that looks safe on top but imports os via a helper is blocked."""
-    pkg = _make_pkg(tmp_path, "indirectpkg", {
-        "__init__.py": "from indirectpkg.helper import thing\n",
-        "helper.py": "import os\n\ndef thing(): pass\n",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "indirectpkg",
+        {
+            "__init__.py": "from indirectpkg.helper import thing\n",
+            "helper.py": "import os\n\ndef thing(): pass\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is False
 
 
 def test_cyclic_safe_package_allowed(tmp_path, monkeypatch):
     """Two modules that import each other, both using only allowed deps."""
-    _make_pkg(tmp_path, "cyclicpkg", {
-        "__init__.py": "",
-        "a.py": "from cyclicpkg.b import b_fn\nimport math\n\ndef a_fn(): pass\n",
-        "b.py": "from cyclicpkg.a import a_fn\nimport math\n\ndef b_fn(): pass\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "cyclicpkg",
+        {
+            "__init__.py": "",
+            "a.py": "from cyclicpkg.b import b_fn\nimport math\n\ndef a_fn(): pass\n",
+            "b.py": "from cyclicpkg.a import a_fn\nimport math\n\ndef b_fn(): pass\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe("cyclicpkg.a") is True
     assert _is_transitively_safe("cyclicpkg.b") is True
 
 
 def test_result_is_cached(tmp_path, monkeypatch):
-    pkg = _make_pkg(tmp_path, "cachepkg", {
-        "__init__.py": "import math\n",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "cachepkg",
+        {
+            "__init__.py": "import math\n",
+        },
+        monkeypatch,
+    )
     _is_transitively_safe(pkg)
     assert pkg in _sec._transitive_safe_cache
 
 
 def test_relative_imports_within_package_are_followed_and_safe(tmp_path, monkeypatch):
     """Relative imports are followed; a package that only uses allowed deps remains safe."""
-    _make_pkg(tmp_path, "relpkg", {
-        "__init__.py": "",
-        "sub.py": "from . import utils\n",
-        "utils.py": "import math\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "relpkg",
+        {
+            "__init__.py": "",
+            "sub.py": "from . import utils\n",
+            "utils.py": "import math\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe("relpkg.sub") is True
 
 
 def test_empty_package_is_safe(tmp_path, monkeypatch):
-    pkg = _make_pkg(tmp_path, "emptypkg", {
-        "__init__.py": "",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "emptypkg",
+        {
+            "__init__.py": "",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is True
 
 
 def test_package_importing_blocked_ocp_submodule_is_unsafe(tmp_path, monkeypatch):
     """A package that imports a blocked OCP sub-module (OCP.OSD) must not be transitively safe."""
-    pkg = _make_pkg(tmp_path, "ocppkg", {
-        "__init__.py": "import OCP.OSD\n",
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "ocppkg",
+        {
+            "__init__.py": "import OCP.OSD\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is False
 
 
 def test_type_checking_guard_not_blocked(tmp_path, monkeypatch):
     """Imports inside 'if TYPE_CHECKING:' are not executed at runtime; package must be allowed."""
-    pkg = _make_pkg(tmp_path, "typechecking_pkg", {
-        "__init__.py": (
-            "from typing import TYPE_CHECKING\n"
-            "if TYPE_CHECKING:\n"
-            "    import os  # never executes at runtime\n"
-            "import math\n"
-        ),
-    }, monkeypatch)
+    pkg = _make_pkg(
+        tmp_path,
+        "typechecking_pkg",
+        {
+            "__init__.py": (
+                "from typing import TYPE_CHECKING\n"
+                "if TYPE_CHECKING:\n"
+                "    import os  # never executes at runtime\n"
+                "import math\n"
+            ),
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe(pkg) is True
 
 
 def test_relative_import_to_blocked_submodule_is_unsafe(tmp_path, monkeypatch):
     """'from . import evil_utils' where evil_utils.py imports os must be blocked."""
-    _make_pkg(tmp_path, "relimport_evil", {
-        "__init__.py": "from . import evil_utils\n",
-        "evil_utils.py": "import os\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "relimport_evil",
+        {
+            "__init__.py": "from . import evil_utils\n",
+            "evil_utils.py": "import os\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe("relimport_evil") is False
 
 
 def test_parent_init_with_blocked_import_blocks_submodule(tmp_path, monkeypatch):
     """'from mypkg.utils import X' must be blocked if mypkg/__init__.py imports os."""
-    _make_pkg(tmp_path, "bad_parent", {
-        "__init__.py": "import os\n",
-        "utils.py": "import math\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "bad_parent",
+        {
+            "__init__.py": "import os\n",
+            "utils.py": "import math\n",
+        },
+        monkeypatch,
+    )
     assert _is_transitively_safe("bad_parent.utils") is False
 
 
@@ -168,10 +227,15 @@ def test_parent_init_with_blocked_import_blocks_submodule(tmp_path, monkeypatch)
 
 
 def test_execute_safe_package_allowed(tmp_path, monkeypatch):
-    _make_pkg(tmp_path, "goodpkg", {
-        "__init__.py": "from goodpkg.core import helper\n",
-        "core.py": "import math\n\ndef helper(): return math.pi\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "goodpkg",
+        {
+            "__init__.py": "from goodpkg.core import helper\n",
+            "core.py": "import math\n\ndef helper(): return math.pi\n",
+        },
+        monkeypatch,
+    )
     s = Session()
     result = s.execute("import goodpkg")
     assert "not allowed" not in result.lower()
@@ -179,10 +243,15 @@ def test_execute_safe_package_allowed(tmp_path, monkeypatch):
 
 
 def test_execute_safe_submodule_from_import(tmp_path, monkeypatch):
-    _make_pkg(tmp_path, "goodpkg2", {
-        "__init__.py": "",
-        "geom.py": "import math\n\ndef area(r): return math.pi * r * r\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "goodpkg2",
+        {
+            "__init__.py": "",
+            "geom.py": "import math\n\ndef area(r): return math.pi * r * r\n",
+        },
+        monkeypatch,
+    )
     s = Session()
     result = s.execute("from goodpkg2.geom import area; x = area(5)")
     assert "not allowed" not in result.lower()
@@ -190,19 +259,29 @@ def test_execute_safe_submodule_from_import(tmp_path, monkeypatch):
 
 
 def test_execute_unsafe_package_blocked(tmp_path, monkeypatch):
-    _make_pkg(tmp_path, "evilpkg", {
-        "__init__.py": "import subprocess\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "evilpkg",
+        {
+            "__init__.py": "import subprocess\n",
+        },
+        monkeypatch,
+    )
     s = Session()
     result = s.execute("import evilpkg")
     assert "not allowed" in result.lower()
 
 
 def test_execute_transitively_unsafe_blocked(tmp_path, monkeypatch):
-    _make_pkg(tmp_path, "sneakypkg", {
-        "__init__.py": "from sneakypkg.loader import load\n",
-        "loader.py": "import os\n\ndef load(): return os.listdir('.')\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "sneakypkg",
+        {
+            "__init__.py": "from sneakypkg.loader import load\n",
+            "loader.py": "import os\n\ndef load(): return os.listdir('.')\n",
+        },
+        monkeypatch,
+    )
     s = Session()
     result = s.execute("import sneakypkg")
     assert "not allowed" in result.lower()
@@ -210,9 +289,14 @@ def test_execute_transitively_unsafe_blocked(tmp_path, monkeypatch):
 
 def test_execute_hint_mentions_import_cad_file(tmp_path, monkeypatch):
     """The error message for a blocked import should surface import_cad_file."""
-    _make_pkg(tmp_path, "blocked_hint_pkg", {
-        "__init__.py": "import os\n",
-    }, monkeypatch)
+    _make_pkg(
+        tmp_path,
+        "blocked_hint_pkg",
+        {
+            "__init__.py": "import os\n",
+        },
+        monkeypatch,
+    )
     s = Session()
     result = s.execute("import blocked_hint_pkg")
     assert "import_cad_file" in result

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -35,10 +35,10 @@ import pytest
 from build123d_mcp import worker
 from build123d_mcp.worker import WorkerSession
 
-
 # --------------------------------------------------------------------------- #
 # AST extraction of the dispatch / proxy op sets (single source of truth)      #
 # --------------------------------------------------------------------------- #
+
 
 def _dispatch_ops() -> set[str]:
     """Op strings compared in ``worker._dispatch`` (``if op == "...":``)."""
@@ -99,6 +99,7 @@ def test_dispatch_ops_match_proxy_methods():
 # tool reflects state created in the worker (objects 'a'/'b', snapshot 'snap',
 # execute_history). Were the tool reading the empty parent proxy, the seeded
 # object would be absent and the assertion would fail.
+
 
 def _measure(ws, tmp_path):
     r = json.loads(ws.measure("a"))

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -144,6 +145,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 
 [[package]]
@@ -1609,6 +1611,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #185 (Phase 1 — the rule-set posture was a human decision; Paul chose **Phase 1 only**).

## What this does
Adds an automated lint/format baseline that fails CI on regressions, without a per-site `# noqa` campaign.

- **`[tool.ruff]`** — `line-length = 100` (matches existing code; `E501` not enabled), `target-version = py310`, lint `select = ["F", "I", "UP", "C4"]` — objective, auto-fixable rules only.
- **`ruff`** added to the dev dependency group.
- **CI** — `ruff check` + `ruff format --check`, Linux-only (OS-independent, like mypy) so they run once.
- Applied `ruff format` (55 files) + the F/I/UP/C4 auto-fixes; hand-fixed 7 non-auto findings (dead locals, unused `result` vars in tests). The `bd_warehouse` availability-probe import keeps a targeted `# noqa: F401` — removing it would break the `try/except ImportError`.

## Explicitly deferred (documented in `pyproject.toml`)
The safety/complexity rules — `BLE` (blind-except), `S` (bandit `eval`/`exec`/`subprocess`), `C901` — that the three-layer sandbox / worker design uses **deliberately**. Enforcing them means ~86 hand-judged `# noqa`s; that's a standalone follow-up, not an automated baseline.

## Gate
- `uv run mypy src/build123d_mcp/` — clean
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pytest tests/` — **587 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)