### PR TITLE
fix(render): suppress VTK Cocoa warning spam on macOS (#208)

### DIFF
--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -242,7 +242,10 @@ def _vtk_render_tesselated(
     # Cocoa backend floods the caller's terminal with "Failed to get alpha color
     # buffer size" warnings via its own output channel, escaping stderr
     # redirection (#208). These warnings do not affect the rendered output.
-    vtk.vtkObject.GlobalWarningDisplayOff()
+    # Guard to macOS only: on Linux, VTK uses its warning channel for OSMesa/EGL
+    # init failures; silencing it there would make blank-PNG returns undiagnosable.
+    if sys.platform == "darwin":
+        vtk.vtkObject.GlobalWarningDisplayOff()
 
     _ensure_display()
 

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -238,6 +238,12 @@ def _vtk_render_tesselated(
 
     import vtk
 
+    # Silence VTK's warning stream before any VTK object is created. On macOS the
+    # Cocoa backend floods the caller's terminal with "Failed to get alpha color
+    # buffer size" warnings via its own output channel, escaping stderr
+    # redirection (#208). These warnings do not affect the rendered output.
+    vtk.vtkObject.GlobalWarningDisplayOff()
+
     _ensure_display()
 
     renderer = vtk.vtkRenderer()


### PR DESCRIPTION
## Summary

- Calls `vtk.vtkObject.GlobalWarningDisplayOff()` once, before any VTK object is created, in `_vtk_render_tesselated`
- On macOS the Cocoa backend floods the caller's terminal with `"Failed to get alpha color buffer size"` warnings via its own output channel, escaping stderr redirection
- These warnings are cosmetic noise — they do not affect rendered output

## Notes

- No automated test: the warning is macOS terminal noise only; it cannot be asserted in CI
- `_vtk_render_tesselated` is the correct insertion point (not `_do_render_png`, which no longer exists after the #202 subprocess refactor)

Closes #208