### PR TITLE
feat(security): resource limits for file inputs and raster width (#189)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
     "build123d-drafting-helpers>=0.4.1",
+    "defusedxml>=0.7.1",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/tools/_paths.py
+++ b/src/build123d_mcp/tools/_paths.py
@@ -62,3 +62,54 @@ def safe_input_path(filename: str) -> str:
     render_drawing, inspect_drawing, lint_drawing) and their sidecar reads.
     """
     return _safe_path(filename, "read")
+
+
+# Resource limits for model-supplied file inputs (issue #189). A model-callable
+# server should reject obviously excessive inputs *before* the expensive
+# parse/import/rasterise, rather than letting the work run until the exec
+# timeout kills the worker and destroys session state. Defaults are generous —
+# they reject only the absurd — and are env-overridable, matching the
+# BUILD123D_EXEC_TIMEOUT convention.
+MAX_SVG_BYTES = int(os.environ.get("BUILD123D_MAX_SVG_BYTES", str(20 * 1024 * 1024)))  # 20 MB
+MAX_CAD_BYTES = int(os.environ.get("BUILD123D_MAX_CAD_BYTES", str(200 * 1024 * 1024)))  # 200 MB
+MAX_RASTER_WIDTH = int(os.environ.get("BUILD123D_MAX_RASTER_WIDTH", "10000"))  # px
+
+# Env var names per kind, surfaced in the rejection message so the caller knows
+# which knob to turn.
+_SIZE_LIMIT_ENV = {"svg": "BUILD123D_MAX_SVG_BYTES", "cad": "BUILD123D_MAX_CAD_BYTES"}
+
+
+def check_input_size(path: str, kind: str) -> None:
+    """Reject an oversized input file before parsing/importing it.
+
+    `kind` is ``"svg"`` or ``"cad"``, selecting the byte limit. No-op when the
+    file is missing or unreadable — the caller's own existence check reports
+    that. The limit globals are read at call time so they stay env-overridable
+    (and test-patchable). Raises ``ValueError`` when the file exceeds the limit;
+    callers let it propagate, like the path-policy check above.
+    """
+    limits = {"svg": MAX_SVG_BYTES, "cad": MAX_CAD_BYTES}
+    max_bytes = limits[kind]
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return
+    if size > max_bytes:
+        raise ValueError(
+            f"Input file '{path}' is {size} bytes, exceeding the {max_bytes}-byte limit "
+            f"for {kind} inputs. Raise {_SIZE_LIMIT_ENV[kind]} to allow a larger file."
+        )
+
+
+def check_raster_width(width: int) -> None:
+    """Reject an extreme raster width before the output bitmap is allocated.
+
+    A bitmap is width × height × 4 bytes, so an unbounded width (e.g. 100000 px)
+    can demand tens of GB. Reads ``MAX_RASTER_WIDTH`` at call time. Raises
+    ``ValueError`` when exceeded; the caller lets it propagate.
+    """
+    if width > MAX_RASTER_WIDTH:
+        raise ValueError(
+            f"Requested raster width {width}px exceeds the {MAX_RASTER_WIDTH}px limit. "
+            f"Raise BUILD123D_MAX_RASTER_WIDTH to allow a larger raster."
+        )

--- a/src/build123d_mcp/tools/_paths.py
+++ b/src/build123d_mcp/tools/_paths.py
@@ -69,14 +69,14 @@ def safe_input_path(filename: str) -> str:
 # parse/import/rasterise, rather than letting the work run until the exec
 # timeout kills the worker and destroys session state. Defaults are generous —
 # they reject only the absurd — and are env-overridable, matching the
-# BUILD123D_EXEC_TIMEOUT convention.
-MAX_SVG_BYTES = int(os.environ.get("BUILD123D_MAX_SVG_BYTES", str(20 * 1024 * 1024)))  # 20 MB
-MAX_CAD_BYTES = int(os.environ.get("BUILD123D_MAX_CAD_BYTES", str(200 * 1024 * 1024)))  # 200 MB
-MAX_RASTER_WIDTH = int(os.environ.get("BUILD123D_MAX_RASTER_WIDTH", "10000"))  # px
-
-# Env var names per kind, surfaced in the rejection message so the caller knows
-# which knob to turn.
-_SIZE_LIMIT_ENV = {"svg": "BUILD123D_MAX_SVG_BYTES", "cad": "BUILD123D_MAX_CAD_BYTES"}
+# BUILD123D_EXEC_TIMEOUT convention. Each limit is the single source of truth:
+# (default value, override env var). Read at call time so the override is
+# honoured per process and tests can set it with monkeypatch.setenv.
+_INPUT_SIZE_LIMITS = {
+    "svg": (20 * 1024 * 1024, "BUILD123D_MAX_SVG_BYTES"),  # 20 MB
+    "cad": (200 * 1024 * 1024, "BUILD123D_MAX_CAD_BYTES"),  # 200 MB
+}
+_RASTER_WIDTH_LIMIT = (10000, "BUILD123D_MAX_RASTER_WIDTH")  # px
 
 
 def check_input_size(path: str, kind: str) -> None:
@@ -84,12 +84,11 @@ def check_input_size(path: str, kind: str) -> None:
 
     `kind` is ``"svg"`` or ``"cad"``, selecting the byte limit. No-op when the
     file is missing or unreadable — the caller's own existence check reports
-    that. The limit globals are read at call time so they stay env-overridable
-    (and test-patchable). Raises ``ValueError`` when the file exceeds the limit;
-    callers let it propagate, like the path-policy check above.
+    that. Raises ``ValueError`` when the file exceeds the limit; callers let it
+    propagate, like the path-policy check above.
     """
