### PR TITLE
fix: use the up vector in _viewport_origin_for azimuth/elevation (#222)

### DIFF
--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -494,21 +494,28 @@ def _viewport_origin_for(direction: str, shapes, azimuth: float, elevation: floa
     }.get(direction, (1.0, 1.0, 1.0))
     up = (0.0, 1.0, 0.0) if direction == "top" else (0.0, 0.0, 1.0)
 
-    # Apply azimuth/elevation as rotations of the direction vector
+    # Apply azimuth/elevation mirroring VTK camera semantics: Azimuth()
+    # rotates the position about the view-up axis, Elevation() about the
+    # camera's right axis (direction x up); up is carried along with the
+    # elevation rotation (OrthogonalizeViewUp).
+    def _rodrigues(v, axis, angle_rad):
+        k = Vector(*axis).normalized()
+        vv = Vector(*v)
+        cos_a, sin_a = math.cos(angle_rad), math.sin(angle_rad)
+        out = vv * cos_a + k.cross(vv) * sin_a + k * (k.dot(vv) * (1.0 - cos_a))
+        return (out.X, out.Y, out.Z)
+
+    d = (dx, dy, dz)
     if azimuth != 0.0:
-        a = math.radians(azimuth)
-        dx, dy = dx * math.cos(a) - dy * math.sin(a), dx * math.sin(a) + dy * math.cos(a)
+        d = _rodrigues(d, up, math.radians(azimuth))
     if elevation != 0.0:
-        e = math.radians(elevation)
-        # Rotate in the plane spanned by current direction and up
-        ux, uy, uz = up
-        # simple elevation: tilt the dz component
-        horiz = math.sqrt(dx * dx + dy * dy)
-        new_horiz = horiz * math.cos(e) - dz * math.sin(e)
-        dz = horiz * math.sin(e) + dz * math.cos(e)
-        if horiz > 1e-9:
-            dx = dx * (new_horiz / horiz)
-            dy = dy * (new_horiz / horiz)
+        right = Vector(*d).cross(Vector(*up))
+        if right.length > 1e-9:
+            axis = (right.X, right.Y, right.Z)
+            e = math.radians(elevation)
+            d = _rodrigues(d, axis, e)
+            up = _rodrigues(up, axis, e)
+    dx, dy, dz = d
 
     # Distance: 10x the largest bounding extent across all shapes (effectively orthographic)
     extents = []

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1607,6 +1607,76 @@ def test_render_view_azimuth_and_elevation_returns_png(session):
     assert out["png"][:8] == PNG_MAGIC
 
 
+# --- _viewport_origin_for azimuth/elevation math (#222) ---
+
+
+def _viewport_direction(direction, azimuth=0.0, elevation=0.0):
+    """Unit view direction (look_at -> origin) and up from _viewport_origin_for."""
+    import math
+
+    from build123d import Box
+
+    from build123d_mcp.tools.render import _viewport_origin_for
+
+    shapes = [("s", Box(10, 10, 10), None)]
+    origin, up, look_at = _viewport_origin_for(direction, shapes, azimuth, elevation)
+    v = [o - l for o, l in zip(origin, look_at)]
+    n = math.sqrt(sum(c * c for c in v))
+    return tuple(c / n for c in v), up
+
+
+def test_viewport_top_elevation_tilts_toward_y():
+    import math
+
+    e = math.radians(30)
+    d, up = _viewport_direction("top", elevation=30.0)
+    # VTK Elevation() rotates about the camera right axis (d x up); for the
+    # top baseline (d=(0,0,1), up=(0,1,0)) the camera tilts toward +Y.
+    assert d == pytest.approx((0.0, math.sin(e), math.cos(e)), abs=1e-9)
+    # up is carried along (OrthogonalizeViewUp), staying perpendicular to d.
+    assert up == pytest.approx((0.0, math.cos(e), -math.sin(e)), abs=1e-9)
+
+
+def test_viewport_top_azimuth_rotates_about_up():
+    d, _up = _viewport_direction("top", azimuth=90.0)
+    # Azimuth rotates about the view-up vector (0,1,0): top swings to side.
+    assert d == pytest.approx((1.0, 0.0, 0.0), abs=1e-9)
+
+
+def test_viewport_front_elevation_matches_z_up_baseline():
+    import math
+
+    e = math.radians(30)
+    d, _up = _viewport_direction("front", elevation=30.0)
+    # Z-up views must keep the pre-#222 behaviour: front tilts up toward +Z.
+    assert d == pytest.approx((0.0, -math.cos(e), math.sin(e)), abs=1e-9)
+
+
+def test_viewport_iso_elevation_matches_z_up_baseline():
+    import math
+
+    e = math.radians(30)
+    d, _up = _viewport_direction("iso", elevation=30.0)
+    expected = (
+        math.cos(e) - math.sin(e) / math.sqrt(2),
+        math.cos(e) - math.sin(e) / math.sqrt(2),
+        math.sqrt(2) * math.sin(e) + math.cos(e),
+    )
+    n = math.sqrt(sum(c * c for c in expected))
+    assert d == pytest.approx(tuple(c / n for c in expected), abs=1e-9)
+
+
+def test_viewport_front_elevation_90_up_not_degenerate():
+    d, up = _viewport_direction("front", elevation=90.0)
+    # At elevation=90 the old code left up parallel to the view direction.
+    cross = (
+        d[1] * up[2] - d[2] * up[1],
+        d[2] * up[0] - d[0] * up[2],
+        d[0] * up[1] - d[1] * up[0],
+    )
+    assert max(abs(c) for c in cross) > 0.5
+
+
 # --- render_view clip_at (new) ---
 
 


### PR DESCRIPTION
Fixes #222.

## Problem

`_viewport_origin_for` (SVG/DXF projection path) unpacked the up vector in its elevation branch and never used it — the tilt hardcoded a Z-up assumption. For `direction="top"` (up = (0,1,0)):

- **elevation** was a no-op: `horiz = sqrt(dx²+dy²) = 0` for the (0,0,1) baseline, so the "tilt" collapsed to scaling dz by cos(e), which normalizes away.
- **azimuth** was also a no-op for the same reason (rotating a zero xy-component around Z).

Meanwhile the PNG path uses VTK's `camera.Azimuth()/Elevation()`, which rotate about the view-up and camera-right axes respectively — so PNG and SVG/DXF disagreed for top views.

## Fix

Replace the hand-rolled math with Rodrigues rotations matching VTK semantics:

- **Azimuth** rotates the view direction about the up vector.
- **Elevation** rotates about the camera right axis (`d × up`), and rotates `up` along with it (the equivalent of VTK's `OrthogonalizeViewUp`).

For the Z-up baselines (front/side/iso, up = (0,0,1)) the new math is **algebraically identical** to the old formula — verified by regression tests asserting the exact pre-fix values — so existing renders are unchanged. Side benefit: `elevation=90` on front/side no longer returns an up vector parallel to the view direction.

## Tests

Five numeric unit tests on `_viewport_origin_for`:
- top + elevation=30 tilts toward +Y with up carried along (the bug)
- top + azimuth=90 rotates about (0,1,0) (same class of bug)
- front/iso + elevation=30 match the pre-fix Z-up values (regression guard)
- front + elevation=90 up no longer degenerate

Full suite: 699 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)