### PR TITLE
refactor(server): extract render marshalling into tools/_marshal.py (#183 part B)

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -1,10 +1,7 @@
-import base64
-import os
-import tempfile
-
 from mcp.server.fastmcp import FastMCP
-from mcp.types import ImageContent, PromptMessage, TextContent
+from mcp.types import PromptMessage, TextContent
 
+from build123d_mcp.tools._marshal import marshal_render_drawing, marshal_render_view
 from build123d_mcp.worker import WorkerSession
 
 mcp = FastMCP("build123d-mcp")
@@ -63,65 +60,7 @@ def render_view(
         mode=mode,
     )
 
-    contents: list = []
-
-    # Helper: prefer the user-requested save_to path (in result["<fmt>_path"])
-    # over a fresh tempfile. When save_to is set, render_view has already
-    # written the file at the requested path; we just need a path to deliver
-    # via the [SEND:] marker. When save_to is empty, fall back to a tempfile.
-    def _path_for(key: str, suffix: str) -> str:
-        saved = result.get(f"{key}_path")
-        if saved:
-            return saved
-        fd, p = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
-        os.close(fd)
-        with open(p, "wb") as f:
-            f.write(result[key])
-        return p
-
-    if "png" in result:
-        path = _path_for("png", ".png")
-        contents.append(
-            ImageContent(
-                type="image",
-                data=base64.b64encode(result["png"]).decode(),
-                mimeType="image/png",
-            )
-        )
-        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
-
-    if "svg" in result:
-        path = _path_for("svg", ".svg")
-        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
-
-    # DXF is a CAD interchange format, not an image — emit only the file marker
-    # so clients deliver the file without the ImageContent base64 round-trip.
-    if "dxf" in result:
-        path = _path_for("dxf", ".dxf")
-        contents.append(
-            TextContent(
-                type="text",
-                text=f"DXF saved: {path}\n[SEND: {path}]",
-            )
-        )
-    if result.get("fallback"):
-        contents.append(TextContent(type="text", text=result["fallback"]))
-    if result.get("png_error"):
-        contents.append(TextContent(type="text", text=f"PNG render failed: {result['png_error']}"))
-    if result.get("png_warnings"):
-        for w in result["png_warnings"]:
-            contents.append(TextContent(type="text", text=f"Warning: {w}"))
-    if result.get("label_warnings"):
-        for w in result["label_warnings"]:
-            contents.append(TextContent(type="text", text=f"Warning: {w}"))
-    if result.get("render_mode"):
-        contents.append(
-            TextContent(
-                type="text",
-                text=f"Rendered via {result['render_mode']} pipeline.",
-            )
-        )
-    return contents
+    return marshal_render_view(result)
 
 
 @mcp.tool()
@@ -268,34 +207,7 @@ def render_drawing(svg_path: str, width: int = 1200, save_to: str = "") -> list:
             delivered inline only.
     """
     result = _session.render_drawing(svg_path, width, save_to)
-
-    if "error" in result:
-        return [TextContent(type="text", text=f"render_drawing error: {result['error']}")]
-
-    contents: list = []
-    if "png" in result:
-        if save_to and result.get("png_path"):
-            path = result["png_path"]
-        else:
-            fd, path = tempfile.mkstemp(suffix=".png", prefix="build123d_drawing_")
-            os.close(fd)
-            with open(path, "wb") as f:
-                f.write(result["png"])
-        contents.append(
-            ImageContent(
-                type="image",
-                data=base64.b64encode(result["png"]).decode(),
-                mimeType="image/png",
-            )
-        )
-        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
-        contents.append(
-            TextContent(
-                type="text",
-                text=f"Rasterised {svg_path} to PNG ({result['size_bytes']} bytes, width={result['width']}px).",
-            )
-        )
-    return contents
+    return marshal_render_drawing(result, svg_path, save_to)
 
 
 @mcp.tool()

--- a/src/build123d_mcp/tools/_marshal.py
+++ b/src/build123d_mcp/tools/_marshal.py
@@ -1,0 +1,106 @@
+"""Marshal worker render results into MCP content lists.
+
+``render_view`` and ``render_drawing`` route through the worker and get back a
+plain ``dict``; turning that into a ``list[ImageContent | TextContent]`` (with
+tempfile fallback for the ``[SEND: …]`` delivery markers) is the only real
+business logic left in those tool wrappers. Kept here so ``server.py`` stays
+registration-only.
+"""
+
+import base64
+import os
+import tempfile
+
+from mcp.types import ImageContent, TextContent
+
+
+def marshal_render_view(result: dict) -> list:
+    contents: list = []
+
+    # Helper: prefer the user-requested save_to path (in result["<fmt>_path"])
+    # over a fresh tempfile. When save_to is set, render_view has already
+    # written the file at the requested path; we just need a path to deliver
+    # via the [SEND:] marker. When save_to is empty, fall back to a tempfile.
+    def _path_for(key: str, suffix: str) -> str:
+        saved = result.get(f"{key}_path")
+        if saved:
+            return saved
+        fd, p = tempfile.mkstemp(suffix=suffix, prefix="build123d_")
+        os.close(fd)
+        with open(p, "wb") as f:
+            f.write(result[key])
+        return p
+
+    if "png" in result:
+        path = _path_for("png", ".png")
+        contents.append(
+            ImageContent(
+                type="image",
+                data=base64.b64encode(result["png"]).decode(),
+                mimeType="image/png",
+            )
+        )
+        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+
+    if "svg" in result:
+        path = _path_for("svg", ".svg")
+        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+
+    # DXF is a CAD interchange format, not an image — emit only the file marker
+    # so clients deliver the file without the ImageContent base64 round-trip.
+    if "dxf" in result:
+        path = _path_for("dxf", ".dxf")
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"DXF saved: {path}\n[SEND: {path}]",
+            )
+        )
+    if result.get("fallback"):
+        contents.append(TextContent(type="text", text=result["fallback"]))
+    if result.get("png_error"):
+        contents.append(TextContent(type="text", text=f"PNG render failed: {result['png_error']}"))
+    if result.get("png_warnings"):
+        for w in result["png_warnings"]:
+            contents.append(TextContent(type="text", text=f"Warning: {w}"))
+    if result.get("label_warnings"):
+        for w in result["label_warnings"]:
+            contents.append(TextContent(type="text", text=f"Warning: {w}"))
+    if result.get("render_mode"):
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"Rendered via {result['render_mode']} pipeline.",
+            )
+        )
+    return contents
+
+
+def marshal_render_drawing(result: dict, svg_path: str, save_to: str) -> list:
+    if "error" in result:
+        return [TextContent(type="text", text=f"render_drawing error: {result['error']}")]
+
+    contents: list = []
+    if "png" in result:
+        if save_to and result.get("png_path"):
+            path = result["png_path"]
+        else:
+            fd, path = tempfile.mkstemp(suffix=".png", prefix="build123d_drawing_")
+            os.close(fd)
+            with open(path, "wb") as f:
+                f.write(result["png"])
+        contents.append(
+            ImageContent(
+                type="image",
+                data=base64.b64encode(result["png"]).decode(),
+                mimeType="image/png",
+            )
+        )
+        contents.append(TextContent(type="text", text=f"[SEND: {path}]"))
+        contents.append(
+            TextContent(
+                type="text",
+                text=f"Rasterised {svg_path} to PNG ({result['size_bytes']} bytes, width={result['width']}px).",
+            )
+        )
+    return contents

--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -1,0 +1,49 @@
+"""Unit tests for the render result-marshalling helpers (tools/_marshal.py).
+
+render_view's marshalling is covered end-to-end by
+test_outcomes.py::test_mcp_render_returns_image_and_file_path; render_drawing's
+marshalled output (ImageContent + [SEND:] marker + "Rasterised …" message) had
+no test, so these lock it after the #183 part-B extraction.
+"""
+
+import base64
+import os
+
+from build123d_mcp.tools._marshal import marshal_render_drawing
+
+_PNG = b"\x89PNG\r\n\x1a\nfake-bytes"
+
+
+def test_marshal_render_drawing_error_branch():
+    out = marshal_render_drawing({"error": "boom"}, "d.svg", "")
+    assert len(out) == 1
+    assert out[0].type == "text"
+    assert out[0].text == "render_drawing error: boom"
+
+
+def test_marshal_render_drawing_png_to_tempfile():
+    out = marshal_render_drawing(
+        {"png": _PNG, "size_bytes": len(_PNG), "width": 120}, "drawing.svg", ""
+    )
+    assert out[0].type == "image"
+    assert out[0].mimeType == "image/png"
+    assert out[0].data == base64.b64encode(_PNG).decode()
+
+    assert out[1].type == "text" and out[1].text.startswith("[SEND: ")
+    sent = out[1].text[len("[SEND: ") : -1]
+    assert os.path.basename(sent).startswith("build123d_drawing_")
+    assert os.path.isfile(sent)
+    os.unlink(sent)
+
+    assert out[2].text == f"Rasterised drawing.svg to PNG ({len(_PNG)} bytes, width=120px)."
+
+
+def test_marshal_render_drawing_uses_save_to_path():
+    # When save_to is set and the worker wrote the file, deliver that path
+    # directly (no tempfile) — preserves the `if save_to and png_path` branch.
+    out = marshal_render_drawing(
+        {"png": _PNG, "png_path": "/tmp/out.png", "size_bytes": 9, "width": 50},
+        "drawing.svg",
+        "/tmp/out.png",
+    )
+    assert out[1].text == "[SEND: /tmp/out.png]"


### PR DESCRIPTION
**Closes #183** (Part B of two — Part A #207 + review cleanup #209 already merged).

## What
`render_view` and `render_drawing` each assembled a `list[ImageContent | TextContent]` (tempfile fallback + `[SEND:]` delivery markers + base64) inline — the last real business logic left in the tool wrappers. Moved **byte-identically** into:
- `tools/_marshal.py::marshal_render_view(result)`
- `tools/_marshal.py::marshal_render_drawing(result, svg_path, save_to)`

The wrappers now just call the worker and `return marshal_*(...)`. (Note: `marshal_render_drawing` takes `save_to` so the exact `if save_to and result.get("png_path")` condition is preserved, not approximated.)

`server.py` drops **741 → 652** lines (**891 → 652** across parts A+B) and is now registration + the `configure()` setter — no business logic. Unused imports (`base64`/`os`/`tempfile`/`ImageContent`) dropped from `server.py`.

## Why it's safe
- **No behavior change** — the moved code is byte-for-byte identical.
- Guarded by `test_outcomes.py::test_mcp_render_returns_image_and_file_path` (asserts `type=image`, `image/png`, PNG magic bytes, `[SEND:]` marker, `.png` suffix, file-on-disk) plus the cookbook render tests.

## Gate
- `uv run mypy src/build123d_mcp/` — clean
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run pytest tests/` — **600 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)