### PR TITLE
feat: --in-process fallback for MCP hosts that block subprocess creation (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Unlike CAD MCP servers that simply `exec()` user code, build123d-mcp ships with 
 
 1. **AST inspection** — rejects imports of anything outside the allowlist (`build123d`, `bd_warehouse`, `math`, `numpy`, `inspect`, plus the rest of the safe stdlib subset and a curated set of geometric OCP submodules), blocks `eval`/`exec`/`compile`/`open`, and refuses dunder attribute access (the most common Python sandbox-escape route).
 2. **Restricted builtins** — the `__builtins__` exposed to user code has the dangerous functions removed and `__import__` rewrapped to enforce the same allowlist at runtime, so a payload that bypasses the AST check still hits the wall on import.
-3. **Execution timeout** — wall-clock limit (default 120 s, `--exec-timeout N` to override) enforced via SIGALRM, with the worker process restarted on breach so a hung script can't hold the session forever.
+3. **Execution timeout** — wall-clock limit (default 120 s, `--exec-timeout N` to override) enforced via SIGALRM, with the worker process restarted on breach so a hung script can't hold the session forever. In `--in-process` mode this layer is absent on Windows (no SIGALRM, no worker to restart) — a runaway script blocks the server.
 
 Filesystem I/O modules (`os`, `pathlib`, `shutil`), networking (`socket`, `urllib`, `requests`), shell access (`subprocess`), and the OCP file-I/O submodules (`STEPControl`, `IGESControl`, `OSD`, …) are **all blocked**. Path traversal is rejected for `export()` and `render_view(save_to=)`.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Build complexity falls into two tiers and the right approach differs between the
 
 > **Timeout note:** the default is 120 s. Raise it with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`. When a timeout fires, all session state is lost (worker is restarted) — you must re-run any setup code.
 
+> **Sandboxed-host note:** if every `execute()` fails with "Worker process failed to start", your MCP host is likely blocking subprocess creation (seen with sandboxed hosts on Windows). Relaunch with `--in-process` or `BUILD123D_IN_PROCESS=1` — a degraded mode that runs the CAD session inside the server process: no crash containment, no operation timeouts.
+
 > **Import note:** after `import_cad_file()` the shape is a named session object. Always render it by name (`objects="part"`) when other shapes from the same build are also in session — two co-located shapes cause Z-fighting (striped colour artifacts). STL imports produce a shell (volume = 0); `render_view` and `measure` work, but `interference()` and boolean operations require a solid.
 
 ## bd_warehouse fasteners

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -50,7 +50,7 @@ def main():
     from importlib.metadata import version
 
     from build123d_mcp import server
-    from build123d_mcp.worker import WorkerSession
+    from build123d_mcp.worker import InProcessSession, WorkerSession
 
     if len(sys.argv) > 1 and sys.argv[1] == "install-skill":
         _cmd_install_skill(sys.argv[2:])
@@ -125,6 +125,16 @@ Part library file format (Python, any .py file under --library path):
         help="Execution time limit in seconds for user code (default: 120). "
         "Overrides BUILD123D_EXEC_TIMEOUT env var.",
     )
+    parser.add_argument(
+        "--in-process",
+        action="store_true",
+        default=os.environ.get("BUILD123D_IN_PROCESS", "").lower() in ("1", "true", "yes"),
+        help="Run the CAD session in the server process instead of a worker "
+        "subprocess. Degraded mode for MCP hosts that block subprocess creation "
+        "(seen with sandboxed hosts on Windows): no crash containment, no "
+        "operation timeouts. Use only if the server reports 'Worker process "
+        "failed to start'. Overrides BUILD123D_IN_PROCESS env var.",
+    )
     args = parser.parse_args()
 
     if args.library and not os.path.isdir(args.library):
@@ -140,8 +150,9 @@ Part library file format (Python, any .py file under --library path):
         if extra_imports:
             _sec.EXTRA_ALLOWED_IMPORTS.update(extra_imports)
 
+    session_cls = InProcessSession if args.in_process else WorkerSession
     server.configure(
-        WorkerSession(
+        session_cls(
             library_path=args.library,
             allow_all_imports=args.allow_all_imports,
             extra_allowed_imports=extra_imports,

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -12,6 +12,11 @@ Timeout is managed at the WorkerSession level: if conn.poll() expires the
 parent kills the worker with SIGKILL and restarts it (fresh session).
 Within the worker, Session.execute() also applies a SIGALRM guard so that
 a hanging execute() call returns an error rather than blocking indefinitely.
+
+InProcessSession (end of this module) is the no-subprocess fallback for MCP
+hosts that block child-process creation (#143). It trades away the isolation
+above: the Session and OCC run inside the server process, with no crash
+containment and no operation timeouts.
 """
 
 import multiprocessing
@@ -20,16 +25,16 @@ from typing import Any
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
 
-def worker_main(
-    conn: Any,
-    library_path: str = "",
-    exec_timeout: int = 120,
-    allow_all_imports: bool = False,
-    extra_allowed_imports: tuple[str, ...] = (),
-) -> None:
-    """Entry point run in the worker subprocess.
+def _build_session(
+    library_path: str,
+    exec_timeout: int,
+    allow_all_imports: bool,
+    extra_allowed_imports: tuple[str, ...],
+) -> tuple[Any, Any]:
+    """Apply security overrides and build the Session (+ optional library index).
 
-    Loops receiving requests until the parent closes the connection.
+    Shared by worker_main (subprocess mode) and InProcessSession so a future
+    setup step cannot be added to one mode and forgotten in the other.
     """
     if allow_all_imports or extra_allowed_imports:
         import build123d_mcp.security as _sec
@@ -47,6 +52,23 @@ def worker_main(
         from build123d_mcp.tools.library import _LibraryIndex
 
         library_index = _LibraryIndex(library_path)
+    return session, library_index
+
+
+def worker_main(
+    conn: Any,
+    library_path: str = "",
+    exec_timeout: int = 120,
+    allow_all_imports: bool = False,
+    extra_allowed_imports: tuple[str, ...] = (),
+) -> None:
+    """Entry point run in the worker subprocess.
+
+    Loops receiving requests until the parent closes the connection.
+    """
+    session, library_index = _build_session(
+        library_path, exec_timeout, allow_all_imports, extra_allowed_imports
+    )
 
     conn.send({"ready": True})
 
@@ -660,29 +682,21 @@ class InProcessSession(WorkerSession):
     - no operation timeouts — a runaway execute() blocks the server (the
       in-Session SIGALRM guard still applies on Unix main threads, but not
       on Windows, which is exactly where this mode is needed);
-    - OCC/TBB threads share the process with the MCP event loop.
+    - OCC/TBB threads share the process with the MCP event loop;
+    - platform render helpers still spawn subprocesses where required
+      (macOS VTK guard, Linux xvfb) and may also fail under a host that
+      blocks spawning — Windows renders in-process and is unaffected.
 
     Enabled via --in-process / BUILD123D_IN_PROCESS=1.
     """
 
     def _start_worker(self) -> None:
-        # Mirror worker_main(): security overrides, Session, optional library.
-        if self._allow_all_imports or self._extra_allowed_imports:
-            import build123d_mcp.security as _sec
-
-            if self._allow_all_imports:
-                _sec.ALLOW_ALL_IMPORTS = True
-            if self._extra_allowed_imports:
-                _sec.EXTRA_ALLOWED_IMPORTS.update(self._extra_allowed_imports)
-
-        from build123d_mcp.session import Session
-
-        self._session = Session(exec_timeout=self._exec_timeout)
-        self._library_index = None
-        if self._library_path:
-            from build123d_mcp.tools.library import _LibraryIndex
-
-            self._library_index = _LibraryIndex(self._library_path)
+        self._session, self._library_index = _build_session(
+            self._library_path,
+            self._exec_timeout,
+            self._allow_all_imports,
+            self._extra_allowed_imports,
+        )
 
     def _kill_worker(self) -> None:
         pass

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -694,13 +694,10 @@ class InProcessSession(WorkerSession):
 
     def _call(self, op: str, args: dict, timeout: int) -> Any:
         # Same error contract as the worker path: tool exceptions surface as
-        # RuntimeError("TypeName: message"). ExecutionTimeout is re-raised
-        # as itself so execute()'s except clause formats it identically.
-        from build123d_mcp.security import ExecutionTimeout
-
+        # RuntimeError("TypeName: message"), mirroring worker_main's error
+        # envelope. (Session.execute() handles ExecutionTimeout internally
+        # and returns an error string, so no special-casing is needed here.)
         try:
             return _dispatch(self._session, op, args, self._library_index)
-        except ExecutionTimeout:
-            raise
         except Exception as exc:
             raise RuntimeError(f"{type(exc).__name__}: {exc}") from exc

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -323,9 +323,20 @@ class WorkerSession:
         self._conn = parent_conn
 
         if not self._conn.poll(_WORKER_READY_TIMEOUT):
+            exitcode = self._proc.exitcode  # read before kill: None means still running
             self._proc.kill()
             self._proc.join(5)
-            raise RuntimeError("Worker process failed to start within timeout.")
+            detail = (
+                f"the worker exited with code {exitcode} before signalling ready"
+                if exitcode is not None
+                else f"the worker did not signal ready within {_WORKER_READY_TIMEOUT}s"
+            )
+            raise RuntimeError(
+                f"Worker process failed to start: {detail}. If your MCP host blocks "
+                "subprocess creation (seen with sandboxed hosts on Windows, issue #143), "
+                "relaunch the server with --in-process or BUILD123D_IN_PROCESS=1 — a "
+                "degraded mode without crash containment or operation timeouts."
+            )
         self._conn.recv()  # consume the ready signal
 
     def _kill_worker(self) -> None:
@@ -635,3 +646,61 @@ class WorkerSession:
         # like a STEP import, so honour the exec-timeout knob here too (#229).
         timeout = max(self._GEOMETRY_TIMEOUT, self._exec_timeout)
         return self._call("load_part", {"name": name, "params": params}, timeout)
+
+
+class InProcessSession(WorkerSession):
+    """WorkerSession-compatible session that skips the worker subprocess.
+
+    Fallback for MCP hosts that block subprocess creation, where the spawn'd
+    worker never signals ready (#143: Codex desktop on Windows). The Session
+    and all OCC/VTK work live in the server process, so this mode is degraded
+    by design:
+
+    - no crash containment — an OCCT segfault kills the whole MCP server;
+    - no operation timeouts — a runaway execute() blocks the server (the
+      in-Session SIGALRM guard still applies on Unix main threads, but not
+      on Windows, which is exactly where this mode is needed);
+    - OCC/TBB threads share the process with the MCP event loop.
+
+    Enabled via --in-process / BUILD123D_IN_PROCESS=1.
+    """
+
+    def _start_worker(self) -> None:
+        # Mirror worker_main(): security overrides, Session, optional library.
+        if self._allow_all_imports or self._extra_allowed_imports:
+            import build123d_mcp.security as _sec
+
+            if self._allow_all_imports:
+                _sec.ALLOW_ALL_IMPORTS = True
+            if self._extra_allowed_imports:
+                _sec.EXTRA_ALLOWED_IMPORTS.update(self._extra_allowed_imports)
+
+        from build123d_mcp.session import Session
+
+        self._session = Session(exec_timeout=self._exec_timeout)
+        self._library_index = None
+        if self._library_path:
+            from build123d_mcp.tools.library import _LibraryIndex
+
+            self._library_index = _LibraryIndex(self._library_path)
+
+    def _kill_worker(self) -> None:
+        pass
+
+    def reset(self) -> str:
+        # The base method short-circuits via self._proc.is_alive(); there is
+        # no process here, so always dispatch the real reset.
+        return self._call("reset", {}, self._SHORT_TIMEOUT)
+
+    def _call(self, op: str, args: dict, timeout: int) -> Any:
+        # Same error contract as the worker path: tool exceptions surface as
+        # RuntimeError("TypeName: message"). ExecutionTimeout is re-raised
+        # as itself so execute()'s except clause formats it identically.
+        from build123d_mcp.security import ExecutionTimeout
+
+        try:
+            return _dispatch(self._session, op, args, self._library_index)
+        except ExecutionTimeout:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"{type(exc).__name__}: {exc}") from exc

--- a/tests/test_in_process_session.py
+++ b/tests/test_in_process_session.py
@@ -13,14 +13,16 @@ import pytest
 from build123d_mcp.worker import InProcessSession
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def session():
-    return InProcessSession(exec_timeout=60)
+    s = InProcessSession(exec_timeout=60)
+    s.execute("from build123d import *\nshow(Box(10, 10, 10), 'b')")
+    return s
 
 
 def test_execute_and_show(session):
-    out = session.execute("from build123d import *\nshow(Box(10, 10, 10), 'b')")
-    assert "Registered 'b'" in out
+    out = session.execute("show(Cylinder(3, 10), 'c')")
+    assert "Registered 'c'" in out
     assert "Error" not in out
 
 
@@ -50,7 +52,7 @@ def test_execute_error_returns_error_string(session):
 
 def test_export_round_trip(session, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    result = session.export_file("part", "step")
+    result = session.export_file("part", "step", object_name="b")
     assert "Exported to" in result
     assert os.path.exists("part.step")
 

--- a/tests/test_in_process_session.py
+++ b/tests/test_in_process_session.py
@@ -1,0 +1,72 @@
+"""InProcessSession — the no-subprocess fallback for hosts that block spawn (#143).
+
+Verifies the WorkerSession-compatible surface works with the Session living
+in-process, and that the error contract matches the worker path (tool
+exceptions surface as RuntimeError("TypeName: message")).
+"""
+
+import json
+import os
+
+import pytest
+
+from build123d_mcp.worker import InProcessSession
+
+
+@pytest.fixture(scope="module")
+def session():
+    return InProcessSession(exec_timeout=60)
+
+
+def test_execute_and_show(session):
+    out = session.execute("from build123d import *\nshow(Box(10, 10, 10), 'b')")
+    assert "Registered 'b'" in out
+    assert "Error" not in out
+
+
+def test_measure_round_trip(session):
+    data = json.loads(session.measure("b"))
+    assert data["volume"] == pytest.approx(1000, rel=0.01)
+    assert data["topology"]["faces"] == 6
+
+
+def test_session_state_sees_objects(session):
+    state = json.loads(session.session_state())
+    assert "b" in state["objects"]
+
+
+def test_unknown_object_error_matches_worker_contract(session):
+    """Worker path raises RuntimeError('ValueError: Unknown object ...');
+    the in-process path must produce the identical surface."""
+    with pytest.raises(RuntimeError, match=r"ValueError: Unknown object 'nope'"):
+        session.measure("nope")
+
+
+def test_execute_error_returns_error_string(session):
+    out = session.execute("raise ValueError('boom')")
+    assert out.startswith("Error:")
+    assert "boom" in out
+
+
+def test_export_round_trip(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = session.export_file("part", "step")
+    assert "Exported to" in result
+    assert os.path.exists("part.step")
+
+
+def test_snapshot_round_trip(session):
+    assert "saved" in session.save_snapshot("s1")
+    session.execute("show(Cylinder(3, 10), 'c')")
+    assert "restored" in session.restore_snapshot("s1")
+
+
+def test_no_library_configured(session):
+    assert session.has_library is False
+    assert "No part library configured" in session.search_library("anything")
+
+
+def test_reset(session):
+    assert session.reset() == "Session reset."
+    state = json.loads(session.session_state())
+    assert state["objects"] == {}

--- a/tests/test_in_process_session.py
+++ b/tests/test_in_process_session.py
@@ -3,6 +3,11 @@
 Verifies the WorkerSession-compatible surface works with the Session living
 in-process, and that the error contract matches the worker path (tool
 exceptions surface as RuntimeError("TypeName: message")).
+
+The parametrized smoke test reuses test_worker_boundary_coverage's per-op
+inventory, so every stateful tool is exercised against InProcessSession — and
+any future WorkerSession proxy method that touches self._proc directly (the
+way reset() does) fails here instead of in a sandboxed user's session.
 """
 
 import json
@@ -12,12 +17,33 @@ import pytest
 
 from build123d_mcp.worker import InProcessSession
 
+from .test_worker_boundary_coverage import SESSION_STATEFUL_TOOLS
+
 
 @pytest.fixture
 def session():
     s = InProcessSession(exec_timeout=60)
     s.execute("from build123d import *\nshow(Box(10, 10, 10), 'b')")
     return s
+
+
+@pytest.fixture
+def seeded_in_process(tmp_path):
+    """Same geometry seed as test_worker_boundary_coverage's seeded_ws."""
+    s = InProcessSession(exec_timeout=60)
+    s.execute(
+        "from build123d import *\n"
+        "show(Box(1, 1, 1), 'a')\n"
+        "show(Box(1, 1, 1).move(Location((0, 0, 1))), 'b')\n"
+    )
+    s.save_snapshot("snap")
+    return s
+
+
+@pytest.mark.parametrize("op", sorted(SESSION_STATEFUL_TOOLS))
+def test_stateful_tool_works_in_process(seeded_in_process, tmp_path, op):
+    """Every stateful tool from the worker smoke inventory works in-process."""
+    SESSION_STATEFUL_TOOLS[op](seeded_in_process, tmp_path)
 
 
 def test_execute_and_show(session):


### PR DESCRIPTION
## Problem

#143: under the Codex desktop MCP host on Windows, every `execute()` fails with "Worker process failed to start within timeout", while the identical `WorkerSession` works from plain PowerShell. The reporter's diagnostics narrowed it cleanly: a monkey-patched no-worker server runs fine under the same host, so the host appears to block `multiprocessing.spawn` child creation — not something a server-side spawn tweak can fix.

## Fix

**`InProcessSession`** — a `WorkerSession` subclass that keeps the entire tool surface but runs the `Session` in the server process. It overrides only `_start_worker` (build Session + library in-process, mirroring `worker_main`), `_call` (dispatch through the existing `_dispatch` op table; tool exceptions surface as `RuntimeError("TypeName: message")` exactly like the worker path), `_kill_worker`, and `reset` (the one proxy with a dead-worker fast path). All ~30 proxy methods are reused untouched.

**Selection**: `--in-process` flag / `BUILD123D_IN_PROCESS=1`. Help text, class docstring, and a README note state the degraded-mode trade-offs explicitly: no crash containment (an OCCT segfault kills the server), no operation timeouts (and SIGALRM doesn't exist on Windows, which is exactly where this mode is needed), OCC threads share the MCP process.

**Diagnostics**: the startup-failure message now includes the worker's exit code (distinguishes "never started/killed by host" from "hung during import") and names the fallback flag, so stranded users self-serve instead of filing a dead-end report.

## Verification

New `tests/test_in_process_session.py` (9 tests): execute/show, measure, session_state, export, snapshot round-trip, reset, no-library behavior, and error-contract parity with the worker path. Full suite: 675 passed; ruff clean. The actual Windows/Codex environment can't be reproduced here — the issue reporter offered to test a patch, so the real validation is asking them to try `--in-process` once released.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)