### PR TITLE
feat(execute): append session object names to execute() result (#206)

### DIFF
--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -455,7 +455,9 @@ class Session:
         for name, shape in self.objects.items():
             try:
                 nf = len(shape.faces())
-                result[name] = f"{type(shape).__name__}, {nf} faces" if nf > 0 else type(shape).__name__
+                result[name] = (
+                    f"{type(shape).__name__}, {nf} faces" if nf > 0 else type(shape).__name__
+                )
             except Exception:
                 result[name] = type(shape).__name__
         return result

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -449,6 +449,17 @@ class Session:
 
         return output
 
+    def objects_types(self) -> dict:
+        """Return {name: description} for each named object in the session."""
+        result = {}
+        for name, shape in self.objects.items():
+            try:
+                nf = len(shape.faces())
+                result[name] = f"{type(shape).__name__}, {nf} faces" if nf > 0 else type(shape).__name__
+            except Exception:
+                result[name] = type(shape).__name__
+        return result
+
     def _rollback_namespace(self, values_before: dict[str, Any]) -> None:
         # Delete keys that didn't exist before; restore values for keys that were overwritten.
         current = {k for k in self.namespace if k not in _INJECTED}

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -102,5 +102,13 @@ def execute_code(session, code: str) -> str:
 
         classification = _classify_from_error_string(result)
         result += "\n\n" + json.dumps(classification)
+        return result
+
+    obj_types = session.objects_types()
+    if obj_types:
+        parts = ", ".join(f"{name} ({desc})" for name, desc in obj_types.items())
+    else:
+        parts = "(none)"
+    result = result.rstrip("\n") + f"\n\nSession objects: {parts}"
 
     return result

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -104,11 +104,11 @@ def execute_code(session, code: str) -> str:
         result += "\n\n" + json.dumps(classification)
         return result
 
-    obj_types = session.objects_types()
-    if obj_types:
-        parts = ", ".join(f"{name} ({desc})" for name, desc in obj_types.items())
-    else:
-        parts = "(none)"
-    result = result.rstrip("\n") + f"\n\nSession objects: {parts}"
+    try:
+        obj_types = session.objects_types()
+        parts = ", ".join(f"{name} ({desc})" for name, desc in obj_types.items()) or "(none)"
+        result = result.rstrip("\n") + f"\n\nSession objects: {parts}"
+    except Exception:
+        pass  # don't mask a successful execute if the objects summary fails
 
     return result

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -151,6 +151,9 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
 
         return session_state(session)
 
+    if op == "objects_types":
+        return session.objects_types()
+
     if op == "health_check":
         from build123d_mcp.tools.health_check import health_check
 
@@ -442,6 +445,9 @@ class WorkerSession:
 
     def session_state(self) -> str:
         return self._call("session_state", {}, self._SHORT_TIMEOUT)
+
+    def objects_types(self) -> dict:
+        return self._call("objects_types", {}, self._SHORT_TIMEOUT)
 
     def health_check(self) -> str:
         return self._call("health_check", {}, self._RENDER_TIMEOUT)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -114,6 +114,22 @@ def test_execute_var_summary_absent_on_error(session):
     assert "# vars:" not in result
 
 
+def test_execute_session_objects_appended_on_success(session):
+    result = execute_code(session, "from build123d import *\nshow(Box(1, 1, 1), 'cube')")
+    assert "Session objects:" in result
+    assert "cube" in result
+
+
+def test_execute_session_objects_none_on_empty(session):
+    result = execute_code(session, "x = 42")
+    assert "Session objects: (none)" in result
+
+
+def test_execute_session_objects_absent_on_error(session):
+    result = execute_code(session, "bad syntax !!!")
+    assert "Session objects:" not in result
+
+
 def test_execute_var_summary_tuple_of_scalars_included(session):
     result = execute_code(session, "pt = (1.0, 2.0, 3.0)")
     assert "pt=(1.0, 2.0, 3.0)" in result

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -152,6 +152,11 @@ def _session_state(ws, tmp_path):
     assert "a" in r["objects"] and "b" in r["objects"]
 
 
+def _objects_types(ws, tmp_path):
+    r = ws.objects_types()
+    assert "a" in r and "b" in r
+
+
 def _diff_snapshot(ws, tmp_path):
     # The 'snap' snapshot captured the seeded objects; on an empty worker the
     # missing snapshot yields a non-JSON "Error:" string and json.loads raises.
@@ -213,6 +218,7 @@ SESSION_STATEFUL_TOOLS = {
     "suggest_view_layout": _suggest_view_layout,
     "script": _script,
     "session_state": _session_state,
+    "objects_types": _objects_types,
     "diff_snapshot": _diff_snapshot,
     "save_snapshot": _save_snapshot,
     "restore_snapshot": _restore_snapshot,


### PR DESCRIPTION
## Summary

After a successful `execute()` call, appends a `Session objects: …` line to the result so the LLM knows what named shapes exist in the session without a separate `session_state()` call.

**Example output:**
```
Session objects: part (Solid, 14 faces), sketch (Sketch)
```
When the session has no named objects: `Session objects: (none)`
On error: line is omitted (behaviour unchanged).

## Changes

- `Session.objects_types()` — new method returns `{name: "TypeName[, N faces]"}`; face count shown only when > 0
- `worker.py` — new `"objects_types"` dispatch op + `WorkerSession.objects_types()` proxy
- `tools/execute.py` — calls `session.objects_types()` and appends summary on success
- 3 new tests in `test_tools.py`
- `_objects_types` smoke check added to `test_worker_boundary_coverage.py`

Closes #206