-    limits = {"svg": MAX_SVG_BYTES, "cad": MAX_CAD_BYTES}
-    max_bytes = limits[kind]
+    default_bytes, env_var = _INPUT_SIZE_LIMITS[kind]
+    max_bytes = int(os.environ.get(env_var, default_bytes))
     try:
         size = os.path.getsize(path)
     except OSError:
@@ -97,7 +96,7 @@ def check_input_size(path: str, kind: str) -> None:
     if size > max_bytes:
         raise ValueError(
             f"Input file '{path}' is {size} bytes, exceeding the {max_bytes}-byte limit "
-            f"for {kind} inputs. Raise {_SIZE_LIMIT_ENV[kind]} to allow a larger file."
+            f"for {kind} inputs. Raise {env_var} to allow a larger file."
         )
 
 
@@ -105,11 +104,13 @@ def check_raster_width(width: int) -> None:
     """Reject an extreme raster width before the output bitmap is allocated.
 
     A bitmap is width × height × 4 bytes, so an unbounded width (e.g. 100000 px)
-    can demand tens of GB. Reads ``MAX_RASTER_WIDTH`` at call time. Raises
-    ``ValueError`` when exceeded; the caller lets it propagate.
+    can demand tens of GB. Raises ``ValueError`` when exceeded; the caller lets
+    it propagate.
     """
-    if width > MAX_RASTER_WIDTH:
+    default_width, env_var = _RASTER_WIDTH_LIMIT
+    max_width = int(os.environ.get(env_var, default_width))
+    if width > max_width:
         raise ValueError(
-            f"Requested raster width {width}px exceeds the {MAX_RASTER_WIDTH}px limit. "
-            f"Raise BUILD123D_MAX_RASTER_WIDTH to allow a larger raster."
+            f"Requested raster width {width}px exceeds the {max_width}px limit. "
+            f"Raise {env_var} to allow a larger raster."
         )

--- a/src/build123d_mcp/tools/import_step.py
+++ b/src/build123d_mcp/tools/import_step.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from build123d_mcp.tools._paths import safe_input_path
+from build123d_mcp.tools._paths import check_input_size, safe_input_path
 
 _STEP_EXTS = frozenset({".step", ".stp"})
 _STL_EXTS = frozenset({".stl"})
@@ -12,6 +12,8 @@ def import_cad_file(session, path: str, name: str = "") -> str:
     # Reject reads outside the allowed roots (traversal / symlink escape)
     # before touching the filesystem, mirroring safe_output_path on writes.
     resolved = safe_input_path(path)
