### PR TITLE
fix: explicit show()/annotate() wins current_shape over the variable scan (#236)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ tools/interference.py — Boolean intersection check between two named shapes
 ## Session model
 
 - **Namespace persists** across `execute()` calls — imports and variables accumulate.
-- **`current_shape`** is auto-detected after each execute: prefers a variable named `result`, then any new `BuildPart` or `Shape`.
+- **`current_shape`** is auto-detected after each execute: an explicit `show()`/`annotate()` in the call wins, then a variable named `result`, then any new `BuildPart` or `Shape`.
 - **`objects` dict** holds named shapes registered via `show(shape, name=None)`. Name defaults to `"shape"` if omitted.
 - **Snapshots** save `current_shape` + `objects` only — the Python namespace is NOT restored on `restore_snapshot()`.
 - **`reset()`** clears everything: namespace, shapes, objects, snapshots.

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -539,8 +539,9 @@ class Session:
             self.current_shape = ns["result"]
             return
 
-        # Scan newly created variables for BuildPart or Shape
-        for key in new_keys:
+        # Scan newly created variables for BuildPart or Shape. Sorted so that
+        # which variable wins is deterministic (set order is hash-seeded).
+        for key in sorted(new_keys):
             if key.startswith("_"):
                 continue
             obj = ns.get(key)

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -29,6 +29,10 @@ class Session:
         self.drawing_page: dict[str, Any] | None = None
         self.geometry_refs: dict[str, Any] = {}
         self.execute_history: list[str] = []
+        # True while the current execute() call has explicitly registered a
+        # shape via show()/annotate()/register_centerline() — blocks the
+        # post-exec variable scan from overriding that registration (#236).
+        self._shape_explicitly_set = False
         self._inject_builtins()
 
     def _inject_builtins(self) -> None:
@@ -129,6 +133,7 @@ class Session:
             drawing_annotations[name] = meta
             objects[name] = shape
             session_ref.current_shape = shape
+            session_ref._shape_explicitly_set = True
             print(f"Annotated '{name}': {meta.get('label_str', '')}")
 
         session_ref.namespace["annotate"] = annotate
@@ -138,6 +143,7 @@ class Session:
                 name = "shape"
             objects[name] = shape
             session_ref.current_shape = shape
+            session_ref._shape_explicitly_set = True
             try:
                 vol = shape.volume
                 faces = len(shape.faces())
@@ -192,6 +198,7 @@ class Session:
             drawing_annotations[name] = {"type": "centerline"}
             objects[name] = shape
             session_ref.current_shape = shape
+            session_ref._shape_explicitly_set = True
             print(f"Registered centerline '{name}'")
 
         self.namespace["register_centerline"] = register_centerline
@@ -305,12 +312,25 @@ class Session:
                 "— boolean may have missed (no intersection?)"
             )
 
-        # Degenerate: previously had volume, now ≈ 0. Failed loft/extrude/intersection.
+        # Degenerate: previously had volume, now ≈ 0. Failed loft/extrude/intersection —
+        # unless the shape is live 2D/1D geometry (a sketch, face, or wire), which has
+        # faces/edges but no solids; an empty boolean result has none of the three (#236).
         if b["vol"] > 1e-9 and a["vol"] < 1e-9:
-            warnings.append(
-                "Warning: resulting shape has volume ≈ 0 — degenerate "
-                "(failed loft/extrude/intersection?)"
-            )
+            try:
+                has_solids = bool(shape.solids())
+            except Exception:
+                has_solids = True  # can't tell — keep the strong warning
+            if not has_solids and (a["faces"] > 0 or a["edges"] > 0):
+                warnings.append(
+                    f"Note: current shape is a {type(shape).__name__} with no solid "
+                    "volume (2D/1D geometry). If this call built a solid, register it "
+                    "with show(part, 'name') or assign it to `result`."
+                )
+            else:
+                warnings.append(
+                    "Warning: resulting shape has volume ≈ 0 — degenerate "
+                    "(failed loft/extrude/intersection?)"
+                )
 
         return diag, warnings
 
@@ -347,6 +367,7 @@ class Session:
         shape_before = self.current_shape
         objects_before = dict(self.objects)
         annotations_before = dict(self.drawing_annotations)
+        self._shape_explicitly_set = False
 
         buf = io.StringIO()
         exc: Exception | None = None
@@ -498,6 +519,14 @@ class Session:
         return {"type": type(exc).__name__, "message": str(exc), "line": lineno, "excerpt": excerpt}
 
     def _update_current_shape(self, new_keys: set[str]) -> None:
