### PR TITLE
docs: estampo handoff in the modeling skill's finish step

### DIFF
--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -110,7 +110,11 @@ The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
 
 1. Final `measure()` against the spec: envelope, volume sanity, hole inventory.
 2. `export("part.step", "step", object_name="part")` — STEP for CAD interchange,
-   STL for printing.
+   STL for printing. If the project slices with
+   [estampo](https://github.com/estampo/estampo) (`estampo.toml` present),
+   add/update the `[[parts]]` entry for the exported file and run `estampo run`
+   instead of stopping at export — apply `analyze_printability` findings as
+   slicer overrides (see estampo's skill).
 3. Unless the user opts out, save a clean regeneration script to
    `scripts/<part>.py`: the parameter block, the build steps, and the export
    call. Follow the project's existing script layout, and pick a non-colliding


### PR DESCRIPTION
## Summary

One addition to the b123d-modeling skill's Step 6 export item: if the project slices with [estampo](https://github.com/estampo/estampo) (`estampo.toml` present), update the `[[parts]]` entry for the exported file and run `estampo run` rather than stopping at export — applying `analyze_printability` findings as slicer overrides.

Reciprocal of estampo/estampo#731, which ships estampo's own Claude Code skill (including the override-mapping table the findings feed into). Together they close the spec → model → verify → STEP → G-code chain for agents.

## Testing

- `uv run pytest tests/` — 643 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)