### PR TITLE
chore: bump augura to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # Import name remains `build123d_drafting` (install name ≠ import name).
     "build123d-drafting-helpers>=0.4.2",
     "defusedxml>=0.7.1",
-    "augura>=0.1.1",
+    "augura>=0.1.2",
 ]
 
 [project.urls]

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -102,6 +102,8 @@ def analyze_printability(
     nozzle: float = 0.4,
     min_perimeters: int = 2,
     build_volume: str = "",
+    bed_tol: float = 0.001,
+    min_feature: float = 0.5,
 ) -> str:
     """Analyse a build123d shape for FDM printability using augura (BREP-exact analysis).
 
@@ -120,9 +122,18 @@ def analyze_printability(
         (default 2).
     build_volume: optional build envelope as 'X Y Z' in mm, e.g. '256 256 256';
         omit to skip the bed-fit check.
+    bed_tol: Z tolerance in mm for identifying bed-contact faces (default 0.001);
+        raise it for parts whose bottom faces sit slightly off Z=0.
+    min_feature: minimum vertical feature size in mm to flag (default 0.5).
     """
     return _session.analyze_printability(
-        object_name, support_angle, nozzle, min_perimeters, build_volume
+        object_name,
+        support_angle,
+        nozzle,
+        min_perimeters,
+        build_volume,
+        bed_tol,
+        min_feature,
     )
 
 

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -113,8 +113,21 @@ The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
    STL for printing. If the project slices with
    [estampo](https://github.com/estampo/estampo) (`estampo.toml` present),
    add/update the `[[parts]]` entry for the exported file and run `estampo run`
-   instead of stopping at export — apply `analyze_printability` findings as
-   slicer overrides (see estampo's skill).
+   instead of stopping at export. To seed the entry's overrides, generate an
+   estampo.toml fragment from the printability report with your shell tool:
+
+   ```bash
+   python -c "
+   import augura
+   from build123d import import_step
+   report = augura.analyze(import_step('part.step'))
+   print(augura.to_estampo_toml(report))
+   "
+   ```
+
+   The fragment sets `enable_support`, `brim_type`, and advisory
+   `[slicer.overrides]` comments — review and merge it into the `[[parts]]`
+   entry rather than pasting blindly (see estampo's skill).
 3. Unless the user opts out, save a clean regeneration script to
    `scripts/<part>.py`: the parameter block, the build steps, and the export
    call. Follow the project's existing script layout, and pick a non-colliding

--- a/src/build123d_mcp/tools/analyze_printability.py
+++ b/src/build123d_mcp/tools/analyze_printability.py
@@ -8,6 +8,8 @@ def analyze_printability(
     nozzle: float = 0.4,
     min_perimeters: int = 2,
     build_volume: str = "",
+    bed_tol: float = 0.001,
+    min_feature: float = 0.5,
 ) -> str:
     """Run augura printability analysis on a named session object."""
     import augura
@@ -41,6 +43,8 @@ def analyze_printability(
         nozzle=nozzle,
         min_perimeters=min_perimeters,
         build_volume=bv,
+        bed_tol=bed_tol,
+        min_feature=min_feature,
     )
 
     data = report.to_dict()

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -260,6 +260,8 @@ def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
             nozzle=args.get("nozzle", 0.4),
             min_perimeters=args.get("min_perimeters", 2),
             build_volume=args.get("build_volume", ""),
+            bed_tol=args.get("bed_tol", 0.001),
+            min_feature=args.get("min_feature", 0.5),
         )
 
     raise ValueError(f"Unknown operation: '{op}'")
@@ -487,6 +489,8 @@ class WorkerSession:
         nozzle: float = 0.4,
         min_perimeters: int = 2,
         build_volume: str = "",
+        bed_tol: float = 0.001,
+        min_feature: float = 0.5,
     ) -> str:
         return self._call(
             "analyze_printability",
@@ -496,6 +500,8 @@ class WorkerSession:
                 "nozzle": nozzle,
                 "min_perimeters": min_perimeters,
                 "build_volume": build_volume,
+                "bed_tol": bed_tol,
+                "min_feature": min_feature,
             },
             self._GEOMETRY_TIMEOUT,
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2199,6 +2199,34 @@ def test_analyze_printability_build_volume(session):
     assert "finding" in result
 
 
+def test_analyze_printability_min_feature_threshold(session):
+    from build123d_mcp.tools.analyze_printability import analyze_printability
+
+    # Box with a 0.3 mm-tall boss on top: flagged at the default
+    # min_feature=0.5, not flagged when the threshold is lowered below it.
+    session.execute(
+        "from build123d import *\n"
+        "base = Box(10, 10, 5)\n"
+        "boss = Box(4, 4, 0.3).move(Location((0, 0, 2.65)))\n"
+        "show(base + boss, 'bossed')\n"
+    )
+    flagged = analyze_printability(session, object_name="bossed")
+    data = json.loads(flagged.split("\n\n", 1)[1])
+    assert any(f["kind"] == "min_feature" for f in data["findings"])
+
+    clean = analyze_printability(session, object_name="bossed", min_feature=0.2)
+    data = json.loads(clean.split("\n\n", 1)[1])
+    assert not any(f["kind"] == "min_feature" for f in data["findings"])
+
+
+def test_analyze_printability_bed_tol_param(session):
+    from build123d_mcp.tools.analyze_printability import analyze_printability
+
+    session.execute("from build123d import *\nshow(Box(10, 10, 5), 'box')")
+    result = analyze_printability(session, object_name="box", bed_tol=0.01)
+    assert "finding" in result
+
+
 def test_analyze_printability_bad_build_volume(session):
     from build123d_mcp.tools.analyze_printability import analyze_printability
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,15 +53,15 @@ wheels = [
 
 [[package]]
 name = "augura"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d" },
     { name = "trimesh" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/38/34d16266304acc1f540acbe38f26224e2e2100330901ab448c716e10d90a/augura-0.1.1.tar.gz", hash = "sha256:51a23edbf0ad0f33b6428f6969575a0d4ded5fe1d97d452eecd552d2a5332a81", size = 83384, upload-time = "2026-06-08T09:25:15.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/b2/eab1a3562da40db0a2c588676d6ad34d7f34805872dc5e0c8aafbf9cab10/augura-0.1.2.tar.gz", hash = "sha256:b9dd7c988f3925483988d5c29b12a4d4cf7cc63c87c94c5ba1a5744d6c38471f", size = 295697, upload-time = "2026-06-10T08:09:17.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/fe/80ce3aec291e896dc99b4b58064098f5240b0b71fa988baf169680966ead/augura-0.1.1-py3-none-any.whl", hash = "sha256:9f1a8176d62a4b8796163ce21bfcad37f8739378ccc019ab104f4118db25f8f2", size = 28536, upload-time = "2026-06-08T09:25:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/2e/fa43f0bb371e0f8ec40655e503f302bc09073df25a6e37b16cef5e23eddc/augura-0.1.2-py3-none-any.whl", hash = "sha256:f260da79617c7c19bac59ffbfe2511741312ca88acd4f8b962af55214def1bc4", size = 34807, upload-time = "2026-06-10T08:09:16.01Z" },
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "augura", specifier = ">=0.1.1" },
+    { name = "augura", specifier = ">=0.1.2" },
     { name = "bd-warehouse" },
     { name = "build123d", specifier = ">=0.10,<0.11" },
     { name = "build123d-drafting-helpers", specifier = ">=0.4.2" },


### PR DESCRIPTION
Updates the augura pin from >=0.1.1 to >=0.1.2, refreshes the lockfile, and adopts the new capabilities where they fit.

## Dependency bump
augura 0.1.2 brings improved wall sampling and orientation tie-breakers, mesh fallback for bed-fit/tip-over/brim checks, a manifold check fix, a CadQuery input adapter, and an estampo.toml output adapter.

## New tool parameters
`analyze_printability` now exposes augura's two new knobs:
- `bed_tol` (default 0.001 mm) — Z tolerance for identifying bed-contact faces
- `min_feature` (default 0.5 mm) — minimum vertical feature size to flag

Threaded through server → WorkerSession → worker dispatch → tool, with behavioral tests (min_feature threshold actually changes findings).

## estampo.toml adapter: skill advice, not a tool
estampo runs as a CLI outside the MCP session, so any workflow that slices already has shell access — a sandboxed MCP tool would produce a file the client couldn't use. The b123d-modeling skill's Step 6 instead shows how to generate the fragment from the exported STEP with `augura.to_estampo_toml`.

## Testing
Full suite: 645 passed (was 643; +2 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