+        # show()/annotate()/register_centerline() set current_shape explicitly,
+        # and that registration must win: the new-variable scan below iterates
+        # an unordered set and can land on an incidental leftover (e.g. the
+        # sketch a solid was revolved from), making the degenerate-shape
+        # warning fire on the wrong object (#236).
+        if self._shape_explicitly_set:
+            return
+
         try:
             from build123d import BuildPart, Shape
         except ImportError:

--- a/tests/test_session_resource.py
+++ b/tests/test_session_resource.py
@@ -39,6 +39,8 @@ def test_session_resource_reflects_live_state(patched_server):
     s.execute("show(Cylinder(3, 15), 'pin')")
     s.save_snapshot("v1")
     data = json.loads(srv.build123d_session_state())
-    assert data["current_shape"]["volume"] == pytest.approx(1000, rel=0.01)
+    # show() registers 'pin' as current_shape (explicit registration outranks
+    # the stale `result` Box from the earlier call — #236).
+    assert data["current_shape"]["volume"] == pytest.approx(3**2 * 3.14159 * 15, rel=0.01)
     assert "pin" in data["objects"]
     assert "v1" in data["snapshots"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -206,6 +206,42 @@ def test_execute_warns_on_degenerate(session):
     assert "degenerate" in out
 
 
+def test_show_outranks_leftover_2d_object(session):
+    """A show()-registered solid must not be displaced by a leftover 2D object
+    created in the same execute() — the false 'volume ≈ 0' alarm from #236."""
+    out = execute_code(
+        session,
+        "peg = Cylinder(2, 8)\nsk = Rectangle(1.3, 4.8)\nshow(peg, 'peg')",
+    )
+    assert session.current_shape is session.objects["peg"]
+    assert "degenerate" not in out
+
+
+def test_show_outranks_stale_result_variable(session):
+    """show() in a later call wins over a `result` variable left from an
+    earlier call (#236)."""
+    execute_code(session, "result = Box(10, 10, 5)")
+    execute_code(session, "show(Cylinder(3, 10), 'cyl')")
+    assert session.current_shape is session.objects["cyl"]
+
+
+def test_variable_scan_resumes_after_show_call(session):
+    """The explicit-registration override applies only to the call that made
+    it — the next execute()'s variable scan works as before."""
+    execute_code(session, "show(Box(10, 10, 5), 'base')")
+    execute_code(session, "cyl = Cylinder(3, 10)")
+    assert session.current_shape is session.namespace["cyl"]
+
+
+def test_2d_shape_gets_note_not_degenerate_warning(session):
+    """A live sketch as current shape is reported as 2D geometry, not as a
+    failed boolean (#236)."""
+    execute_code(session, "show(Box(10, 10, 5), 'base')")
+    out = execute_code(session, "sk = Rectangle(5, 5)")
+    assert "degenerate" not in out
+    assert "no solid volume" in out
+
+
 def test_execute_move_does_not_warn(session):
     """A pure translation changes bbox center, not size/topology/volume — must
     not trigger the no-op warning."""


### PR DESCRIPTION
## Problem

#236: an `execute()` that revolved a sketch into a solid and registered it with `show(peg, "peg")` still reported on the leftover sketch, complete with a false `volume ≈ 0 — degenerate` warning. Root cause: `_update_current_shape()` runs *after* exec and overrides the `show()` assignment — it scans an **unordered set** of new variable names and takes the first `Shape` it finds, so which object wins was nondeterministic.

A second latent bug fell out of the same analysis: the "always prefer `result`" branch matches a `result` variable left over from *any earlier call*, so once a session ever used `result`, every later `show()` was silently overridden by the stale shape (a previously-passing test actually encoded this behavior).

## Fix

- A per-call flag is set by `show()` / `annotate()` / `register_centerline()`; when set, `_update_current_shape()` leaves the explicit registration alone. Precedence is now: explicit registration in this call → `result` → new-variable scan.
- The degenerate warning distinguishes live 2D/1D geometry (has faces/edges, no solids → "Note: … no solid volume (2D/1D geometry)") from a genuinely empty boolean result (no solids, faces, or edges → unchanged strong warning).
- `CLAUDE.md` session-model line updated; `test_session_resource_reflects_live_state` updated to the corrected expectation (it was asserting the stale-`result` behavior).

## Tests

4 new tests: show-vs-leftover-2D, show-vs-stale-result, scan resumes next call, 2D note wording. Existing degenerate/boolean-noop warning tests unchanged and passing. Full suite: 649 passed.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)