+    # Reject an oversized file before the (expensive) OCC import begins (#189).
+    check_input_size(resolved, "cad")
     if not os.path.isfile(resolved):
         raise ValueError(f"File not found: '{path}'")
     ext = os.path.splitext(resolved)[1].lower()

--- a/src/build123d_mcp/tools/inspect_drawing.py
+++ b/src/build123d_mcp/tools/inspect_drawing.py
@@ -107,6 +107,9 @@ def _inspect_svg(svg_path: str) -> str:
     # build123d renders Text as filled glyph paths so <text> elements are absent;
     # the sidecar restores label content and measured-length metadata.
     sidecar_path = os.path.splitext(svg_path)[0] + ".dims.json"
+    # The sidecar is a separate caller-influenced file; bound its size too (#189)
+    # so it can't be the unguarded side door the SVG limit above closes.
+    check_input_size(sidecar_path, "svg")
     annotations: dict = {}
     if os.path.isfile(sidecar_path):
         try:

--- a/src/build123d_mcp/tools/inspect_drawing.py
+++ b/src/build123d_mcp/tools/inspect_drawing.py
@@ -5,7 +5,10 @@ import os
 import re
 import xml.etree.ElementTree as ET
 
-from build123d_mcp.tools._paths import safe_input_path
+from defusedxml.common import DefusedXmlException
+from defusedxml.ElementTree import parse as _safe_xml_parse
+
+from build123d_mcp.tools._paths import check_input_size, safe_input_path
 
 
 def _bbox_dict(shape) -> dict | None:
@@ -38,12 +41,17 @@ def _inspect_svg(svg_path: str) -> str:
     # the .dims.json sidecar below derives from this resolved path so it stays
     # within the same validated directory.
     svg_path = safe_input_path(svg_path)
+    check_input_size(svg_path, "svg")
     if not os.path.isfile(svg_path):
         return json.dumps({"error": f"SVG file not found: {svg_path}"})
     try:
-        tree = ET.parse(svg_path)
+        # Hardened parse: defusedxml forbids entity/DTD expansion, so a
+        # billion-laughs SVG is rejected instead of exhausting memory (#189).
+        tree = _safe_xml_parse(svg_path)
     except ET.ParseError as e:
         return json.dumps({"error": f"SVG parse error: {e}"})
+    except DefusedXmlException as e:
+        return json.dumps({"error": f"SVG rejected by XML hardening: {e}"})
 
     root = tree.getroot()
 

--- a/src/build123d_mcp/tools/lint_drawing.py
+++ b/src/build123d_mcp/tools/lint_drawing.py
@@ -272,6 +272,9 @@ def _lint_svg(svg_path: str, drawing_scale: float = 1.0) -> list[dict]:
     walk(tree.getroot(), None)
 
     sidecar = os.path.splitext(svg_path)[0] + ".dims.json"
+    # Bound the sidecar's size too (#189) — it is a separate caller-influenced
+    # file, so the SVG limit above does not cover it.
+    check_input_size(sidecar, "svg")
     if os.path.isfile(sidecar):
         try:
             with open(sidecar) as f:

