### PR TITLE
feat: advertise companion packages in version()/hints; export sanity echo (#240, #241)

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -45,11 +45,11 @@ show(axle, "axle")
 ## Tools
 
 ### `version`
-Return the server version string.
+Return installed versions of the server, key dependencies, and companion packages importable inside `execute()` (`bd_warehouse` for threads/fasteners/gears/bearings, `augura` for printability analysis).
 
 **No inputs.**
 
-**Returns:** version string, e.g. `"0.3.5"`
+**Returns:** one `name: version` line per package
 
 ---
 
@@ -194,7 +194,7 @@ Export a shape to a file.
 - `format` (string, default `"step"`) — `"step"`, `"stl"`, `"dxf"`, `"svg"`, or comma-separated like `"step,stl"` or `"dxf,svg"`. 3D solids → step/stl; 2D Sketches/dimensioned drawings → dxf/svg. Mixing dimensions across that boundary errors with a clear pointer at the right tool.
 - `object_name` (string, default `""`) — named object from `show()`; `"*"` to export all named objects as a combined assembly; empty = `current_shape`
 
-**Returns:** path(s) of exported file(s)
+**Returns:** path(s) of exported file(s), plus a sanity line echoing the exported shape's volume/bbox/face count (bbox/edge count for 2D) — confirms the right, non-degenerate object was written
 
 STEP preserves exact geometry for downstream CAD tools. STL is for mesh-based workflows (3D printing, slicers, GitHub preview).
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -145,7 +145,7 @@ def cross_sections(object_name: str = "", axis: str = "Z", num_slices: int = 10)
 
 @mcp.tool()
 def export(filename: str, format: str = "step", object_name: str = "") -> str:
-    """Export model. format: step, stl, dxf, svg, or comma-separated list e.g. 'step,stl' or 'dxf,svg'. 3D shapes (solids) export to step/stl; 2D shapes (Sketches and dimensioned drawings composed via build123d.drafting) export to dxf/svg. Mixing 2D and 3D formats for the same shape errors with a clear message. object_name: named object from show(), '*' to export all named shapes as a combined assembly (default: current shape). STEP exports carry the session names as labels — single-object exports use the object_name, '*' exports produce a Compound labelled 'assembly' with each child labelled by its show() name. Downstream CAD tools (FreeCAD, Fusion) will see the structured assembly with named bodies. Use dxf for engineering-drawing handoff to other CAD tools; svg for embedding in docs/wikis."""
+    """Export model. format: step, stl, dxf, svg, or comma-separated list e.g. 'step,stl' or 'dxf,svg'. 3D shapes (solids) export to step/stl; 2D shapes (Sketches and dimensioned drawings composed via build123d.drafting) export to dxf/svg. Mixing 2D and 3D formats for the same shape errors with a clear message. object_name: named object from show(), '*' to export all named shapes as a combined assembly (default: current shape). STEP exports carry the session names as labels — single-object exports use the object_name, '*' exports produce a Compound labelled 'assembly' with each child labelled by its show() name. Downstream CAD tools (FreeCAD, Fusion) will see the structured assembly with named bodies. Use dxf for engineering-drawing handoff to other CAD tools; svg for embedding in docs/wikis. The result echoes the exported shape's volume/bbox/face count (or bbox/edge count for 2D) as a final sanity check that the right, non-degenerate object was written."""
     return _session.export_file(filename, format, object_name)
 
 
@@ -402,7 +402,7 @@ def last_error() -> str:
 
 @mcp.tool()
 def version() -> str:
-    """Return the installed versions of the build123d-mcp server and its key dependencies (build123d, build123d-drafting-helpers). Use this to confirm which server build is running — e.g. to check whether a feature or fix is present, or whether the client is talking to a stale install."""
+    """Return the installed versions of the build123d-mcp server, its key dependencies (build123d, build123d-drafting-helpers), and the companion packages importable inside execute() (bd_warehouse for threads/fasteners/gears/bearings, augura for printability analysis). Use this to confirm which server build is running — e.g. to check whether a feature or fix is present, or whether the client is talking to a stale install."""
     # Computed in-process (pure importlib.metadata, same venv as the worker), so
     # it still answers when the worker subprocess is down — exactly the stale /
     # broken-install case this tool exists to diagnose.
@@ -468,7 +468,10 @@ BUILD123D-MCP WORKFLOW GUIDE
    Call load_part("name", '{"param": value}') immediately — no second lookup needed.
    Unspecified parameters use the defaults shown in search results.
 
-9. BD_WAREHOUSE FASTENERS
+9. BD_WAREHOUSE FASTENERS, THREADS, GEARS, BEARINGS
+   bd_warehouse ships with this server — import it directly in execute() instead of
+   hand-rolling threads, fasteners, gears, or bearings (a 5-line Thread beats a fiddly
+   helical sweep). version() lists installed companion packages.
    Read the build123d://bd_warehouse resource before scripting any fastener geometry.
    Always probe sizes before writing the script to get the correct string format:
      execute('from bd_warehouse.fastener import CounterSunkScrew; print(CounterSunkScrew.sizes("iso10642"))')

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -141,6 +141,21 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
         _write_one(shape, abs_path, fmt)
         exported.append(abs_path)
 
+    # Echo what was written so the (typically final) export step doubles as a
+    # sanity check that the right, non-degenerate object landed in the file (#241).
+    sanity = _sanity_line(shape)
+    suffix = f"\n{sanity}" if sanity else ""
     if len(exported) == 1:
-        return f"Exported to {exported[0]}"
-    return "Exported to:\n" + "\n".join(exported)
+        return f"Exported to {exported[0]}{suffix}"
+    return "Exported to:\n" + "\n".join(exported) + suffix
+
+
+def _sanity_line(shape) -> str:
+    try:
+        bb = shape.bounding_box()
+        size = f"{bb.size.X:.4g}×{bb.size.Y:.4g}×{bb.size.Z:.4g} mm"
+        if _is_2d(shape):
+            return f"2D drawing: bbox {size}, {len(shape.edges())} edges"
+        return f"volume {shape.volume:.4g} mm³, bbox {size}, {len(shape.faces())} faces"
+    except Exception:
+        return ""

--- a/src/build123d_mcp/tools/version.py
+++ b/src/build123d_mcp/tools/version.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _dist_version
 
-# distribution names (as on PyPI); these double as the display labels
-_PACKAGES = ("build123d-mcp", "build123d", "build123d-drafting-helpers")
+# distribution names (as on PyPI); these double as the display labels.
+# Companion packages importable inside execute() (bd_warehouse, augura) are
+# listed so agents can discover them instead of hand-rolling threads/gears (#240).
+_PACKAGES = ("build123d-mcp", "build123d", "build123d-drafting-helpers", "bd_warehouse", "augura")
 
 
 def version_info() -> dict:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1224,6 +1224,25 @@ def test_export_multi_format(session, tmp_path, monkeypatch):
     assert ".stl" in result
 
 
+def test_export_echoes_sanity_line_3d(session, tmp_path, monkeypatch):
+    """Export result reports volume/bbox/faces of the written solid (#241)."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "result = Box(10, 10, 10)")
+    result = export_file(session, "out", "step")
+    assert "volume 1000" in result
+    assert "10×10×10 mm" in result
+    assert "6 faces" in result
+
+
+def test_export_echoes_sanity_line_2d(session, tmp_path, monkeypatch):
+    """2D exports report bbox/edge count instead of volume (#241)."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Rectangle(20, 10), 'sk')")
+    result = export_file(session, "out", "dxf", object_name="sk")
+    assert "2D drawing" in result
+    assert "edges" in result
+
+
 def test_export_invalid_format(session):
     execute_code(session, "result = Box(10, 10, 10)")
     with pytest.raises(ValueError, match="Unknown format"):
@@ -2205,9 +2224,19 @@ def test_version_returns_package_versions():
 
     info = version_info()
     assert isinstance(info, dict)
-    for key in ("build123d-mcp", "build123d", "build123d-drafting-helpers"):
+    for key in (
+        "build123d-mcp",
+        "build123d",
+        "build123d-drafting-helpers",
+        "bd_warehouse",
+        "augura",
+    ):
         assert key in info, f"version_info() missing key {key!r}"
         assert isinstance(info[key], str) and info[key], f"empty version for {key}"
+    # Companion packages are hard deps of this distribution — they must report
+    # a real version, otherwise the #240 discoverability promise is broken.
+    assert info["bd_warehouse"] != "unknown"
+    assert info["augura"] != "unknown"
 
 
 def test_version_build123d_mcp_matches_metadata():


### PR DESCRIPTION
## #240 — companion-package discoverability

- `version()` adds `bd_warehouse` and `augura` (the packages importable inside `execute()`) to its report; both are hard deps, and a test pins that they never report "unknown".
- `workflow_hints()` section 9 now opens with "bd_warehouse ships with this server — import it directly instead of hand-rolling threads, fasteners, gears, or bearings".
- Deliberately **not** added to the first-execute banner the issue floated as an option: that would tax every session (including ones that never need threads) — `version()` + `workflow_hints()` + the modeling skill's Step 0.3 cover the discovery paths.

## #241 (export half) — final sanity echo

`export()` results now append one line: `volume 1000 mm³, bbox 10×10×10 mm, 6 faces` (or `2D drawing: bbox …, N edges` for dxf/svg). Wrapped in a broad try so an echo failure can never break a successful export.

The render-temp-path half of #241 is deliberately not changed — the `[SEND:]` marker is the delivery mechanism for clients without inline image rendering; rationale will be posted on the issue.

## Tests

4 new/updated: 3D echo content, 2D echo content, version_info includes both companions with real versions. llms.md and docstrings updated. Full suite: 657 passed; ruff clean.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)