### PR TITLE
feat: add b123d-modeling skill and MCP server instructions

### DIFF
--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -10,12 +10,12 @@ def _cmd_install_skill(argv: list) -> None:
     import argparse
     import sys
 
-    from build123d_mcp.tools.install_skill import TARGETS
+    from build123d_mcp.tools.install_skill import SKILLS, TARGETS
     from build123d_mcp.tools.install_skill import install_skill as _install
 
     p = argparse.ArgumentParser(
         prog="build123d-mcp install-skill",
-        description="Copy the b123d-drawing skill into the current project for the specified agent.",
+        description="Copy a b123d workflow skill into the current project for the specified agent.",
     )
     p.add_argument(
         "--target",
@@ -23,18 +23,24 @@ def _cmd_install_skill(argv: list) -> None:
         default="claude",
         help="Agent to install for (default: claude)",
     )
+    p.add_argument(
+        "--skill",
+        choices=tuple(SKILLS),
+        default="drawing",
+        help="Workflow to install: drawing or modeling (default: drawing)",
+    )
     p.add_argument("--force", action="store_true", help="Overwrite existing installation")
     args = p.parse_args(argv)
 
     from build123d_mcp.tools.install_skill import _dest_exists
 
-    if not args.force and _dest_exists(args.target):
+    if not args.force and _dest_exists(args.target, skill=args.skill):
         print(
             f"Skill already installed for '{args.target}' — use --force to overwrite.",
             file=sys.stderr,
         )
         sys.exit(1)
-    print(_install(target=args.target, force=args.force))
+    print(_install(target=args.target, force=args.force, skill=args.skill))
 
 
 def main():
