### PR TITLE
feat: measure() density/material for mass + condensed face inventory (#237, #238)

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -130,15 +130,18 @@ Each named object is rendered in a distinct colour. Call this after each signifi
 ### `measure`
 Return a complete geometric summary of a shape in a single call.
 
-**Input:** `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
+**Input:**
+- `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
+- `density` (float, default `0`) — material density in g/cm³; adds `density_g_cm3` + `mass_g` and scales `inertia` to true mass moments (g·mm²)
+- `material` (string, default `""`) — density preset: `steel`, `stainless`, `aluminum`/`6061`, `brass`, `copper`, `titanium`, `abs`, `pla`, `petg`, `nylon`; mutually exclusive with `density`
 
 **Returns:** JSON with:
-- `volume` (mm³), `area` (mm²)
+- `volume` (mm³), `area` (mm²); plus `density_g_cm3` and `mass_g` when a density was given
 - `topology` — `faces`, `edges`, `vertices`; fastest way to confirm a boolean succeeded (a failed cut leaves counts unchanged)
 - `bounding_box` — per-axis min/max, size, and `center`
 - `center_of_mass` — volumetric centroid
-- `inertia` — 6-component tensor: `Ixx/Iyy/Izz/Ixy/Ixz/Iyz`
-- `face_inventory` — every face classified as `Plane/Cylinder/Cone/Sphere/Torus/BSpline` with area and type-specific params (e.g. cylinder diameter and axis)
+- `inertia` — 6-component tensor: `Ixx/Iyy/Izz/Ixy/Ixz/Iyz`; `inertia_units` states `g·mm²` (density given) or `mm⁵` (volume inertia)
+- `face_inventory` — faces classified as `Plane/Cylinder/Cone/Sphere/Torus/BSpline` with area and type-specific params (e.g. cylinder diameter and axis). Identical faces collapse into one entry with a `count` (4 identical drilled holes → one Cylinder entry, `count: 4`), and non-analytic sliver faces (thread fades) fold into a single `slivers_folded` summary entry
 
 Prefer `measure()` over `render_view()` for verifying geometry — numbers are unambiguous.
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -84,9 +84,9 @@ def render_view(
 
 
 @mcp.tool()
-def measure(object_name: str = "") -> str:
-    """Measure a shape and return a complete geometric summary: volume (mm³), surface area (mm²), topology (face/edge/vertex counts), bounding box with per-axis size and center, volumetric center of mass, 6-component inertia tensor (Ixx/Iyy/Izz/Ixy/Ixz/Iyz), and a face-type inventory classifying every face as Plane/Cylinder/Cone/Sphere/Torus/BSpline with area and type-specific params (e.g. cylinder diameter and axis). Prefer measure over render_view for verifying geometry — numbers are unambiguous. topology is the fastest confirmation that a boolean operation succeeded: a failed cut leaves face/edge/vertex counts unchanged. object_name: named object from show() (default: current shape)."""
-    return _session.measure(object_name)
+def measure(object_name: str = "", density: float = 0.0, material: str = "") -> str:
+    """Measure a shape and return a complete geometric summary: volume (mm³), surface area (mm²), topology (face/edge/vertex counts), bounding box with per-axis size and center, volumetric center of mass, 6-component inertia tensor (Ixx/Iyy/Izz/Ixy/Ixz/Iyz), and a face-type inventory classifying every face as Plane/Cylinder/Cone/Sphere/Torus/BSpline with area and type-specific params (e.g. cylinder diameter and axis); identical faces are collapsed with a count, non-analytic sliver faces folded into one summary line. Prefer measure over render_view for verifying geometry — numbers are unambiguous. topology is the fastest confirmation that a boolean operation succeeded: a failed cut leaves face/edge/vertex counts unchanged. object_name: named object from show() (default: current shape). density (g/cm³) or material preset (steel, stainless, aluminum/6061, brass, copper, titanium, abs, pla, petg, nylon) adds mass_g and scales inertia to true mass moments in g·mm²."""
+    return _session.measure(object_name, density, material)
 
 
 @mcp.tool()

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -72,7 +72,9 @@ if the drawing leaves a critical dimension ambiguous. Do not guess silently.
 - Check the bounding box against the drawing envelope, and the face-type
   inventory against the features: each plain drilled hole contributes one
   cylinder face whose diameter must match the callout (Ø6.6 hole → 6.6 mm
-  cylinder in the inventory).
+  cylinder in the inventory). Identical faces are aggregated — `4× Ø6.6 THRU`
+  shows as ONE cylinder entry with `"count": 4`, so sum the counts, don't
+  count entries.
 - Render only after `measure()` agrees with the spec:
   `render_view(save_to="/tmp/part.png")` [SEND: /tmp/part.png].
   Use `clip_plane`/`clip_at` to reveal internal features.

--- a/src/build123d_mcp/tools/measure.py
+++ b/src/build123d_mcp/tools/measure.py
@@ -1,6 +1,38 @@
 import json
 import math
 
+# Standard densities in g/cm³ for the measure(material=...) presets.
+_DENSITIES = {
+    "steel": 7.85,
+    "stainless": 8.00,
+    "aluminum": 2.70,
+    "6061": 2.70,
+    "brass": 8.50,
+    "copper": 8.96,
+    "titanium": 4.43,
+    "abs": 1.04,
+    "pla": 1.24,
+    "petg": 1.27,
+    "nylon": 1.15,
+}
+
+
+def _resolve_density(density: float, material: str) -> float:
+    """Return the effective density in g/cm³, or 0.0 when none was requested."""
+    if material:
+        if density:
+            raise ValueError("Pass either density or material, not both.")
+        key = material.strip().lower()
+        if key not in _DENSITIES:
+            raise ValueError(
+                f"Unknown material '{material}'. Presets: {', '.join(sorted(_DENSITIES))}. "
+                "Or pass density in g/cm³ directly."
+            )
+        return _DENSITIES[key]
+    if density < 0:
+        raise ValueError("density must be positive (g/cm³).")
+    return density
+
 
 def _resolve_shape(session, object_name: str):
     if object_name:
@@ -93,8 +125,52 @@ def _face_inventory(shape) -> list:
         faces.append(info)
         explorer.Next()
 
-    faces.sort(key=lambda f: (f["type"], -f["area"]))
-    return faces
+    return _condense_inventory(faces)
+
+
+# Analytic surface types stay in the inventory verbatim — their parameters
+# (diameters, axes, angles) are what lets a drawing be verified numerically.
+_ANALYTIC_TYPES = frozenset({"Plane", "Cylinder", "Cone", "Sphere", "Torus"})
+
+
+def _condense_inventory(faces: list) -> list:
+    """Cut inventory noise for LLM consumers (#238): fold non-analytic sliver
+    faces (thread fades etc.) into one summary entry and collapse identical
+    entries into a single record with a count."""
+    total_area = sum(f["area"] for f in faces)
+    # Relative threshold so big parts shed their sliver noise, with an absolute
+    # floor so genuinely small parts keep their genuinely small faces.
+    sliver_threshold = max(0.01, total_area * 1e-4)
+
+    kept: list = []
+    slivers: list = []
+    for f in faces:
+        if f["type"] not in _ANALYTIC_TYPES and f["area"] < sliver_threshold:
+            slivers.append(f)
+        else:
+            kept.append(f)
+
+    # Collapse bit-identical entries (after rounding) into one with a count.
+    grouped: dict = {}
+    for f in kept:
+        key = tuple(sorted(f.items()))
+        if key in grouped:
+            grouped[key]["count"] = grouped[key].get("count", 1) + 1
+        else:
+            grouped[key] = f
+    result = list(grouped.values())
+    result.sort(key=lambda f: (f["type"], -f["area"]))
+
+    if slivers:
+        result.append(
+            {
+                "type": "slivers_folded",
+                "count": len(slivers),
+                "total_area": round(sum(f["area"] for f in slivers), 4),
+                "note": f"non-analytic faces < {round(sliver_threshold, 4)} mm² each",
+            }
+        )
+    return result
 
 
 def _inertia(shape) -> dict:
@@ -183,16 +259,30 @@ def _cross_sections(shape, axis: str = "Z", num_slices: int = 10) -> list:
     return results
 
 
-def measure(session, object_name: str = "") -> str:
+def measure(session, object_name: str = "", density: float = 0.0, material: str = "") -> str:
+    rho = _resolve_density(density, material)
     shape = _resolve_shape(session, object_name)
     bb = shape.bounding_box()
     cx = round((bb.min.X + bb.max.X) / 2, 4)
     cy = round((bb.min.Y + bb.max.Y) / 2, 4)
     cz = round((bb.min.Z + bb.max.Z) / 2, 4)
+
+    inertia = _inertia(shape)
+    mass_fields = {}
+    if rho:
+        # volume mm³ × g/cm³ → g (1 cm³ = 1000 mm³); OCCT's volume inertia
+        # (mm³·mm² = mm⁵) × g/mm³ → true mass moment of inertia in g·mm².
+        mass_fields = {
+            "density_g_cm3": rho,
+            "mass_g": round(shape.volume * rho / 1000, 4),
+        }
+        inertia = {k: round(v * rho / 1000, 4) for k, v in inertia.items()}
+
     return json.dumps(
         {
             "volume": round(shape.volume, 4),
             "area": round(shape.area, 4),
+            **mass_fields,
             "topology": {
                 "faces": len(shape.faces()),
                 "edges": len(shape.edges()),
@@ -211,7 +301,8 @@ def measure(session, object_name: str = "") -> str:
                 "center": {"x": cx, "y": cy, "z": cz},
             },
             "center_of_mass": _center_of_mass(shape),
-            "inertia": _inertia(shape),
+            "inertia": inertia,
+            "inertia_units": "g·mm²" if rho else "mm⁵ (volume inertia; pass density/material)",
             "face_inventory": _face_inventory(shape),
         },
         indent=2,

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -442,8 +442,12 @@ class WorkerSession:
             self._INTERFERENCE_TIMEOUT,
         )
 
-    def measure(self, object_name: str = "") -> str:
-        return self._call("measure", {"object_name": object_name}, self._GEOMETRY_TIMEOUT)
+    def measure(self, object_name: str = "", density: float = 0.0, material: str = "") -> str:
+        return self._call(
+            "measure",
+            {"object_name": object_name, "density": density, "material": material},
+            self._GEOMETRY_TIMEOUT,
+        )
 
     def clearance(self, object_a: str, object_b: str) -> str:
         return self._call(

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -385,6 +385,7 @@ def test_measure_returns_all_fields(session):
     assert "area" in data and data["area"] > 0
     assert "center_of_mass" in data
     assert "inertia" in data
+    assert "inertia_units" in data
     assert "face_inventory" in data
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1945,13 +1945,72 @@ def test_measure_inertia_differs_for_different_shapes(session):
 
 
 def test_measure_face_inventory_box(session):
+    """Six identical 100 mm² planes collapse to one entry with count=6 (#238)."""
     execute_code(session, "result = Box(10, 10, 10)")
     data = json.loads(measure(session))
     fi = data["face_inventory"]
     assert isinstance(fi, list)
-    assert len(fi) == 6
-    assert all(f["type"] == "Plane" for f in fi)
-    assert all(abs(f["area"] - 100) < 1 for f in fi)
+    assert len(fi) == 1
+    assert fi[0]["type"] == "Plane"
+    assert abs(fi[0]["area"] - 100) < 1
+    assert fi[0]["count"] == 6
+
+
+def test_condense_inventory_folds_non_analytic_slivers():
+    """Thread-fade sliver BSplines fold into one summary line; analytic faces
+    are kept verbatim however small; identical entries aggregate (#238)."""
+    from build123d_mcp.tools.measure import _condense_inventory
+
+    faces = (
+        [{"type": "BSpline", "area": 0.001} for _ in range(23)]
+        + [{"type": "BSpline", "area": 22.17} for _ in range(6)]
+        + [{"type": "Cylinder", "area": 50.0, "diameter": 6.6, "axis": (0, 0, 1)}]
+        + [{"type": "Plane", "area": 0.001}]
+    )
+    out = _condense_inventory(faces)
+    big_bsplines = [f for f in out if f["type"] == "BSpline"]
+    assert len(big_bsplines) == 1 and big_bsplines[0]["count"] == 6
+    assert [f for f in out if f["type"] == "Cylinder"]
+    assert [f for f in out if f["type"] == "Plane"]  # analytic sliver survives
+    folded = [f for f in out if f["type"] == "slivers_folded"]
+    assert len(folded) == 1 and folded[0]["count"] == 23
+    assert folded[0]["total_area"] == pytest.approx(0.023)
+
+
+def test_measure_density_reports_mass(session):
+    """volume mm³ × g/cm³ / 1000 = grams (#237)."""
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(measure(session, density=7.85))
+    assert data["density_g_cm3"] == 7.85
+    assert data["mass_g"] == pytest.approx(7.85, rel=1e-3)
+    assert data["inertia_units"] == "g·mm²"
+
+
+def test_measure_material_preset(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    data = json.loads(measure(session, material="brass"))
+    assert data["mass_g"] == pytest.approx(8.5, rel=1e-3)
+
+
+def test_measure_density_scales_inertia(session):
+    """With density the volume inertia (mm⁵) becomes mass inertia (g·mm²)."""
+    execute_code(session, "result = Box(10, 10, 10)")
+    plain = json.loads(measure(session))
+    dense = json.loads(measure(session, density=2.0))
+    assert plain["inertia_units"].startswith("mm⁵")
+    assert dense["inertia"]["Ixx"] == pytest.approx(plain["inertia"]["Ixx"] * 2.0 / 1000, rel=1e-3)
+
+
+def test_measure_density_and_material_conflict(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="not both"):
+        measure(session, density=1.0, material="steel")
+
+
+def test_measure_unknown_material_raises(session):
+    execute_code(session, "result = Box(10, 10, 10)")
+    with pytest.raises(ValueError, match="Unknown material"):
+        measure(session, material="unobtainium")
 
 
 def test_measure_face_inventory_cylinder(session):


### PR DESCRIPTION
## #237 — mass and physical inertia

`measure()` gains `density` (g/cm³) and `material` (preset: steel, stainless, aluminum/6061, brass, copper, titanium, abs, pla, petg, nylon). When either is given the response adds `density_g_cm3` + `mass_g` and scales the inertia tensor to true mass moments; a new `inertia_units` field states `g·mm²` vs the previous ambiguous `mm⁵ (volume inertia)`. Passing both, an unknown preset, or a negative density raises a clear error.

## #238 — face-inventory noise

`_face_inventory` now runs through `_condense_inventory`:
- **Identical entries collapse** to one record with `count` (`6 × BSpline @ 22.17 mm²` as the issue asked; a plain Box is now one line instead of six).
- **Non-analytic slivers fold** into a single `slivers_folded` summary (count + total area). Threshold is `max(0.01 mm², 0.01% of total area)` — relative so big threaded parts shed fade noise, floored so tiny parts keep their genuinely small faces.
- **Analytic faces (Plane/Cylinder/Cone/Sphere/Torus) are never folded** — their diameters/axes are the high-value verification data.

## Wiring

Worker proxy + server tool signature updated; `_dispatch` already forwards kwargs. Tool docstring extended by one sentence each (token-budget conscious, #217).

## Tests

8 new/updated: mass from density, preset, inertia scaling, conflict + unknown-material errors, box aggregation, synthetic sliver-folding unit test. Full suite: 655 passed; ruff clean.

Closes #237
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)