--- a/src/build123d_mcp/tools/lint_drawing.py
+++ b/src/build123d_mcp/tools/lint_drawing.py
@@ -29,8 +29,10 @@ from build123d_drafting import (
 from build123d_drafting import (
     lint_drawing as _helper_lint,
 )
+from defusedxml.common import DefusedXmlException
+from defusedxml.ElementTree import parse as _safe_xml_parse
 
-from build123d_mcp.tools._paths import safe_input_path
+from build123d_mcp.tools._paths import check_input_size, safe_input_path
 
 # Checks that apply to a single annotation — run per-item so the violation can
 # carry the session object name (the helpers' issues only know the label text).
@@ -234,10 +236,12 @@ def _lint_svg(svg_path: str, drawing_scale: float = 1.0) -> list[dict]:
     # the .dims.json sidecar below derives from this resolved path so it stays
     # within the same validated directory.
     svg_path = safe_input_path(svg_path)
+    check_input_size(svg_path, "svg")
     violations: list[dict] = []
     try:
-        tree = ET.parse(svg_path)
-    except (FileNotFoundError, ET.ParseError) as e:
+        # Hardened parse: defusedxml rejects entity/DTD bombs (#189).
+        tree = _safe_xml_parse(svg_path)
+    except (FileNotFoundError, ET.ParseError, DefusedXmlException) as e:
         return [{"severity": "error", "check": "svg_parse", "object": svg_path, "message": str(e)}]
 
     def walk(elem, inherited_fill):

--- a/src/build123d_mcp/tools/render_drawing.py
+++ b/src/build123d_mcp/tools/render_drawing.py
@@ -11,7 +11,11 @@ resvg-py is already a runtime dep (used by render_view's 2D path).
 import os
 import re
 
-from build123d_mcp.tools._paths import safe_input_path
+from build123d_mcp.tools._paths import (
+    check_input_size,
+    check_raster_width,
+    safe_input_path,
+)
 
 # Build123d emits SVG with physical units (mm/cm/in) on width/height attributes.
 # resvg-py needs unitless pixel-equivalent values; this regex strips the unit.
@@ -31,8 +35,13 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
     Returns dict with at least {png: bytes} and {png_path: str} if save_to.
     On error returns {error: str} so the caller can surface it.
     """
+    # Reject extreme inputs early (#189): an absurd width allocates a huge
+    # bitmap, and an oversized SVG burns parse time — both raise ValueError and
+    # propagate, like the path-policy check below.
+    check_raster_width(width)
     # Reject reads outside the allowed roots before touching the filesystem.
     svg_path = safe_input_path(svg_path)
+    check_input_size(svg_path, "svg")
     if not os.path.isfile(svg_path):
         return {"error": f"SVG file not found: {svg_path}"}
 

--- a/src/build123d_mcp/tools/render_drawing.py
+++ b/src/build123d_mcp/tools/render_drawing.py
@@ -37,8 +37,10 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
     """
     # Reject extreme inputs early (#189): an absurd width allocates a huge
     # bitmap, and an oversized SVG burns parse time — both raise ValueError and
-    # propagate, like the path-policy check below.
-    check_raster_width(width)
+    # propagate, like the path-policy check below. Check the *effective* width
+    # (after the default substitution) since that is what the bitmap uses.
+    out_width = width if width > 0 else 1200
+    check_raster_width(out_width)
     # Reject reads outside the allowed roots before touching the filesystem.
     svg_path = safe_input_path(svg_path)
     check_input_size(svg_path, "svg")
@@ -57,7 +59,6 @@ def render_drawing(svg_path: str, width: int = 0, save_to: str = "") -> dict:
         return {"error": f"Could not read {svg_path}: {e}"}
 
     svg = _UNIT_RE.sub(r'\1="\2"', svg, count=2)
-    out_width = width if width > 0 else 1200
 
     try:
         png = bytes(

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -68,6 +68,15 @@ def test_render_drawing_rejects_extreme_width(tmp_path, monkeypatch):
         render_drawing(svg, width=101)
 
 
+def test_render_drawing_width_check_uses_effective_width(tmp_path, monkeypatch):
+    # width<=0 resolves to the 1200px default; the guard must check that
+    # effective width, not the raw 0, or a sub-1200 cap is silently exceeded.
+    monkeypatch.setenv("BUILD123D_MAX_RASTER_WIDTH", "500")
+    svg = _write(tmp_path, "drawing.svg", _VALID_SVG)
+    with pytest.raises(ValueError, match="raster width"):
+        render_drawing(svg, width=0)
+
+
 def test_render_drawing_allows_normal_width(tmp_path):
     # A sane width still rasterises (guards against an over-tight limit).
     result = render_drawing(_write(tmp_path, "drawing.svg", _VALID_SVG), width=200)

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -7,20 +7,21 @@ exec timeout kills the worker and destroys session state. These tests prove:
   * render_drawing() rejects an extreme raster width (huge bitmap allocation)
     and an oversized SVG file.
   * import_cad_file(), inspect_drawing(), and lint_drawing() reject oversized
-    inputs via the shared ``check_input_size`` preflight.
+    inputs via the shared ``check_input_size`` preflight — including the
+    ``.dims.json`` sidecar, a separate caller-influenced file.
   * inspect_drawing() and lint_drawing() reject an XML entity-expansion
     ("billion laughs") SVG via the hardened defusedxml parser — stdlib
     ElementTree expands such entities and is memory-exhaustible.
 
-Size limits are patched small (instead of writing multi-MB files) so the tests
-stay fast; the real defaults are generous.
+Limits are read from the environment at call time, so the tests set them small
+with monkeypatch.setenv (instead of writing multi-MB files) to stay fast; the
+real defaults are generous.
 """
 
 import json
 
 import pytest
 
-import build123d_mcp.tools._paths as _paths
 from build123d_mcp.session import Session
 from build123d_mcp.tools.import_step import import_cad_file
 from build123d_mcp.tools.inspect_drawing import inspect_drawing
@@ -60,10 +61,11 @@ def _write(tmp_path, name, text) -> str:
 # --- raster width ----------------------------------------------------------
 
 
-def test_render_drawing_rejects_extreme_width(tmp_path):
+def test_render_drawing_rejects_extreme_width(tmp_path, monkeypatch):
+    monkeypatch.setenv("BUILD123D_MAX_RASTER_WIDTH", "100")
     svg = _write(tmp_path, "drawing.svg", _VALID_SVG)
     with pytest.raises(ValueError, match="raster width"):
-        render_drawing(svg, width=_paths.MAX_RASTER_WIDTH + 1)
+        render_drawing(svg, width=101)
 
 
 def test_render_drawing_allows_normal_width(tmp_path):
@@ -77,30 +79,52 @@ def test_render_drawing_allows_normal_width(tmp_path):
 
 
 def test_render_drawing_rejects_oversized_svg(tmp_path, monkeypatch):
-    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    monkeypatch.setenv("BUILD123D_MAX_SVG_BYTES", "10")
     with pytest.raises(ValueError, match="exceeding"):
         render_drawing(_write(tmp_path, "drawing.svg", _VALID_SVG))
 
 
 def test_inspect_drawing_rejects_oversized_svg(session, tmp_path, monkeypatch):
-    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    monkeypatch.setenv("BUILD123D_MAX_SVG_BYTES", "10")
     with pytest.raises(ValueError, match="exceeding"):
         inspect_drawing(session, svg_path=_write(tmp_path, "drawing.svg", _VALID_SVG))
 
 
 def test_lint_drawing_rejects_oversized_svg(session, tmp_path, monkeypatch):
-    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    monkeypatch.setenv("BUILD123D_MAX_SVG_BYTES", "10")
     with pytest.raises(ValueError, match="exceeding"):
         lint_drawing(session, svg_path=_write(tmp_path, "drawing.svg", _VALID_SVG))
 
 
 def test_import_cad_file_rejects_oversized_file(session, tmp_path, monkeypatch):
     # Size is checked before the OCC import, so the file need not be valid CAD.
-    monkeypatch.setattr(_paths, "MAX_CAD_BYTES", 10)
+    monkeypatch.setenv("BUILD123D_MAX_CAD_BYTES", "10")
     big = tmp_path / "big.stl"
     big.write_bytes(b"x" * 100)
     with pytest.raises(ValueError, match="exceeding"):
         import_cad_file(session, str(big))
+
+
+# --- sidecar (.dims.json) size preflight -----------------------------------
+# The sidecar path derives from svg_path, so it must be size-bounded too — a
+# small SVG with a giant sidecar must still be rejected. Set the limit between
+# the two file sizes so only the sidecar trips it.
+
+
+def test_inspect_drawing_rejects_oversized_sidecar(session, tmp_path, monkeypatch):
+    monkeypatch.setenv("BUILD123D_MAX_SVG_BYTES", "1000")
+    svg = _write(tmp_path, "drawing.svg", _VALID_SVG)  # ~130 bytes, under the limit
+    (tmp_path / "drawing.dims.json").write_text(json.dumps({"k": "x" * 5000}))  # over it
+    with pytest.raises(ValueError, match="exceeding"):
+        inspect_drawing(session, svg_path=svg)
+
+
+def test_lint_drawing_rejects_oversized_sidecar(session, tmp_path, monkeypatch):
+    monkeypatch.setenv("BUILD123D_MAX_SVG_BYTES", "1000")
+    svg = _write(tmp_path, "drawing.svg", _VALID_SVG)
+    (tmp_path / "drawing.dims.json").write_text(json.dumps({"k": "x" * 5000}))
+    with pytest.raises(ValueError, match="exceeding"):
+        lint_drawing(session, svg_path=svg)
 
 
 # --- XML entity-expansion (billion laughs) ---------------------------------

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,126 @@
+"""Resource-limit guards for model-supplied file inputs (issue #189).
+
+A model-callable server should reject obviously excessive inputs *before* the
+expensive parse/import/rasterise, rather than letting the work run until the
+exec timeout kills the worker and destroys session state. These tests prove:
+
+  * render_drawing() rejects an extreme raster width (huge bitmap allocation)
+    and an oversized SVG file.
+  * import_cad_file(), inspect_drawing(), and lint_drawing() reject oversized
+    inputs via the shared ``check_input_size`` preflight.
+  * inspect_drawing() and lint_drawing() reject an XML entity-expansion
+    ("billion laughs") SVG via the hardened defusedxml parser — stdlib
+    ElementTree expands such entities and is memory-exhaustible.
+
+Size limits are patched small (instead of writing multi-MB files) so the tests
+stay fast; the real defaults are generous.
+"""
+
+import json
+
+import pytest
+
+import build123d_mcp.tools._paths as _paths
+from build123d_mcp.session import Session
+from build123d_mcp.tools.import_step import import_cad_file
+from build123d_mcp.tools.inspect_drawing import inspect_drawing
+from build123d_mcp.tools.lint_drawing import lint_drawing
+from build123d_mcp.tools.render_drawing import render_drawing
+
+_VALID_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="50mm" height="50mm">\n'
+    '  <rect x="5" y="5" width="40" height="40" fill="green"/>\n'
+    "</svg>"
+)
+
+# Billion-laughs payload: a tiny file whose entities expand exponentially. The
+# hardened parser must reject it at the first entity definition, never expand.
+_BOMB_SVG = (
+    '<?xml version="1.0"?>\n'
+    "<!DOCTYPE lolz [\n"
+    ' <!ENTITY lol "lol">\n'
+    ' <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">\n'
+    ' <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">\n'
+    "]>\n"
+    '<svg xmlns="http://www.w3.org/2000/svg"><text>&lol2;</text></svg>'
+)
+
+
+@pytest.fixture
+def session():
+    return Session()
+
+
+def _write(tmp_path, name, text) -> str:
+    p = tmp_path / name
+    p.write_text(text)
+    return str(p)
+
+
+# --- raster width ----------------------------------------------------------
+
+
+def test_render_drawing_rejects_extreme_width(tmp_path):
+    svg = _write(tmp_path, "drawing.svg", _VALID_SVG)
+    with pytest.raises(ValueError, match="raster width"):
+        render_drawing(svg, width=_paths.MAX_RASTER_WIDTH + 1)
+
+
+def test_render_drawing_allows_normal_width(tmp_path):
+    # A sane width still rasterises (guards against an over-tight limit).
+    result = render_drawing(_write(tmp_path, "drawing.svg", _VALID_SVG), width=200)
+    assert result.get("error") is None
+    assert result["size_bytes"] > 0
+
+
+# --- file size preflight ---------------------------------------------------
+
+
+def test_render_drawing_rejects_oversized_svg(tmp_path, monkeypatch):
+    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    with pytest.raises(ValueError, match="exceeding"):
+        render_drawing(_write(tmp_path, "drawing.svg", _VALID_SVG))
+
+
+def test_inspect_drawing_rejects_oversized_svg(session, tmp_path, monkeypatch):
+    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    with pytest.raises(ValueError, match="exceeding"):
+        inspect_drawing(session, svg_path=_write(tmp_path, "drawing.svg", _VALID_SVG))
+
+
+def test_lint_drawing_rejects_oversized_svg(session, tmp_path, monkeypatch):
+    monkeypatch.setattr(_paths, "MAX_SVG_BYTES", 10)
+    with pytest.raises(ValueError, match="exceeding"):
+        lint_drawing(session, svg_path=_write(tmp_path, "drawing.svg", _VALID_SVG))
+
+
+def test_import_cad_file_rejects_oversized_file(session, tmp_path, monkeypatch):
+    # Size is checked before the OCC import, so the file need not be valid CAD.
+    monkeypatch.setattr(_paths, "MAX_CAD_BYTES", 10)
+    big = tmp_path / "big.stl"
+    big.write_bytes(b"x" * 100)
+    with pytest.raises(ValueError, match="exceeding"):
+        import_cad_file(session, str(big))
+
+
+# --- XML entity-expansion (billion laughs) ---------------------------------
+
+
+def test_inspect_drawing_rejects_xml_bomb(session, tmp_path):
+    result = json.loads(inspect_drawing(session, svg_path=_write(tmp_path, "bomb.svg", _BOMB_SVG)))
+    assert "XML hardening" in result.get("error", "")
+
+
+def test_lint_drawing_rejects_xml_bomb(session, tmp_path):
+    violations = json.loads(
+        lint_drawing(session, svg_path=_write(tmp_path, "bomb.svg", _BOMB_SVG))
+    )["violations"]
+    assert any(v["check"] == "svg_parse" for v in violations)
+
+
+def test_lint_drawing_accepts_normal_svg(session, tmp_path):
+    # The hardened parser must not false-positive on an ordinary SVG.
+    violations = json.loads(lint_drawing(session, svg_path=_write(tmp_path, "ok.svg", _VALID_SVG)))[
+        "violations"
+    ]
+    assert not any(v["check"] == "svg_parse" for v in violations)

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,7 @@ dependencies = [
     { name = "bd-warehouse" },
     { name = "build123d" },
     { name = "build123d-drafting-helpers" },
+    { name = "defusedxml" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]
@@ -135,6 +136,7 @@ requires-dist = [
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
     { name = "build123d-drafting-helpers", specifier = ">=0.4.1" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "mcp" },
     { name = "resvg-py" },
 ]
@@ -467,6 +469,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #189.

A model-callable server should **fail early on obviously excessive inputs** rather than let the work run until the exec timeout kills the worker and destroys session state. Three guards, all env-overridable (the `BUILD123D_*` convention, like `BUILD123D_EXEC_TIMEOUT`):

| Guard | Tool(s) | Default | Why |
|---|---|---|---|
| **Raster width** | `render_drawing(width=…)` | 10000 px | bitmap = w×h×4 bytes; width=100 K ⇒ ~40 GB |
| **File-size preflight** | `import_cad_file`, `render_drawing`, `inspect_drawing`, `lint_drawing` | SVG 20 MB / CAD 200 MB | reject before the parse/OCC import; protects session state |
| **XML hardening** | `inspect_drawing`, `lint_drawing` | — | `defusedxml` forbids entity/DTD expansion |

### Evidence (why XML hardening is warranted, not speculative)
I empirically confirmed on the target Python (3.12):
- **Billion-laughs: real.** stdlib `ET.parse` *expands* internal entities — a tiny SVG → 30 000 chars at depth 4; a deeper bomb → unbounded memory. A size cap does **not** stop it (the bomb is a small file). `defusedxml` raises `EntitiesForbidden`. ✅
- **XXE external-entity: already safe.** stdlib ET refuses external `SYSTEM` entities ("undefined entity") — so that vector needed **no** change.

### Design notes
- Limit rejections **raise `ValueError` and propagate**, consistent with the #188 path-policy contract; operational failures (not-found, resvg error) still return structured `{error}`.
- `check_input_size()` is a **no-op on missing files**, so each tool's existing not-found path is unchanged.
- The shared limits/helpers live in `_paths.py` next to the #188 path policy.

### Explicitly scoped out (documented)
**CAD triangle/topology limits** — these can't be a *cheap* preflight (counting requires the expensive parse itself), so the file-size cap is the feasible proxy. Mentioned here so the omission is a decision, not an oversight.

### Gate
- `uv run mypy src/build123d_mcp/` — clean
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pytest tests/` — **596 passed** (9 new in `tests/test_resource_limits.py`: width, per-tool size preflight, billion-laughs rejection for inspect + lint, normal-SVG happy paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)