### PR TITLE
Stop slow geometry queries and VTK hangs from destroying the session

### DIFF
--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -423,7 +423,7 @@ def _do_render_png(
 
 
 def _vtk_render_subprocess(
-    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels, timeout=120
+    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels, timeout=100
 ) -> bytes:
     """Run VTK rendering in an isolated subprocess on macOS.
 
@@ -432,6 +432,11 @@ def _vtk_render_subprocess(
     foreground process. Isolating the render in a child process prevents the
     freeze from locking the MCP server itself, and the timeout+kill ensures
     the server always recovers even if VTK hangs permanently.
+
+    The default timeout must stay below WorkerSession._RENDER_TIMEOUT (120s):
+    if both expire together, the parent wins the race and SIGKILLs the whole
+    worker — destroying session state — instead of this guard returning a
+    clean error with the session intact (issue #216).
     """
     import multiprocessing
 

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -272,6 +272,12 @@ class WorkerSession:
     _RENDER_TIMEOUT = 120
     _EXPORT_TIMEOUT = 60
     _INTERFERENCE_TIMEOUT = 30
+    # Geometry-heavy queries (boolean ops, per-face walks, BREP analysis, part
+    # construction) can legitimately exceed 10s on complex parts, and a timeout
+    # here kills the worker and destroys all session state — so the budget errs
+    # generous (issue #214). _SHORT_TIMEOUT is only for ops that read session
+    # bookkeeping without touching geometry kernels.
+    _GEOMETRY_TIMEOUT = 60
     _SHORT_TIMEOUT = 10
 
     def __init__(
@@ -328,7 +334,10 @@ class WorkerSession:
     def _call(self, op: str, args: dict, timeout: int) -> Any:
         if not self._proc.is_alive():
             self._start_worker()
-            raise RuntimeError("Worker crashed; session restarted. Re-run your setup code.")
+            raise RuntimeError(
+                "Worker crashed; session restarted. All session state (variables, "
+                "shapes, named objects, snapshots) has been lost — re-run your setup code."
+            )
 
         self._conn.send({"op": op, "args": args})
 
@@ -349,13 +358,21 @@ class WorkerSession:
                     f"The timeout limit can be raised with the --exec-timeout flag or "
                     f"BUILD123D_EXEC_TIMEOUT env var."
                 )
-            raise RuntimeError(f"Operation '{op}' timed out after {timeout}s.")
+            raise RuntimeError(
+                f"Operation '{op}' timed out after {timeout}s. The worker was killed "
+                f"and restarted — all session state (variables, shapes, named objects, "
+                f"snapshots) has been lost. Re-run your setup code."
+            )
 
         try:
             response = self._conn.recv()
         except EOFError:
             self._start_worker()
-            raise RuntimeError("Worker process crashed unexpectedly; session restarted.")
+            raise RuntimeError(
+                "Worker process crashed unexpectedly; session restarted. All session "
+                "state (variables, shapes, named objects, snapshots) has been lost — "
+                "re-run your setup code."
+            )
 
         if response["ok"]:
             return response["result"]
@@ -422,22 +439,22 @@ class WorkerSession:
         )
 
     def measure(self, object_name: str = "") -> str:
