### PR TITLE
feat: find_edges() session helper for fillet/chamfer selection (#239)

### DIFF
--- a/src/build123d_mcp/quickref.py
+++ b/src/build123d_mcp/quickref.py
@@ -314,7 +314,8 @@ show(result, "part_unchanged_by_private")""",
 ## MCP server conventions
 - Name the final shape 'result' OR call show() — both trigger current_shape auto-detection
 - show(shape, "name")      registers object, prints vol + face count as immediate confirmation
-- named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right""",
+- named_face(shape, "top") returns the highest-Z face; also: bottom/front/back/left/right
+- find_edges(shape, geom="circle", radius=4.25, at_z=10.2) filters edges for fillet/chamfer; prints count + radii + Z levels""",
     ),
     Section(
         text="""\

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -41,7 +41,7 @@ def configure(session: WorkerSession) -> None:
 
 @mcp.tool()
 def execute(code: str) -> str:
-    """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly."""
+    """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly. find_edges(shape, geom='circle', radius=4.25, at_z=10.2, length=None, tol=0.05) filters edges for fillet/chamfer selection and prints what matched."""
     from build123d_mcp.tools.execute import execute_code
 
     return execute_code(_session, code)

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -13,7 +13,15 @@ from build123d_mcp.security import (
 
 # Names injected by the session itself — excluded from rollback and new-key detection.
 _INJECTED = frozenset(
-    {"__builtins__", "show", "named_face", "annotate", "register_centerline", "set_page"}
+    {
+        "__builtins__",
+        "show",
+        "named_face",
+        "find_edges",
+        "annotate",
+        "register_centerline",
+        "set_page",
+    }
 )
 
 
@@ -226,6 +234,72 @@ class Session:
                     )
 
         self.namespace["named_face"] = named_face
+
+        def find_edges(
+            shape: Any,
+            geom: str | None = None,
+            radius: float | None = None,
+            at_z: float | None = None,
+            length: float | None = None,
+            tol: float = 0.05,
+        ) -> Any:
+            """Filter shape.edges() by geometry type, radius, Z position, and/or
+            length — the bread-and-butter selection for fillet/chamfer on turned
+            parts ("the circular edge of radius 4.25 at Z=10.2") without
+            hand-rolled filtering (#239).
+
+            Args:
+                shape: the part to select edges from.
+                geom: edge geometry type name, e.g. 'circle', 'line', 'bspline'.
+                radius: keep circular edges with this radius (within tol).
+                at_z: keep edges whose center Z is within tol of this value.
+                length: keep edges with this length (within tol).
+                tol: tolerance for radius/at_z/length matching (default 0.05 mm).
+
+            Returns a ShapeList; prints the match count plus the radii and Z
+            levels found so a wrong selection is visible immediately.
+            """
+            from build123d import GeomType, ShapeList
+
+            def _radius(e: Any) -> float | None:
+                try:
+                    return e.radius
+                except Exception:
+                    return None
+
+            edges = shape.edges()
+            if geom is not None:
+                try:
+                    gt = GeomType[geom.upper()]
+                except KeyError:
+                    names = ", ".join(g.name.lower() for g in GeomType)
+                    raise ValueError(f"Unknown geom '{geom}'. Use one of: {names}") from None
+                edges = edges.filter_by(gt)
+            if radius is not None:
+                edges = [
+                    e for e in edges if (r := _radius(e)) is not None and abs(r - radius) <= tol
+                ]
+            if at_z is not None:
+                edges = [e for e in edges if abs(e.center().Z - at_z) <= tol]
+            if length is not None:
+                edges = [e for e in edges if abs(e.length - length) <= tol]
+
+            result = ShapeList(edges)
+            radii = sorted({round(r, 3) for e in result if (r := _radius(e)) is not None})
+            zs = sorted({round(e.center().Z, 3) for e in result})
+
+            def _fmt(vals: list) -> str:
+                return str(vals[:8])[:-1] + ", …]" if len(vals) > 8 else str(vals)
+
+            desc = f"find_edges: {len(result)} edge(s) matched"
+            if radii:
+                desc += f", radii {_fmt(radii)}"
+            if zs:
+                desc += f", Z levels {_fmt(zs)}"
+            print(desc)
+            return result
+
+        self.namespace["find_edges"] = find_edges
 
     def _shape_summary(self, shape) -> dict | None:
         """Pull volume/bbox/topology from a shape; None if anything errors."""

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -153,6 +153,10 @@ The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
 - Selector indices are not stable across rebuilds. Use
   `resolve("part", ".faces().sort_by(Axis.Z)[-1]", label="top")` to confirm a
   selector grabs the entity you think it does.
+- For fillet/chamfer edge selection on turned parts, use the built-in
+  `find_edges(shape, geom="circle", radius=4.25, at_z=10.2)` instead of
+  hand-rolled filtering — it prints the match count, radii, and Z levels so a
+  wrong selection is visible before the fillet runs.
 - Errors from `execute()` come back with a failure classification and fix hint —
   read them before retrying; `last_error()` has the line number and excerpt.
 - `show()` stores by reference: mutating a shape after `show()` changes the

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1714,6 +1714,86 @@ def test_face_unknown_name_raises(session):
     assert "Error" in result and "diagonal" in result
 
 
+# --- find_edges() helper (#239) ---
+
+
+def test_find_edges_circle_radius_at_z(session):
+    """The turned-part bread-and-butter: circular edges of a given radius at a
+    given Z. A Cylinder(5, 10) has two Ø10 rim circles at Z=±5."""
+    out = execute_code(
+        session,
+        "from build123d import *\n"
+        "c = Cylinder(5, 10)\n"
+        "top_rim = find_edges(c, geom='circle', radius=5, at_z=5)",
+    )
+    assert "1 edge(s) matched" in out
+    assert "radii [5" in out
+    rim = session.namespace["top_rim"]
+    assert len(rim) == 1
+    assert abs(rim[0].center().Z - 5) < 0.01
+
+
+def test_find_edges_no_filters_returns_all(session):
+    execute_code(session, "from build123d import *\nb = Box(10, 10, 10)\nes = find_edges(b)")
+    assert len(session.namespace["es"]) == 12
+
+
+def test_find_edges_by_length(session):
+    """Box(10, 20, 30) has exactly 4 edges of each length."""
+    execute_code(
+        session, "from build123d import *\nb = Box(10, 20, 30)\nes = find_edges(b, length=20)"
+    )
+    assert len(session.namespace["es"]) == 4
+
+
+def test_find_edges_radius_excludes_lines(session):
+    """A radius filter silently drops non-circular edges instead of raising."""
+    execute_code(
+        session,
+        "from build123d import *\n"
+        "p = Box(20, 20, 5) + Cylinder(4, 5).move(Location((0, 0, 5)))\n"
+        "es = find_edges(p, radius=4)",
+    )
+    es = session.namespace["es"]
+    assert len(es) >= 1
+    assert all(abs(e.radius - 4) < 0.05 for e in es)
+
+
+def test_find_edges_unknown_geom_raises(session):
+    out = execute_code(
+        session, "from build123d import *\nb = Box(10,10,10)\nfind_edges(b, geom='wiggle')"
+    )
+    assert "Error" in out and "wiggle" in out and "circle" in out
+
+
+def test_find_edges_zero_matches_prints_count(session):
+    out = execute_code(
+        session, "from build123d import *\nb = Box(10,10,10)\nes = find_edges(b, geom='circle')"
+    )
+    assert "0 edge(s) matched" in out
+    assert len(session.namespace["es"]) == 0
+
+
+def test_find_edges_result_feeds_fillet(session):
+    """The returned ShapeList plugs straight into fillet()."""
+    out = execute_code(
+        session,
+        "from build123d import *\n"
+        "c = Cylinder(5, 10)\n"
+        "rim = find_edges(c, geom='circle', at_z=5)\n"
+        "result = fillet(rim, 1)",
+    )
+    assert "Error" not in out
+
+
+def test_find_edges_survives_rollback(session):
+    execute_code(session, "raise ValueError('oops')")
+    out = execute_code(
+        session, "from build123d import *\nb = Box(5,5,5)\nes = find_edges(b, length=5)"
+    )
+    assert "Error" not in out
+
+
 def test_face_survives_rollback(session):
     # face() should still be available after a failed execute()
     execute_code(session, "raise ValueError('oops')")


### PR DESCRIPTION
## What

Adds the `find_edges()` namespace helper requested in #239, mirroring `named_face()`:

```python
find_edges(shape, geom="circle", radius=4.25, at_z=10.2, tol=0.05)
```

- Filters: `geom` (any build123d GeomType name, case-insensitive), `radius` (circular edges within `tol`; non-circular edges are skipped, not errors), `at_z` (edge center Z within `tol`), `length`. All optional and combinable; no filters returns all edges.
- Returns a `ShapeList` that plugs directly into `fillet()`/`chamfer()`.
- Prints immediate feedback — `find_edges: 2 edge(s) matched, radii [5.0], Z levels [-5.0, 5.0]` — so a wrong selection is visible before the fillet runs (same philosophy as `show()`'s volume echo).
- Unknown `geom` raises with the full list of valid names.
- Registered in `_INJECTED` so it survives rollback and is excluded from new-key detection.

Kept `at_z` rather than a generic axis parameter: turned parts are Z-axis-aligned in practice, and the generic form is what `resolve()` already covers. (Noting the Z-up assumption overlaps issue #222's theme.)

As a namespace helper it adds zero MCP tool-schema tokens; discovery is via the quickref conventions section, the `execute()` docstring, and a new modeling-skill pitfall entry.

## Tests

8 new tests: radius+Z rim selection, no-filter count, length filter, radius-vs-line robustness, unknown-geom error, zero-match feedback, fillet round-trip, rollback survival. Full suite: 665 passed; ruff clean.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)