@@ -56,8 +62,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Subcommands:
-  install-skill     Copy the b123d-drawing Claude Code skill into .claude/skills/ of the current project
-                    Usage: build123d-mcp install-skill [--force]
+  install-skill     Copy a b123d workflow skill (drawing or modeling) into .claude/skills/ of the current project
+                    Usage: build123d-mcp install-skill [--skill drawing|modeling] [--force]
 
 MCP client configuration example:
   {

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -4,7 +4,27 @@ from mcp.types import PromptMessage, TextContent
 from build123d_mcp.tools._marshal import marshal_render_drawing, marshal_render_view
 from build123d_mcp.worker import WorkerSession
 
-mcp = FastMCP("build123d-mcp")
+_INSTRUCTIONS = """\
+Persistent CAD modeling server for build123d. Use these tools for ANY task that
+builds, modifies, measures, or renders 3D geometry or engineering drawings —
+"model this part", "build this from the technical drawing", "does A fit inside
+B", "make a drawing of X" — instead of writing standalone Python scripts run
+via the shell. The server keeps a persistent build123d session, so you can
+build incrementally with execute(), verify each step numerically with measure()
+(volume, bounding box, face inventory), inspect visually with render_view(),
+check fits with clearance(), and undo experiments with snapshots — a feedback
+loop a one-shot script cannot give.
+
+Quick start: execute("from build123d import *"), build in small steps,
+register parts with show(part, "name"), measure() after every boolean,
+export() when done. Read the build123d://quickref resource before writing
+build code. Step-by-step workflows: build123d://skill/modeling (build 3D
+parts, incl. from technical drawings) and build123d://skill/drawing
+(multi-view engineering drawings); install either into the project with
+install_skill().
+"""
+
+mcp = FastMCP("build123d-mcp", instructions=_INSTRUCTIONS)
 _session: WorkerSession
 
 
@@ -638,26 +658,41 @@ def build123d_drawing_skill() -> str:
     """b123d-drawing engineering workflow skill."""
     from build123d_mcp.tools.install_skill import _load_raw
 
-    return _load_raw()
+    return _load_raw("drawing")
+
+
+@mcp.resource(
+    "build123d://skill/modeling",
+    mime_type="text/plain",
+    description="The b123d-modeling workflow skill: step-by-step guide for building 3D parts and assemblies with build123d via this server — including extracting a spec from a technical drawing, the incremental build/measure/render loop, snapshots, and export.",
+)
+def build123d_modeling_skill() -> str:
+    """b123d-modeling workflow skill."""
+    from build123d_mcp.tools.install_skill import _load_raw
+
+    return _load_raw("modeling")
 
 
 @mcp.tool()
-def install_skill(target: str = "claude", force: bool = False) -> str:
-    """Copy the b123d-drawing engineering drawing skill into the current project.
+def install_skill(target: str = "claude", force: bool = False, skill: str = "drawing") -> str:
+    """Copy a b123d workflow skill into the current project.
 
     Writes the appropriate config file for the requested agent so the
-    step-by-step drawing workflow is available in future sessions.
+    step-by-step workflow is available in future sessions.
 
+    skill: which workflow to install (default "drawing")
+      - drawing   → multi-view engineering drawings from build123d geometry
+      - modeling  → build 3D parts/assemblies (incl. from technical drawings)
     target: one of "claude" (default), "agents-md", "cursor", "windsurf"
-      - claude     → .claude/skills/b123d-drawing/SKILL.md  (Claude Code)
+      - claude     → .claude/skills/<skill-dir>/SKILL.md  (Claude Code)
       - agents-md  → AGENTS.md  (Codex CLI, Antigravity, GitHub Copilot, Cline)
-      - cursor     → .cursor/rules/b123d-drawing.mdc
+      - cursor     → .cursor/rules/<skill-dir>.mdc
       - windsurf   → .windsurfrules
     force: overwrite existing installation (default False)
     """
     from build123d_mcp.tools.install_skill import install_skill as _install
 
-    return _install(target=target, force=force)
+    return _install(target=target, force=force, skill=skill)
 
 
 @mcp.prompt(

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -1,0 +1,140 @@
+# Build 3D Geometry with build123d
+
+Use this skill when asked to model, build, or modify a 3D part or assembly with
+build123d — from a text description, a technical drawing (image or PDF),
+dimensions in a spec, or an existing STEP/STL file.
+
+**Use the build123d-mcp MCP server tools, not standalone Python scripts run with
+the shell.** The server keeps a persistent build123d session, so you build in
+small verified steps — `execute()` → `measure()` → `render_view()` — instead of
+writing one large script and hoping. A one-shot script gives no numeric feedback
+between features, and a single error throws away everything. (The one exception,
+very heavy builds, is covered in Step 5.)
+
+---
+
+## Step 0 — Start the session
+
+1. `reset()`, then `execute("from build123d import *")`.
+2. Read the `build123d://quickref` resource before writing build code — it has
+   accurate API syntax for the current build123d version.
+3. If the part uses fasteners, bearings, or threads, read
+   `build123d://bd_warehouse` and probe catalogue sizes before scripting.
+
+## Step 1 — Extract the spec before modeling
+
+Do not model while reading the input. First convert it into a parameter block.
+
+**From a technical drawing** (image or PDF):
+
+- Identify the views — front / plan (top) / side — and the projection
+  convention; the title block states first- or third-angle, the SCALE
+  (e.g. 2:1), and the units/tolerance standard.
+- Printed dimension callouts are real part dimensions. Never measure the image,
+  and never multiply a printed dimension by the drawing scale.
+- Hidden (dashed) lines are internal features — holes, pockets, bores.
+  Centrelines (long-short chain) mark hole centres and symmetry axes. Section
+  hatching shows solid material in a cut view.
+- Symbols: Ø diameter (not radius), R radius, M6/M8… threads,
+  ⌴ counterbore, ⌵ countersink, typical hole note `4× Ø6.6 THRU`.
+- Cross-check every feature in at least two views before trusting it — a circle
+  in plan with no matching hidden lines in front is probably a boss, not a hole.
+
+Then write the spec as named parameters in your first `execute()`:
+
+```python
+# All dims in mm, from drawing DWG-042 rev B
+LENGTH, WIDTH, HEIGHT = 80.0, 50.0, 12.0
+HOLE_DIA, HOLE_INSET = 6.6, 8.0      # 4x Ø6.6 THRU, 8 from each edge
+FILLET_R = 3.0                        # vertical corners only
+```
+
+[ASK: A dimension I need is missing or two views disagree — which value should I use?]
+if the drawing leaves a critical dimension ambiguous. Do not guess silently.
+
+## Step 2 — Build incrementally
+
+- One feature (or one boolean) per `execute()` call. Small steps are easy to
+  debug; a 60-line block that fails tells you nothing about which line broke.
+- Build from the parameters, never from magic numbers — the part must
+  regenerate when a dimension changes.
+- Register the part under a stable name as soon as it exists:
+  `show(part, "part")`. `show()` prints volume and face count immediately,
+  confirming the shape is non-empty.
+
+## Step 3 — Verify numerically, then visually
+
+`measure()` is the source of truth; renders confirm appearance, not geometry.
+
+- **After every boolean (`-`, `+`, `&`) call `measure()`** and check
+  `topology.faces` changed. Unchanged face/edge counts mean the boolean
+  silently failed.
+- Check the bounding box against the drawing envelope, and the face-type
+  inventory against the features: each plain drilled hole contributes one
+  cylinder face whose diameter must match the callout (Ø6.6 hole → 6.6 mm
+  cylinder in the inventory).
+- Render only after `measure()` agrees with the spec:
+  `render_view(save_to="/tmp/part.png")` [SEND: /tmp/part.png].
+  Use `clip_plane`/`clip_at` to reveal internal features.
+- Assemblies: `clearance("a", "b")` for fit (apart / touching / containing /
+  interpenetrating, with volumes), `align_check()` for flush/concentric checks,
+  and connect parts with Joints (RigidJoint / RevoluteJoint / …) rather than
+  raw `.move()` — see `build123d://quickref`.
+
+## Step 4 — Experiments and recovery
+
+- `save_snapshot("before_fillet")` before any operation you might want to undo;
+  `restore_snapshot()` brings the geometry back (Python variables are NOT
+  restored — re-run assignments).
+- For "what if?" questions, use the loop: snapshot → mutate → measure/render →
+  restore. It is cheaper and more accurate than rebuilding.
+- If an `execute()` times out, the worker restarts and **all session state is
+  lost** — re-run your setup. Keep the build reproducible (Step 6's script) so
+  this costs one paste, not a rebuild from memory. `script()` returns the
+  executed history if you need to reconstruct.
+
+## Step 5 — Heavy builds (threads, gears, many fillets)
+
+The `execute()` timeout (default 120 s) hard-limits a single call. For builds
+with expensive booleans (IsoThread, multi-body fillets, very high face counts):
+
+1. Probe the API in-session with small `execute()` calls.
+2. Write the build as a script and run it with your shell tool.
+3. `import_cad_file("part.step", "part")` to bring the result back in.
+4. Verify as usual: `measure("part")`, `render_view(objects="part")`.
+
+The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
+(this also extends the import budget for heavy STEP files).
+
+## Step 6 — Finish
+
+1. Final `measure()` against the spec: envelope, volume sanity, hole inventory.
+2. `export("part.step", "step", object_name="part")` — STEP for CAD interchange,
+   STL for printing.
+3. Unless the user opts out, save a clean regeneration script to
+   `scripts/<part>.py`: the parameter block, the build steps, and the export
+   call. Follow the project's existing script layout, and pick a non-colliding
+   name if one exists. The part should live in version control as code, not
+   only as a STEP artifact.
+4. If the part will be FDM printed, run `analyze_printability("part")` and
+   report overhangs / thin walls / bed-fit findings.
+5. For an engineering drawing of the finished part, switch to the b123d-drawing
+   skill (or the `build123d://skill/drawing` resource).
+
+---
+
+## Pitfalls
+
+- `Box(...) + Cylinder(...)` returns a **ShapeList**, not a fused Part — it has
+  no `.volume` or `.faces()`. Fuse with `Part() + Box(...) + Cylinder(...)` or
+  `box.fuse(cyl)`.
+- Fillet failures usually mean the radius is too large for the local geometry
+  or the selected edges are non-manifold — reduce the radius or select fewer
+  edges.
+- Selector indices are not stable across rebuilds. Use
+  `resolve("part", ".faces().sort_by(Axis.Z)[-1]", label="top")` to confirm a
+  selector grabs the entity you think it does.
+- Errors from `execute()` come back with a failure classification and fix hint —
+  read them before retrying; `last_error()` has the line number and excerpt.
+- `show()` stores by reference: mutating a shape after `show()` changes the
+  stored object too. Re-`show()` under a new name to keep a frozen copy.

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -23,8 +23,7 @@ SKILLS = {
     "drawing": {
         "dir": "b123d-drawing",
         "cursor_description": (
-            "Engineering drawing workflow for build123d geometry "
-            "using the build123d-mcp MCP server"
+            "Engineering drawing workflow for build123d geometry using the build123d-mcp MCP server"
         ),
         "cursor_globs": "scripts/drawings/**, scripts/*_drawing.py, drawings/**",
     },
@@ -82,11 +81,7 @@ def _cursor_frontmatter(skill: str) -> str:
     spec = SKILLS[skill]
     globs_line = f'globs: "{spec["cursor_globs"]}"\n' if spec["cursor_globs"] else ""
     return (
-        "---\n"
-        f"description: {spec['cursor_description']}\n"
-        f"{globs_line}"
-        "alwaysApply: false\n"
-        "---\n\n"
+        f"---\ndescription: {spec['cursor_description']}\n{globs_line}alwaysApply: false\n---\n\n"
     )
 
 
@@ -170,7 +165,9 @@ def install_skill(
             dest_file.write_text(_replace_or_append(existing, section, skill), encoding="utf-8")
         else:
             dest_file.write_text(section, encoding="utf-8")
-        return f"Installed {skill_dir} skill into {dest_file} (Codex / Antigravity / Copilot / Cline)"
+        return (
+            f"Installed {skill_dir} skill into {dest_file} (Codex / Antigravity / Copilot / Cline)"
+        )
 
     if target == "cursor":
         dest_file = base / ".cursor" / "rules" / f"{skill_dir}.mdc"

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -1,9 +1,13 @@
-"""install_skill — write the b123d-drawing workflow to a project's agent config.
+"""install_skill — write a b123d workflow skill to a project's agent config.
+
+Two skills are available:
+  drawing   → b123d-drawing  (multi-view engineering drawings from geometry)
+  modeling  → b123d-modeling (build 3D parts/assemblies via the MCP session)
 
 Supports four targets:
-  claude     → .claude/skills/b123d-drawing/SKILL.md
+  claude     → .claude/skills/<skill-dir>/SKILL.md
   agents-md  → AGENTS.md  (Codex CLI, Antigravity, GitHub Copilot, Cline)
-  cursor     → .cursor/rules/b123d-drawing.mdc
+  cursor     → .cursor/rules/<skill-dir>.mdc
   windsurf   → .windsurfrules
 """
 
@@ -15,13 +19,39 @@ from pathlib import Path
 
 TARGETS = ("claude", "agents-md", "cursor", "windsurf")
 
-# Delimiters used when appending to shared files (AGENTS.md, .windsurfrules)
+SKILLS = {
+    "drawing": {
+        "dir": "b123d-drawing",
+        "cursor_description": (
+            "Engineering drawing workflow for build123d geometry "
+            "using the build123d-mcp MCP server"
+        ),
+        "cursor_globs": "scripts/drawings/**, scripts/*_drawing.py, drawings/**",
+    },
+    "modeling": {
+        "dir": "b123d-modeling",
+        "cursor_description": (
+            "3D CAD modeling workflow: build parts and assemblies with build123d "
+            "via the build123d-mcp MCP server"
+        ),
+        # No path affinity — the rule is routed by description (agent-requested).
+        "cursor_globs": "",
+    },
+}
+
+# Delimiters used when appending to shared files (AGENTS.md, .windsurfrules).
+# Kept as drawing-skill constants for back-compat with already-installed files.
 _START = "<!-- b123d-drawing:start -->"
 _END = "<!-- b123d-drawing:end -->"
 
 
-def _load_raw() -> str:
-    return (files("build123d_mcp") / "skills" / "b123d-drawing" / "SKILL.md").read_text(
+def _markers(skill: str) -> tuple[str, str]:
+    d = SKILLS[skill]["dir"]
+    return f"<!-- {d}:start -->", f"<!-- {d}:end -->"
+
+
+def _load_raw(skill: str = "drawing") -> str:
+    return (files("build123d_mcp") / "skills" / SKILLS[skill]["dir"] / "SKILL.md").read_text(
         encoding="utf-8"
     )
 
@@ -48,25 +78,29 @@ def _strip_claude_markers(text: str) -> str:
     return text
 
 
-def _cursor_frontmatter() -> str:
+def _cursor_frontmatter(skill: str) -> str:
+    spec = SKILLS[skill]
+    globs_line = f'globs: "{spec["cursor_globs"]}"\n' if spec["cursor_globs"] else ""
     return (
         "---\n"
-        "description: Engineering drawing workflow for build123d geometry using the build123d-mcp MCP server\n"
-        'globs: "scripts/drawings/**, scripts/*_drawing.py, drawings/**"\n'
+        f"description: {spec['cursor_description']}\n"
+        f"{globs_line}"
         "alwaysApply: false\n"
         "---\n\n"
     )
 
 
-def _wrap_section(content: str) -> str:
+def _wrap_section(content: str, skill: str) -> str:
     """Wrap content in delimiters for safe replacement in shared files."""
-    return f"{_START}\n{content.strip()}\n{_END}\n"
+    start, end = _markers(skill)
+    return f"{start}\n{content.strip()}\n{end}\n"
 
 
-def _replace_or_append(existing: str, new_section: str) -> str:
-    """Replace delimited section if present, else append."""
+def _replace_or_append(existing: str, new_section: str, skill: str) -> str:
+    """Replace this skill's delimited section if present, else append."""
+    start, end = _markers(skill)
     pattern = re.compile(
-        re.escape(_START) + r".*?" + re.escape(_END),
+        re.escape(start) + r".*?" + re.escape(end),
         re.DOTALL,
     )
     if pattern.search(existing):
@@ -74,77 +108,88 @@ def _replace_or_append(existing: str, new_section: str) -> str:
     return existing.rstrip() + "\n\n" + new_section
 
 
-def _dest_exists(target: str, cwd: Path | None = None) -> bool:
-    """Return True if the skill is already installed for *target*.
+def _dest_exists(target: str, cwd: Path | None = None, skill: str = "drawing") -> bool:
+    """Return True if *skill* is already installed for *target*.
 
     NOTE: the file-path logic here must stay in sync with install_skill() below.
     If you change a target's destination path, update both functions.
     """
     base = cwd or Path.cwd()
+    skill_dir = SKILLS[skill]["dir"]
+    start, _ = _markers(skill)
     if target == "claude":
-        return (base / ".claude" / "skills" / "b123d-drawing" / "SKILL.md").exists()
+        return (base / ".claude" / "skills" / skill_dir / "SKILL.md").exists()
     if target == "agents-md":
         f = base / "AGENTS.md"
-        return f.exists() and _START in f.read_text(encoding="utf-8")
+        return f.exists() and start in f.read_text(encoding="utf-8")
     if target == "cursor":
-        return (base / ".cursor" / "rules" / "b123d-drawing.mdc").exists()
+        return (base / ".cursor" / "rules" / f"{skill_dir}.mdc").exists()
     if target == "windsurf":
         f = base / ".windsurfrules"
-        return f.exists() and _START in f.read_text(encoding="utf-8")
+        return f.exists() and start in f.read_text(encoding="utf-8")
     return False
 
 
-def install_skill(target: str = "claude", force: bool = False, cwd: Path | None = None) -> str:
-    """Install the b123d-drawing skill into the current project for *target*.
+def install_skill(
+    target: str = "claude",
+    force: bool = False,
+    cwd: Path | None = None,
+    skill: str = "drawing",
+) -> str:
+    """Install a b123d skill into the current project for *target*.
 
     Returns a human-readable status string.
     """
     if target not in TARGETS:
         return f"Unknown target '{target}'. Supported targets: {', '.join(TARGETS)}"
+    if skill not in SKILLS:
+        return f"Unknown skill '{skill}'. Supported skills: {', '.join(SKILLS)}"
 
     base = cwd or Path.cwd()
-    raw = _load_raw()
+    skill_dir = SKILLS[skill]["dir"]
+    start, _ = _markers(skill)
+    raw = _load_raw(skill)
     adapted = _strip_claude_markers(raw)
 
     if target == "claude":
-        dest_dir = base / ".claude" / "skills" / "b123d-drawing"
+        dest_dir = base / ".claude" / "skills" / skill_dir
         dest_file = dest_dir / "SKILL.md"
         if dest_file.exists() and not force:
             return f"Already installed at {dest_file} — use force=True to overwrite."
         dest_dir.mkdir(parents=True, exist_ok=True)
         dest_file.write_text(raw, encoding="utf-8")
-        return f"Installed b123d-drawing skill for Claude Code → {dest_file}"
+        return f"Installed {skill_dir} skill for Claude Code → {dest_file}"
 
     if target == "agents-md":
         dest_file = base / "AGENTS.md"
-        section = _wrap_section(adapted)
+        section = _wrap_section(adapted, skill)
         if dest_file.exists():
             existing = dest_file.read_text(encoding="utf-8")
-            if _START in existing and not force:
-                return f"b123d-drawing section already present in {dest_file} — use force=True to overwrite."
-            dest_file.write_text(_replace_or_append(existing, section), encoding="utf-8")
+            if start in existing and not force:
+                return f"{skill_dir} section already present in {dest_file} — use force=True to overwrite."
+            dest_file.write_text(_replace_or_append(existing, section, skill), encoding="utf-8")
         else:
             dest_file.write_text(section, encoding="utf-8")
-        return f"Installed b123d-drawing skill into {dest_file} (Codex / Antigravity / Copilot / Cline)"
+        return f"Installed {skill_dir} skill into {dest_file} (Codex / Antigravity / Copilot / Cline)"
 
     if target == "cursor":
-        dest_file = base / ".cursor" / "rules" / "b123d-drawing.mdc"
+        dest_file = base / ".cursor" / "rules" / f"{skill_dir}.mdc"
         if dest_file.exists() and not force:
             return f"Already installed at {dest_file} — use force=True to overwrite."
         dest_file.parent.mkdir(parents=True, exist_ok=True)
-        dest_file.write_text(_cursor_frontmatter() + adapted, encoding="utf-8")
-        return f"Installed b123d-drawing rule for Cursor → {dest_file}"
+        dest_file.write_text(_cursor_frontmatter(skill) + adapted, encoding="utf-8")
+        return f"Installed {skill_dir} rule for Cursor → {dest_file}"
 
     if target == "windsurf":
         dest_file = base / ".windsurfrules"
-        section = _wrap_section(adapted)
+        section = _wrap_section(adapted, skill)
         if dest_file.exists():
             existing = dest_file.read_text(encoding="utf-8")
-            if _START in existing and not force:
-                return f"b123d-drawing section already present in {dest_file} — use force=True to overwrite."
-            dest_file.write_text(_replace_or_append(existing, section), encoding="utf-8")
+            if start in existing and not force:
+                return f"{skill_dir} section already present in {dest_file} — use force=True to overwrite."
+            dest_file.write_text(_replace_or_append(existing, section, skill), encoding="utf-8")
         else:
             dest_file.write_text(section, encoding="utf-8")
-        return f"Installed b123d-drawing skill into {dest_file} (Windsurf)"
+        return f"Installed {skill_dir} skill into {dest_file} (Windsurf)"
 
     return "Unreachable"  # mypy

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -32,6 +32,12 @@ def test_load_raw_returns_skill_content():
     assert len(content) > 1000
 
 
+def test_load_raw_modeling_returns_skill_content():
+    content = _load_raw("modeling")
+    assert "Build 3D Geometry" in content
+    assert len(content) > 1000
+
+
 # ---------------------------------------------------------------------------
 # _strip_claude_markers
 # ---------------------------------------------------------------------------
@@ -214,6 +220,86 @@ def test_dest_exists_true_after_install(tmp_path):
 
 def test_dest_exists_unknown_target():
     assert not _dest_exists("unknown")
+
+
+# ---------------------------------------------------------------------------
+# skill: modeling
+# ---------------------------------------------------------------------------
+
+
+def test_install_claude_modeling(tmp_path):
+    result = install_skill(target="claude", cwd=tmp_path, skill="modeling")
+    dest = tmp_path / ".claude" / "skills" / "b123d-modeling" / "SKILL.md"
+    assert dest.exists()
+    assert "Build 3D Geometry" in _read(dest)
+    assert "Installed" in result
+
+
+def test_agents_md_both_skills_coexist(tmp_path):
+    install_skill(target="agents-md", cwd=tmp_path, skill="drawing")
+    install_skill(target="agents-md", cwd=tmp_path, skill="modeling")
+    content = _read(tmp_path / "AGENTS.md")
+    assert "<!-- b123d-drawing:start -->" in content
+    assert "<!-- b123d-modeling:start -->" in content
+    assert "Engineering Drawing" in content
+    assert "Build 3D Geometry" in content
+
+
+def test_agents_md_modeling_force_only_replaces_own_section(tmp_path):
+    install_skill(target="agents-md", cwd=tmp_path, skill="drawing")
+    install_skill(target="agents-md", cwd=tmp_path, skill="modeling")
+    install_skill(target="agents-md", cwd=tmp_path, skill="modeling", force=True)
+    content = _read(tmp_path / "AGENTS.md")
+    assert content.count("<!-- b123d-drawing:start -->") == 1
+    assert content.count("<!-- b123d-modeling:start -->") == 1
+    assert "Engineering Drawing" in content
+
+
+def test_install_cursor_modeling_description_routed(tmp_path):
+    install_skill(target="cursor", cwd=tmp_path, skill="modeling")
+    content = _read(tmp_path / ".cursor" / "rules" / "b123d-modeling.mdc")
+    assert "description:" in content
+    assert "alwaysApply: false" in content
+    # modeling has no path affinity — no globs line at all
+    assert "globs" not in content.split("---")[1]
+
+
+def test_dest_exists_tracks_skills_independently(tmp_path):
+    install_skill(target="claude", cwd=tmp_path, skill="drawing")
+    assert _dest_exists("claude", cwd=tmp_path, skill="drawing")
+    assert not _dest_exists("claude", cwd=tmp_path, skill="modeling")
+
+
+def test_unknown_skill_returns_error():
+    result = install_skill(skill="welding")
+    assert "Unknown skill" in result
+    assert "welding" in result
+
+
+# ---------------------------------------------------------------------------
+# server instructions + skill resources
+# ---------------------------------------------------------------------------
+
+
+def test_server_instructions_registered():
+    # The instructions field is what stays visible when MCP clients defer tool
+    # schemas behind tool search — it must exist and fit the 2KB client cap.
+    from build123d_mcp.server import _INSTRUCTIONS, mcp
+
+    assert mcp.instructions == _INSTRUCTIONS
+    assert 0 < len(_INSTRUCTIONS.encode("utf-8")) <= 2048
+    for needle in ("execute()", "measure()", "skill/modeling", "skill/drawing"):
+        assert needle in _INSTRUCTIONS
+
+
+def test_modeling_skill_resource_registered():
+    import asyncio
+
+    from build123d_mcp.server import mcp
+
+    uris = {str(r.uri) for r in asyncio.run(mcp.list_resources())}
+    assert "build123d://skill/modeling" in uris
+    assert "build123d://skill/drawing" in uris
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

A real session showed Claude (Fable 5) ignoring the installed server for a "build 3D objects from technical drawings" task. Diagnosis: this server exposes 32 tools (~7k tokens of schemas), which puts it in tool-schema-deferral territory in current Claude Code — the model sees only bare tool names plus the server's `instructions` field. And `FastMCP("build123d-mcp")` sent **no** instructions, so nothing explained why `execute`/`measure`/`render_view` beat the model's default move of writing a one-shot build123d script via the shell.

## What

**1. Server instructions** (the field that survives schema deferral, 1,112 bytes — under the documented 2 KB client cap): what the server is for, an explicit "use these tools instead of standalone shell scripts" with the reason (persistent session, numeric verification loop), a quick-start, and pointers to both skill resources. Registered and asserted by test.

**2. New `b123d-modeling` skill** (`skills/b123d-modeling/SKILL.md`, exposed as `build123d://skill/modeling`): the build-side counterpart to the drawing skill, since skills are the strongest task-routing mechanism agents have. Covers:
- extracting a parameter spec from a technical drawing first (views/projection, scale, hidden lines, centrelines, Ø/R/thread/counterbore callouts, two-view cross-checking)
- the incremental `execute → measure → render_view` loop with topology checks after every boolean
- snapshots for what-if experiments, session-loss recovery
- the heavy-build escape hatch (script + `import_cad_file`) and timeout knob
- export + committable regeneration script (with the #230 non-colliding-path rule), `analyze_printability` for FDM parts, handoff to the drawing skill

**3. `install_skill` parameterized**: `skill="drawing"|"modeling"` on the MCP tool and `--skill` on the CLI. Per-skill section markers mean both skills coexist in `AGENTS.md`/`.windsurfrules`; `force` on one skill only replaces its own section (tested). Drawing remains the default everywhere — existing callers and already-installed files are unaffected.

## Testing

- `uv run pytest tests/` — 643 passed (9 new: modeling install across targets, marker coexistence, instructions registration/size, resource listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)