### PR TITLE
refactor(server): extract CLI/startup into cli.py (#183 part A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Repository = "https://github.com/pzfreo/build123d-mcp"
 Issues = "https://github.com/pzfreo/build123d-mcp/issues"
 
 [project.scripts]
-build123d-mcp = "build123d_mcp.server:main"
+build123d-mcp = "build123d_mcp.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/build123d_mcp"]

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -1,0 +1,171 @@
+"""Command-line entry point for the build123d MCP server.
+
+Parses CLI arguments / environment variables, wires up the ``WorkerSession``,
+and starts the FastMCP server defined in ``server.py``. Kept separate so
+``server.py`` stays focused on tool/resource/prompt registration.
+"""
+
+
+def _cmd_install_skill(argv: list) -> None:
+    import argparse
+    import sys
+
+    from build123d_mcp.tools.install_skill import TARGETS
+    from build123d_mcp.tools.install_skill import install_skill as _install
+
+    p = argparse.ArgumentParser(
+        prog="build123d-mcp install-skill",
+        description="Copy the b123d-drawing skill into the current project for the specified agent.",
+    )
+    p.add_argument(
+        "--target",
+        choices=TARGETS,
+        default="claude",
+        help="Agent to install for (default: claude)",
+    )
+    p.add_argument("--force", action="store_true", help="Overwrite existing installation")
+    args = p.parse_args(argv)
+
+    from build123d_mcp.tools.install_skill import _dest_exists
+
+    if not args.force and _dest_exists(args.target):
+        print(
+            f"Skill already installed for '{args.target}' — use --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(_install(target=args.target, force=args.force))
+
+
+def main():
+    import argparse
+    import os
+    import sys
+    from importlib.metadata import version
+
+    from build123d_mcp import server
+    from build123d_mcp.worker import WorkerSession
+
+    if len(sys.argv) > 1 and sys.argv[1] == "install-skill":
+        _cmd_install_skill(sys.argv[2:])
+        return
+
+    parser = argparse.ArgumentParser(
+        prog="build123d-mcp",
+        description="MCP server for interactive 3D CAD via build123d. Communicates over stdio.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Subcommands:
+  install-skill     Copy the b123d-drawing Claude Code skill into .claude/skills/ of the current project
+                    Usage: build123d-mcp install-skill [--force]
+
+MCP client configuration example:
+  {
+    "mcpServers": {
+      "build123d": {
+        "command": "uv",
+        "args": ["tool", "run", "--python", "3.12", "build123d-mcp", "--library", "/path/to/parts"]
+      }
+    }
+  }
+
+Available tools:
+  execute           Run build123d Python code; errors include automatic fix hints
+  render_view       Render model as PNG (direction, azimuth, elevation, clip_plane, clip_at, save_to)
+  measure           Full geometric summary: volume, area, topology, bbox, center_of_mass, inertia, face_inventory
+  clearance         Minimum distance between two named shapes
+  cross_sections    Cross-sectional areas along X/Y/Z axis at evenly-spaced planes
+  export            Export model to STEP or STL
+  interference      Check intersection volume between two named shapes
+  session_state     Full session JSON: current_shape, all named objects, snapshot names, variables
+  health_check      Verify VTK/SVG/STEP/STL dependencies work end-to-end
+  search_library    Search the part library by keyword (requires --library)
+  load_part         Load a named part with optional parameter overrides (requires --library)
+  save_snapshot     Save a named geometric checkpoint
+  restore_snapshot  Restore geometry from a named checkpoint
+  diff_snapshot     Compare two snapshots; format="json" for structured output
+  last_error        Details of the last failed execute() (type, message, line, excerpt)
+  shape_compare     Compare two named shapes by geometry metrics
+  import_cad_file   Import a STEP or STL file as a named object for comparison
+  repair_hints      Get additional fix suggestions for a given execute() error message
+  version           Return the server version string
+  workflow_hints    Return guidance on using these tools effectively
+  reset             Clear the session (namespace, shapes, snapshots)
+
+Part library file format (Python, any .py file under --library path):
+  PART_INFO = {
+      "description": "Short description",
+      "tags": ["tag1", "tag2"],
+      "parameters": {
+          "width": {"type": "float", "default": 10.0, "description": "width mm"},
+      }
+  }
+  from build123d import *
+  def make(width=10.0):
+      return Box(width, width, width)
+""",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {version('build123d-mcp')}"
+    )
+    parser.add_argument(
+        "--library",
+        metavar="PATH",
+        default=os.environ.get("BUILD123D_PART_LIBRARY", ""),
+        help="Path to part library directory (overrides BUILD123D_PART_LIBRARY env var)",
+    )
+    parser.add_argument(
+        "--allow-all-imports",
+        action="store_true",
+        default=os.environ.get("BUILD123D_ALLOW_ALL_IMPORTS", "").lower() in ("1", "true", "yes"),
+        help="Disable the import allowlist — any Python module can be imported. "
+        "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
+    )
+    parser.add_argument(
+        "--allow-imports",
+        metavar="MODULES",
+        default=os.environ.get("BUILD123D_ALLOW_IMPORTS", ""),
+        help="Comma-separated extra modules added to the import allowlist on top of "
+        "the defaults (e.g. --allow-imports scipy,pandas). Each entry permits the "
+        "named module and all its submodules. Use this for CAD scripts that need "
+        "extra packages without disabling the sandbox via --allow-all-imports. "
+        "Overrides BUILD123D_ALLOW_IMPORTS env var.",
+    )
+    parser.add_argument(
+        "--exec-timeout",
+        metavar="SECONDS",
+        type=int,
+        default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT", "120")),
+        help="Execution time limit in seconds for user code (default: 120). "
+        "Overrides BUILD123D_EXEC_TIMEOUT env var.",
+    )
+    args = parser.parse_args()
+
+    if args.library and not os.path.isdir(args.library):
+        parser.error(f"Library path is not a directory: {args.library}")
+
+    extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
+
+    if args.allow_all_imports or extra_imports:
+        import build123d_mcp.security as _sec
+
+        if args.allow_all_imports:
+            _sec.ALLOW_ALL_IMPORTS = True
+        if extra_imports:
+            _sec.EXTRA_ALLOWED_IMPORTS.update(extra_imports)
+
+    server.configure(
+        WorkerSession(
+            library_path=args.library,
+            allow_all_imports=args.allow_all_imports,
+            extra_allowed_imports=extra_imports,
+            exec_timeout=args.exec_timeout,
+        ),
+        bool(args.library),
+    )
+
+    server.mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -12,6 +12,17 @@ _session: WorkerSession
 _has_library = False
 
 
+def configure(session: WorkerSession, has_library: bool) -> None:
+    """Set the module-level session singleton and library flag.
+
+    Called by ``cli.main()`` at startup; kept here so the tool closures resolve
+    ``_session`` / ``_has_library`` at this module's scope.
+    """
+    global _session, _has_library
+    _session = session
+    _has_library = has_library
+
+
 @mcp.tool()
 def execute(code: str) -> str:
     """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly."""
@@ -728,164 +739,3 @@ Read the build123d://bd_warehouse resource for fastener/bearing/thread catalogue
 Call workflow_hints() if unsure which tool to use next.
 """
     return [PromptMessage(role="user", content=TextContent(type="text", text=text))]
-
-
-def _cmd_install_skill(argv: list) -> None:
-    import argparse
-    import sys
-
-    from build123d_mcp.tools.install_skill import TARGETS
-    from build123d_mcp.tools.install_skill import install_skill as _install
-
-    p = argparse.ArgumentParser(
-        prog="build123d-mcp install-skill",
-        description="Copy the b123d-drawing skill into the current project for the specified agent.",
-    )
-    p.add_argument(
-        "--target",
-        choices=TARGETS,
-        default="claude",
-        help="Agent to install for (default: claude)",
-    )
-    p.add_argument("--force", action="store_true", help="Overwrite existing installation")
-    args = p.parse_args(argv)
-
-    from build123d_mcp.tools.install_skill import _dest_exists
-
-    if not args.force and _dest_exists(args.target):
-        print(
-            f"Skill already installed for '{args.target}' — use --force to overwrite.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    print(_install(target=args.target, force=args.force))
-
-
-def main():
-    import argparse
-    import os
-    import sys
-    from importlib.metadata import version
-
-    if len(sys.argv) > 1 and sys.argv[1] == "install-skill":
-        _cmd_install_skill(sys.argv[2:])
-        return
-
-    parser = argparse.ArgumentParser(
-        prog="build123d-mcp",
-        description="MCP server for interactive 3D CAD via build123d. Communicates over stdio.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""\
-Subcommands:
-  install-skill     Copy the b123d-drawing Claude Code skill into .claude/skills/ of the current project
-                    Usage: build123d-mcp install-skill [--force]
-
-MCP client configuration example:
-  {
-    "mcpServers": {
-      "build123d": {
-        "command": "uv",
-        "args": ["tool", "run", "--python", "3.12", "build123d-mcp", "--library", "/path/to/parts"]
-      }
-    }
-  }
-
-Available tools:
-  execute           Run build123d Python code; errors include automatic fix hints
-  render_view       Render model as PNG (direction, azimuth, elevation, clip_plane, clip_at, save_to)
-  measure           Full geometric summary: volume, area, topology, bbox, center_of_mass, inertia, face_inventory
-  clearance         Minimum distance between two named shapes
-  cross_sections    Cross-sectional areas along X/Y/Z axis at evenly-spaced planes
-  export            Export model to STEP or STL
-  interference      Check intersection volume between two named shapes
-  session_state     Full session JSON: current_shape, all named objects, snapshot names, variables
-  health_check      Verify VTK/SVG/STEP/STL dependencies work end-to-end
-  search_library    Search the part library by keyword (requires --library)
-  load_part         Load a named part with optional parameter overrides (requires --library)
-  save_snapshot     Save a named geometric checkpoint
-  restore_snapshot  Restore geometry from a named checkpoint
-  diff_snapshot     Compare two snapshots; format="json" for structured output
-  last_error        Details of the last failed execute() (type, message, line, excerpt)
-  shape_compare     Compare two named shapes by geometry metrics
-  import_cad_file   Import a STEP or STL file as a named object for comparison
-  repair_hints      Get additional fix suggestions for a given execute() error message
-  version           Return the server version string
-  workflow_hints    Return guidance on using these tools effectively
-  reset             Clear the session (namespace, shapes, snapshots)
-
-Part library file format (Python, any .py file under --library path):
-  PART_INFO = {
-      "description": "Short description",
-      "tags": ["tag1", "tag2"],
-      "parameters": {
-          "width": {"type": "float", "default": 10.0, "description": "width mm"},
-      }
-  }
-  from build123d import *
-  def make(width=10.0):
-      return Box(width, width, width)
-""",
-    )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {version('build123d-mcp')}"
-    )
-    parser.add_argument(
-        "--library",
-        metavar="PATH",
-        default=os.environ.get("BUILD123D_PART_LIBRARY", ""),
-        help="Path to part library directory (overrides BUILD123D_PART_LIBRARY env var)",
-    )
-    parser.add_argument(
-        "--allow-all-imports",
-        action="store_true",
-        default=os.environ.get("BUILD123D_ALLOW_ALL_IMPORTS", "").lower() in ("1", "true", "yes"),
-        help="Disable the import allowlist — any Python module can be imported. "
-        "Use only in trusted environments. Overrides BUILD123D_ALLOW_ALL_IMPORTS env var.",
-    )
-    parser.add_argument(
-        "--allow-imports",
-        metavar="MODULES",
-        default=os.environ.get("BUILD123D_ALLOW_IMPORTS", ""),
-        help="Comma-separated extra modules added to the import allowlist on top of "
-        "the defaults (e.g. --allow-imports scipy,pandas). Each entry permits the "
-        "named module and all its submodules. Use this for CAD scripts that need "
-        "extra packages without disabling the sandbox via --allow-all-imports. "
-        "Overrides BUILD123D_ALLOW_IMPORTS env var.",
-    )
-    parser.add_argument(
-        "--exec-timeout",
-        metavar="SECONDS",
-        type=int,
-        default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT", "120")),
-        help="Execution time limit in seconds for user code (default: 120). "
-        "Overrides BUILD123D_EXEC_TIMEOUT env var.",
-    )
-    args = parser.parse_args()
-
-    if args.library and not os.path.isdir(args.library):
-        parser.error(f"Library path is not a directory: {args.library}")
-
-    extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
-
-    if args.allow_all_imports or extra_imports:
-        import build123d_mcp.security as _sec
-
-        if args.allow_all_imports:
-            _sec.ALLOW_ALL_IMPORTS = True
-        if extra_imports:
-            _sec.EXTRA_ALLOWED_IMPORTS.update(extra_imports)
-
-    global _session, _has_library
-    _has_library = bool(args.library)
-    _session = WorkerSession(
-        library_path=args.library,
-        allow_all_imports=args.allow_all_imports,
-        extra_allowed_imports=extra_imports,
-        exec_timeout=args.exec_timeout,
-    )
-
-    mcp.run()
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Part A of two for **#183** (server.py refactor). Does **not** close the issue — Part B (extract render marshalling) follows separately.

## What
`server.py` mixed MCP tool/resource/prompt registration with CLI parsing, the `install-skill` subcommand, and `main()` startup wiring. This moves the CLI/startup out:

- New `src/build123d_mcp/cli.py` holds `_cmd_install_skill` and `main()` (moved verbatim).
- `server.py` keeps the `_session` / `_has_library` module globals (read by every tool closure) and gains a small `configure(session, has_library)` setter that `cli.main()` calls before `server.mcp.run()`.
- Entry point flips: `pyproject.toml` `server:main` → `cli:main`.

**No behavior change.** `server.py` drops **891 → 741** lines and is now registration + the session-wiring setter.

## Why this is safe
- The live MCP tests (`test_outcomes.py`) launch the `build123d-mcp` **console script** via `uv run`, so the entry-point change is exercised end-to-end — including `test_mcp_lists_all_tools` (pins all 31 tool names) and the render image test.
- The `install-skill` subcommand path is covered by `test_install_skill.py`.
- `test_session_resource.py` monkeypatches `server._session` directly — unaffected (globals stayed in `server.py`).
- No back-compat `server:main` re-export was added (would risk a circular import; nothing references it).

## Gate
- `uv run mypy src/build123d_mcp/` — clean
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pytest tests/` — **599 passed**
- Manual smoke: `build123d-mcp --version` and `build123d-mcp install-skill --help` both work via `cli:main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)