### PR TITLE
chore: note macOS VTK render fix in v0.3.39 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
   the codebase was reformatted to match. (#185)
 - `server.json` registry version is kept in sync with the package version. (#181)
 
+### Fixed
+
+- **macOS:** `render_view` isolates VTK rendering in a subprocess to avoid a
+  window-server freeze. (#198)
+
 ### Packaging
 
 - Added per-version Python trove classifiers (3.10–3.12). (#178)


### PR DESCRIPTION
Adds a **### Fixed** line to the v0.3.39 entry for the macOS VTK render fix (#198/#202), which landed in the release window and ships in v0.3.39. Documents the outcome only (the #200→revert→#202 churn nets to the fix shipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)