### PR TITLE
Revert #200 — VTK subprocess isolation broke macOS render CI

### DIFF
--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -224,16 +224,9 @@ def _add_label_actors(renderer, labels) -> None:
         renderer.AddActor(actor)
 
 
-def _vtk_render_tesselated(
-    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels=None
-) -> bytes:
-    """Pure VTK render from pre-tessellated mesh data.
-
-    shape_data: list of (name, [(x,y,z), ...], [(i,j,k), ...], color_or_None)
-
-    Separated from _do_render_png so it can be called in a subprocess on macOS,
-    where VTK's Cocoa context creation freezes the window server on cold-start.
-    """
+def _do_render_png(
+    shapes, tess, direction, clip_plane, clip_at, azimuth, elevation, labels=None
+) -> tuple[bytes, list[str]]:
     import tempfile
 
     import vtk
@@ -259,15 +252,22 @@ def _vtk_render_tesselated(
         render_window.SetNumberOfLayers(2)
         render_window.AddRenderer(label_renderer)
 
+    failed: list[str] = []
     actor_count = 0
 
-    for i, (name, vert_tuples, tri_list, obj_color) in enumerate(shape_data):
+    for i, (name, shape, obj_color) in enumerate(shapes):
+        try:
+            verts, tris = shape.tessellate(tess["linear_deflection"], tess["angular_deflection"])
+        except Exception as exc:
+            failed.append(f"{name}: {exc}")
+            continue
+
         points = vtk.vtkPoints()
-        for v in vert_tuples:
-            points.InsertNextPoint(v[0], v[1], v[2])
+        for v in verts:
+            points.InsertNextPoint(v.X, v.Y, v.Z)
 
         cells = vtk.vtkCellArray()
-        for tri in tri_list:
+        for tri in tris:
             cells.InsertNextCell(3)
             cells.InsertCellPoint(tri[0])
             cells.InsertCellPoint(tri[1])
@@ -329,7 +329,12 @@ def _vtk_render_tesselated(
         actor_count += 1
 
     if actor_count == 0:
-        raise RuntimeError("No geometry to render")
+        msg = (
+            "All shapes failed to tessellate: " + "; ".join(failed)
+            if failed
+            else "No geometry to render"
+        )
+        raise RuntimeError(msg)
 
     if label_renderer is not None:
         _add_label_actors(label_renderer, labels)
@@ -363,90 +368,7 @@ def _vtk_render_tesselated(
         writer.Write()
 
         with open(png_path, "rb") as f:
-            return f.read()
-
-
-def _vtk_subprocess_worker(conn, shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels):
-    """Module-level worker for multiprocessing.Process (must be top-level to be picklable)."""
-    try:
-        png_bytes = _vtk_render_tesselated(
-            shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-        )
-        conn.send(("ok", png_bytes))
-    except Exception as exc:
-        conn.send(("error", f"{type(exc).__name__}: {exc}"))
-    finally:
-        conn.close()
-
-
-def _do_render_png(
-    shapes, tess, direction, clip_plane, clip_at, azimuth, elevation, labels=None
-) -> tuple[bytes, list[str]]:
-    # Tessellate shapes using build123d (no VTK) so the data is serializable.
-    shape_data = []
-    failed: list[str] = []
-    for name, shape, obj_color in shapes:
-        try:
-            verts, tris = shape.tessellate(tess["linear_deflection"], tess["angular_deflection"])
-            shape_data.append((name, [(v.X, v.Y, v.Z) for v in verts], list(tris), obj_color))
-        except Exception as exc:
-            failed.append(f"{name}: {exc}")
-
-    if not shape_data:
-        msg = (
-            "All shapes failed to tessellate: " + "; ".join(failed)
-            if failed
-            else "No geometry to render"
-        )
-        raise RuntimeError(msg)
-
-    if sys.platform == "darwin":
-        png_bytes = _vtk_render_subprocess(
-            shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-        )
-    else:
-        png_bytes = _vtk_render_tesselated(
-            shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-        )
-    return png_bytes, failed
-
-
-def _vtk_render_subprocess(
-    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels, timeout=120
-) -> bytes:
-    """Run VTK rendering in an isolated subprocess on macOS.
-
-    VTK's Cocoa backend touches the macOS window server on first context
-    creation, which freezes all GUI applications when called from a non-
-    foreground process. Isolating the render in a child process prevents the
-    freeze from locking the MCP server itself, and the timeout+kill ensures
-    the server always recovers even if VTK hangs permanently.
-    """
-    import multiprocessing
-
-    parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
-    p = multiprocessing.Process(
-        target=_vtk_subprocess_worker,
-        args=(child_conn, shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels),
-        daemon=True,
-    )
-    p.start()
-    child_conn.close()
-
-    try:
-        if parent_conn.poll(timeout):
-            try:
-                kind, data = parent_conn.recv()
-            except (EOFError, OSError) as exc:
-                raise RuntimeError(f"VTK render subprocess died unexpectedly: {exc}") from exc
-            if kind == "error":
-                raise RuntimeError(data)
-            return data
-        raise RuntimeError(f"VTK render subprocess timed out after {timeout}s")
-    finally:
-        if p.is_alive():
-            p.kill()
-        p.join(timeout=5)
+            return f.read(), failed
 
 
 def _viewport_origin_for(direction: str, shapes, azimuth: float, elevation: float):


### PR DESCRIPTION
Reverts #200 (`e624268`).

## Why
#200 was merged with **red CI**. Its macOS leg fails two real `render_view` tests:

- `test_outcomes.py::test_mcp_render_returns_image_and_file_path` → `AttributeError: 'TextContent' object has no attribute 'data'`
- `test_worker_boundary_coverage.py::test_session_stateful_tool_sees_worker_state[render_view]` → render produced no file

The VTK-subprocess-on-macOS path #200 introduced returns an error object instead of image bytes on the macOS CI runner. macOS **passed** at the prior commit (#185) and **fails** at #200 — unambiguously #200's regression. This leaves `main` red and blocks the merge queue (e.g. #189).

## Scope
Pure revert of the single squash commit; touches only `src/build123d_mcp/tools/render.py` (back to the pre-#200, known-green state). The macOS window-server-freeze #200 set out to fix returns as a known issue, to be addressed by a corrected forward fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)