### PR TITLE
fix: replace personal [SEND:]/[ASK:] markers in modeling skill with plain English

### DIFF
--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -49,8 +49,8 @@ HOLE_DIA, HOLE_INSET = 6.6, 8.0      # 4x Ø6.6 THRU, 8 from each edge
 FILLET_R = 3.0                        # vertical corners only
 ```
 
-[ASK: A dimension I need is missing or two views disagree — which value should I use?]
-if the drawing leaves a critical dimension ambiguous. Do not guess silently.
+If the drawing leaves a critical dimension ambiguous — a value missing, or two
+views disagreeing — ask the user which value to use. Do not guess silently.
 
 ## Step 2 — Build incrementally
 
@@ -76,7 +76,7 @@ if the drawing leaves a critical dimension ambiguous. Do not guess silently.
   shows as ONE cylinder entry with `"count": 4`, so sum the counts, don't
   count entries.
 - Render only after `measure()` agrees with the spec:
-  `render_view(save_to="/tmp/part.png")` [SEND: /tmp/part.png].
+  `render_view(save_to="/tmp/part.png")`, then show /tmp/part.png to the user.
   Use `clip_plane`/`clip_at` to reveal internal features.
 - Assemblies: `clearance("a", "b")` for fit (apart / touching / containing /
   interpenetrating, with volumes), `align_check()` for flush/concentric checks,

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -62,6 +62,16 @@ def test_strip_ask_marker_no_options():
     assert "Ready to proceed?" in out
 
 
+def test_shipped_skills_have_no_personal_markers():
+    """[SEND:]/[ASK:] are conventions of the maintainer's own client setup —
+    the claude install target ships SKILL.md verbatim, so the source files
+    must spell the instructions out in plain English instead."""
+    for skill in ("drawing", "modeling"):
+        raw = _load_raw(skill)
+        assert "[SEND:" not in raw, f"{skill} skill contains a [SEND:] marker"
+        assert "[ASK:" not in raw, f"{skill} skill contains an [ASK:] marker"
+
+
 # ---------------------------------------------------------------------------
 # target: claude
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The b123d-modeling SKILL.md used `[SEND: /tmp/part.png]` (Step 3) and `[ASK: …]` (Step 1) — conventions that only the maintainer's own client setup interprets. `install_skill(target="claude")` writes the file **verbatim** (only non-Claude targets go through `_strip_claude_markers`), and the `build123d://skill/modeling` resource also serves it raw, so every other user's agent received markers it doesn't understand.

## Fix

- Step 3: `render_view(save_to="/tmp/part.png")`, then show /tmp/part.png to the user.
- Step 1: "If the drawing leaves a critical dimension ambiguous — a value missing, or two views disagreeing — ask the user which value to use. Do not guess silently."
- New regression test asserts both shipped skills (drawing + modeling) contain no `[SEND:`/`[ASK:` markers, so they can't sneak back in.

`_strip_claude_markers` itself is kept — it still guards the agents-md/cursor/windsurf install paths if markers ever reappear.

## Tests

Full suite: 666 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)