### PR TITLE
docs: fix MCP config examples for recent uv (--upgrade no longer works in uv tool run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The server runs over stdio — the client launches it as a subprocess using `uv 
 
 > **Note on Python version.** All examples below pass `--python 3.12`. VTK and cadquery-ocp do not yet ship wheels for Python 3.13+, so pinning to 3.12 is required. uv will auto-download a managed Python 3.12 if you don't already have one.
 
-> **Note on `--upgrade`.** The examples pass `--upgrade` so each launch re-resolves to the latest published `build123d-mcp` instead of reusing uv's cached environment — without it, the client can stay pinned to whatever version uv first cached and silently miss releases. The trade-off is a short dependency-resolution step at every startup (and it needs network access to check for updates). Drop `--upgrade` if you prefer faster, offline-capable starts and update manually with `uv tool upgrade build123d-mcp`.
+> **Note on `@latest`.** The examples request `build123d-mcp@latest` so each launch re-resolves to the latest published release instead of reusing uv's cached environment — without it, the client can stay pinned to whatever version uv first cached and silently miss releases. The trade-off is a short dependency-resolution step at every startup (and it needs network access to check for updates). Use plain `build123d-mcp` if you prefer faster, offline-capable starts and update manually with `uv tool upgrade build123d-mcp`. (Older versions of this README passed `--upgrade` instead; recent uv ignores that flag in `uv tool run` and warns on every launch — swap to `@latest` if you have the old config.)
 
 ### Claude Code
 
@@ -180,7 +180,7 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
     }
   }
 }
@@ -197,7 +197,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
     }
   }
 }
@@ -214,7 +214,7 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
   "mcpServers": {
     "build123d-mcp": {
       "command": "uv",
-      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
     }
   }
 }
@@ -230,7 +230,7 @@ For **Continue** extension, add to `.continue/config.json`:
     {
       "name": "build123d-mcp",
       "command": "uv",
-      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
     }
   ]
 }
@@ -244,7 +244,7 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
     "build123d-mcp": {
       "type": "stdio",
       "command": "uv",
-      "args": ["tool", "run", "--upgrade", "--python", "3.12", "build123d-mcp"]
+      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Recent uv (verified on 0.9.18) ignores `--upgrade` in `uv tool run` and prints a warning on every launch:

```
warning: Tools cannot be upgraded via `uv tool run`; use `uv tool upgrade --all` to upgrade all
installed tools, or `uv tool run package@latest` to run the latest version of a tool.
```

The README's five MCP client config examples (Claude Code, Claude Desktop, Cursor, Continue, GitHub Copilot) all passed `--upgrade`, so they:

1. emitted that warning on stderr at every server launch, and
2. **silently stayed pinned to uv's cached version** — exactly the stale-version problem the "Note on `--upgrade`" paragraph claimed the flag solved.

## Change

- All five examples now use uv's replacement, the `@latest` specifier:
  ```json
  "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
  ```
- The note paragraph is rewritten around `@latest` (same trade-off explanation: per-launch resolution + network, plain `build123d-mcp` + `uv tool upgrade` for offline starts), with a migration pointer for readers still carrying the old `--upgrade` config.

Verified on uv 0.9.18: `uv tool run --python 3.12 build123d-mcp@latest --version` → `build123d-mcp 0.3.41`, no warning, re-resolves per launch.

Not touched: the `cli.py --help` epilog and CLAUDE.md examples never used `--upgrade`, so they were not broken.

## Testing

README-only change; full suite still passes locally (**623 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)