### PR TITLE
Quick wins from codebase review: dead code, injected-helper filtering, mutable defaults, security-doc corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Three layers, all must pass before user code runs:
 2. **Restricted builtins** — exec namespace gets a filtered `__builtins__` dict; `open`, `eval`, `exec`, `compile` removed; `__import__` wrapped to enforce the same allowlist at runtime.
 3. **Exec timeout** — default 120 s wall-clock, configurable via `--exec-timeout` CLI flag or `BUILD123D_EXEC_TIMEOUT` env var. After timeout, the thread continues in background and the namespace may be dirty; callers should `reset()` or `restore_snapshot()`.
 
-Known limits: memory exhaustion is not bounded; Python introspection chains can escape the sandbox.
+Known limits: memory exhaustion is not bounded; Python introspection chains can escape the sandbox; part-library files (`--library`) are trusted input — the AST check on them is non-transitive.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Filesystem I/O modules (`os`, `pathlib`, `shutil`), networking (`socket`, `urlli
 
 This is not a perfect sandbox — memory exhaustion isn't bounded, and Python introspection chains via build123d internals could in principle escape — but it raises the bar significantly against realistic prompt-injection payloads.
 
+**The part library is trusted input.** Files under `--library` run with the same restricted builtins as user code, but the AST check inspects only each file's own top-level imports — it is a guard against accidents, not sandbox-equivalent isolation. Point `--library` only at directories you control, never at untrusted downloads.
+
 ### Extending or relaxing the sandbox
 
 Two CLI flags let you adjust the import policy without giving up the rest of the layers:

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -66,8 +66,11 @@ IMPORT_ALLOWLIST = frozenset(
         "io",
         "warnings",
         "contextlib",
-        # Introspection — signature(), getdoc(), getmembers() are read-only and help with
-        # API discovery without requiring docs. Cannot execute code.
+        # Introspection — signature(), getdoc(), getmembers() are read-only and help
+        # with API discovery without requiring docs. Note: getmembers() returns dunder
+        # attributes by string key, sidestepping the AST dunder block, so introspection
+        # chains through it can still escape the sandbox — accepted as a known limit
+        # (see module docstring) in exchange for API discovery.
         "inspect",
     }
 )

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -162,8 +162,8 @@ def inspect_drawing(objects: str = "", svg_path: str = "") -> str:
 @mcp.tool()
 def view_axes(
     viewport_origin: list[float],
-    viewport_up: list[float] = [0.0, 1.0, 0.0],
-    look_at: list[float] = [0.0, 0.0, 0.0],
+    viewport_up: list[float] | None = None,
+    look_at: list[float] | None = None,
 ) -> str:
     """Return the world→page axis mapping for a project_to_viewport call,
     computed analytically (no projection performed). Use this BEFORE rendering
@@ -180,7 +180,11 @@ def view_axes(
         viewport_up: up vector. Defaults to (0,1,0).
         look_at: target point. Defaults to origin.
     """
-    return _session.view_axes(tuple(viewport_origin), tuple(viewport_up), tuple(look_at))
+    return _session.view_axes(
+        tuple(viewport_origin),
+        tuple(viewport_up) if viewport_up is not None else (0.0, 1.0, 0.0),
+        tuple(look_at) if look_at is not None else (0.0, 0.0, 0.0),
+    )
 
 
 @mcp.tool()

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -41,33 +41,6 @@ _SUGGESTED_FIXES = {
 }
 
 
-def _classify_error(exc: Exception, code: str) -> dict:
-    """Classify an exception into a failure_class with a suggested fix."""
-    from build123d_mcp.security import ExecutionTimeout
-
-    msg = str(exc)
-    msg_lower = msg.lower()
-
-    if "Can't get geom adaptor" in msg:
-        cls = "boolean_fail"
-    elif isinstance(exc, (SyntaxError, IndentationError)):
-        cls = "syntax_error"
-    elif isinstance(exc, AttributeError) and "ShapeList" in msg:
-        cls = "shapelist_attr"
-    elif "ShapeList" in msg or ("index" in msg_lower and "faces" in str(exc)):
-        cls = "selector_empty"
-    elif "fillet" in msg_lower or "non-manifold" in msg_lower:
-        cls = "fillet_fail"
-    elif isinstance(exc, ExecutionTimeout):
-        cls = "timeout"
-    elif "not allowed" in msg:
-        cls = "import_blocked"
-    else:
-        cls = "unknown"
-
-    return {"failure_class": cls, "suggested_fix": _SUGGESTED_FIXES[cls]}
-
-
 def _classify_from_error_string(error_result: str) -> dict:
     """Classify an error string (as returned by session.execute) into a failure_class."""
     msg = error_result

--- a/src/build123d_mcp/tools/session_state.py
+++ b/src/build123d_mcp/tools/session_state.py
@@ -1,9 +1,8 @@
 import json
 import types
 
+from build123d_mcp.session import _INJECTED
 from build123d_mcp.tools.diff import _collect
-
-_SKIP = {"__builtins__", "show"}
 
 
 def _is_imported_symbol(val) -> bool:
@@ -44,7 +43,7 @@ def _namespace_summary(namespace: dict) -> dict:
 
     result = {}
     for name, val in namespace.items():
-        if name.startswith("_") or name in _SKIP:
+        if name.startswith("_") or name in _INJECTED:
             continue
         if _is_imported_symbol(val):
             continue

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1845,6 +1845,17 @@ def test_session_state_with_shape_and_objects(session):
     assert "v1" in data["snapshots"]
 
 
+def test_session_state_variables_exclude_injected_helpers(session):
+    # The injected helpers (show, annotate, named_face, ...) live in the user
+    # namespace but are session plumbing, not user variables (issue #219).
+    from build123d_mcp.session import _INJECTED
+
+    execute_code(session, "x = 5")
+    variables = json.loads(session_state(session))["variables"]
+    assert "x" in variables
+    assert not (_INJECTED & set(variables))
+
+
 # --- diff_snapshot JSON mode ---
 
 


### PR DESCRIPTION
## Summary

Batches the five small, low-risk findings from the codebase review:

- **#218 — dead code.** Deletes `_classify_error` in `tools/execute.py`: zero callers (only the string-based `_classify_from_error_string` is used), and as a near-duplicate the two classifiers would drift.

- **#219 — injected-helper filtering.** `session_state` now uses the canonical `_INJECTED` set from `session.py` instead of a stale two-entry `_SKIP`. The other injected helpers (`annotate`, `named_face`, `set_page`, `register_centerline`) were previously excluded from the variables summary only by coincidence — their closures' `__module__` (`"build123d_mcp.session"`) happens to pass the `startswith("build123d")` imported-symbol check. One source of truth now; regression test added.

- **#223 — mutable defaults.** `view_axes` drops mutable default list args (`[0.0, 1.0, 0.0]`) for the `None`-default pattern used by the other tools. No behaviour change.

- **#224 — inspect comment overstated.** The allowlist comment claimed `inspect` "Cannot execute code", but `getmembers()` returns dunder attributes by string key, sidestepping the AST dunder block — introspection chains through it can escape. Reworded to match the module docstring's known-limits stance.

- **#225 — trusted-library assumption made explicit.** README security section and CLAUDE.md known-limits now state that `--library` part files are trusted input (the AST check on them is non-transitive), so operators don't point it at untrusted directories expecting sandbox-equivalent isolation.

## Testing

- New regression test: `test_session_state_variables_exclude_injected_helpers`.
- Full suite: **623 passed** locally; ruff clean.

Closes #218, closes #219, closes #223, closes #224, closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)