-        return self._call("measure", {"object_name": object_name}, self._SHORT_TIMEOUT)
+        return self._call("measure", {"object_name": object_name}, self._GEOMETRY_TIMEOUT)
 
     def clearance(self, object_a: str, object_b: str) -> str:
         return self._call(
-            "clearance", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT
+            "clearance", {"object_a": object_a, "object_b": object_b}, self._GEOMETRY_TIMEOUT
         )
 
     def cross_sections(self, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
         return self._call(
             "cross_sections",
             {"object_name": object_name, "axis": axis, "num_slices": num_slices},
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def save_snapshot(self, name: str) -> str:
-        return self._call("save_snapshot", {"name": name}, self._SHORT_TIMEOUT)
+        return self._call("save_snapshot", {"name": name}, self._GEOMETRY_TIMEOUT)
 
     def restore_snapshot(self, name: str) -> str:
         return self._call("restore_snapshot", {"name": name}, self._SHORT_TIMEOUT)
@@ -452,7 +469,7 @@ class WorkerSession:
         return self._call(
             "diff_snapshot",
             {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b, "format": format},
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def session_state(self) -> str:
@@ -478,7 +495,7 @@ class WorkerSession:
                 "min_perimeters": min_perimeters,
                 "build_volume": build_volume,
             },
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def health_check(self) -> str:
@@ -489,7 +506,7 @@ class WorkerSession:
 
     def shape_compare(self, object_a: str, object_b: str) -> str:
         return self._call(
-            "shape_compare", {"object_a": object_a, "object_b": object_b}, self._SHORT_TIMEOUT
+            "shape_compare", {"object_a": object_a, "object_b": object_b}, self._GEOMETRY_TIMEOUT
         )
 
     def import_cad_file(self, path: str, name: str = "") -> str:
@@ -550,14 +567,14 @@ class WorkerSession:
         return self._call(
             "align_check",
             {"object_a": object_a, "object_b": object_b, "axis": axis, "mode": mode},
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def resolve(self, object_name: str, selector: str, label: str = "") -> str:
         return self._call(
             "resolve",
             {"object_name": object_name, "selector": selector, "label": label},
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def suggest_view_layout(
@@ -583,7 +600,7 @@ class WorkerSession:
                 "title_block_h": title_block_h,
                 "margin": margin,
             },
-            self._SHORT_TIMEOUT,
+            self._GEOMETRY_TIMEOUT,
         )
 
     def script(self, save_to: str = "") -> str:
@@ -593,4 +610,4 @@ class WorkerSession:
         return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)
 
     def load_part(self, name: str, params: str = "") -> str:
-        return self._call("load_part", {"name": name, "params": params}, self._SHORT_TIMEOUT)
+        return self._call("load_part", {"name": name, "params": params}, self._GEOMETRY_TIMEOUT)

--- a/tests/test_worker_timeouts.py
+++ b/tests/test_worker_timeouts.py
@@ -1,0 +1,136 @@
+"""Timeout-tier routing and session-loss messaging in WorkerSession (issues #214-#216).
+
+A timeout on any worker op SIGKILLs the worker and destroys all session state,
+so geometry-heavy ops must get a budget that complex parts can actually meet
+(#214), every restart path must tell the caller that state was lost (#215),
+and the macOS VTK subprocess guard must fire before the parent's render poll
+so a VTK hang surfaces as a clean error instead of a dead session (#216).
+
+These tests stub the pipe/process layer — no worker subprocess is spawned.
+"""
+
+import inspect
+
+import pytest
+
+from build123d_mcp.security import ExecutionTimeout
+from build123d_mcp.worker import WorkerSession
+
+_STATE_LOSS_MARKER = "has been lost"
+
+
+def _proxy_session(record):
+    """A WorkerSession whose _call only records (op, timeout) — no worker."""
+    ws = WorkerSession.__new__(WorkerSession)
+
+    def _call(op, args, timeout):
+        record.append((op, timeout))
+        return ""
+
+    ws._call = _call
+    ws._exec_timeout = 120
+    return ws
+
+
+def test_geometry_heavy_ops_use_geometry_timeout():
+    record = []
+    ws = _proxy_session(record)
+
+    ws.measure("a")
+    ws.clearance("a", "b")
+    ws.cross_sections("a")
+    ws.shape_compare("a", "b")
+    ws.align_check("a", "b")
+    ws.analyze_printability("a")
+    ws.save_snapshot("s")
+    ws.diff_snapshot("s")
+    ws.resolve("a", ".faces()")
+    ws.suggest_view_layout("a")
+    ws.load_part("p")
+
+    assert all(t == WorkerSession._GEOMETRY_TIMEOUT for _op, t in record), record
+    assert WorkerSession._GEOMETRY_TIMEOUT > WorkerSession._SHORT_TIMEOUT
+
+
+def test_bookkeeping_ops_keep_short_timeout():
+    record = []
+    ws = _proxy_session(record)
+
+    ws.session_state()
+    ws.objects_types()
+    ws.last_error()
+    ws.script()
+    ws.restore_snapshot("s")
+    ws.search_library("q")
+
+    assert all(t == WorkerSession._SHORT_TIMEOUT for _op, t in record), record
+
+
+class _StubConn:
+    """Pipe stand-in: poll() result and recv() behaviour are scripted."""
+
+    def __init__(self, poll_result=True, recv_exc=None):
+        self._poll_result = poll_result
+        self._recv_exc = recv_exc
+
+    def send(self, msg):
+        pass
+
+    def poll(self, timeout=None):
+        return self._poll_result
+
+    def recv(self):
+        if self._recv_exc is not None:
+            raise self._recv_exc
+        return {"ok": True, "result": ""}
+
+
+class _StubProc:
+    def __init__(self, alive=True):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def _stubbed_session(conn, alive=True):
+    ws = WorkerSession.__new__(WorkerSession)
+    ws._conn = conn
+    ws._proc = _StubProc(alive=alive)
+    ws._exec_timeout = 120
+    ws._kill_worker = lambda: None
+    ws._start_worker = lambda: None
+    return ws
+
+
+def test_generic_timeout_message_reports_session_loss():
+    ws = _stubbed_session(_StubConn(poll_result=False))
+    with pytest.raises(RuntimeError, match=_STATE_LOSS_MARKER):
+        ws._call("measure", {}, 1)
+
+
+def test_execute_timeout_message_reports_session_loss():
+    ws = _stubbed_session(_StubConn(poll_result=False))
+    with pytest.raises(ExecutionTimeout, match=_STATE_LOSS_MARKER):
+        ws._call("execute", {"code": "pass"}, 1)
+
+
+def test_dead_worker_message_reports_session_loss():
+    ws = _stubbed_session(_StubConn(), alive=False)
+    with pytest.raises(RuntimeError, match=_STATE_LOSS_MARKER):
+        ws._call("measure", {}, 1)
+
+
+def test_mid_call_crash_message_reports_session_loss():
+    ws = _stubbed_session(_StubConn(recv_exc=EOFError()))
+    with pytest.raises(RuntimeError, match=_STATE_LOSS_MARKER):
+        ws._call("measure", {}, 1)
+
+
+def test_vtk_subprocess_timeout_below_render_poll():
+    # If the inner guard and the parent's poll expire together, the parent
+    # SIGKILLs the worker and the session dies; the inner guard must win.
+    from build123d_mcp.tools.render import _vtk_render_subprocess
+
+    inner = inspect.signature(_vtk_render_subprocess).parameters["timeout"].default
+    assert inner < WorkerSession._RENDER_TIMEOUT


### PR DESCRIPTION
## Summary

Fixes the session-loss-on-timeout issues from the codebase review:

- **#214 — geometry timeout tier.** Adds `_GEOMETRY_TIMEOUT = 60` to `WorkerSession` and moves every op that touches the geometry kernel onto it: `measure`, `clearance`, `cross_sections`, `shape_compare`, `align_check`, `analyze_printability`, `save_snapshot`, `diff_snapshot`, `resolve`, `suggest_view_layout`, `load_part`. These previously shared the 10s `_SHORT_TIMEOUT`, and a timeout SIGKILLs the worker — destroying all session state. `_SHORT_TIMEOUT` now only covers ops that read session bookkeeping (`session_state`, `last_error`, `script`, `restore_snapshot`, `search_library`, drawing inspection, …).

- **#215 — session-loss messaging.** Every worker restart path (generic op timeout, dead-worker detection, mid-call EOFError crash) now states that all session state has been lost and to re-run setup code, matching the existing `execute()` timeout message. Previously the client would keep referencing dead object names and get baffling "Unknown object" errors.

- **#216 — inner VTK guard ordering (partial).** The macOS VTK render subprocess timeout drops from 120s to 100s so it expires before the parent's `_RENDER_TIMEOUT` (120s) poll. **Caveat found in review:** this guard only applies when rendering outside the worker — inside the production worker (`daemon=True`), `_vtk_render_subprocess` falls back to in-process VTK with no inner timeout (`render.py:446`), so the parent poll remains the operative guard there. #216 stays open for an in-worker render timeout guard (e.g. SIGALRM, mirroring `Session.execute`); see the issue for details.

## Testing

- New `tests/test_worker_timeouts.py` (7 tests): timeout-tier routing for heavy vs bookkeeping ops, state-loss wording on all four restart paths, and a guard asserting the inner VTK timeout stays below `_RENDER_TIMEOUT`. All use stubbed pipes — no worker subprocess spawned.
- Full suite: **622 passed** locally.

Closes #214, closes #215. Partially addresses #216 (left open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)