### PR TITLE
refactor: single op table replaces worker dispatch if-chain and proxy methods (#220)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,16 @@ tools/interference.py — Boolean intersection check between two named shapes
 1. Create `tools/<name>.py` with a function `def <name>(session, ...) -> str`.
    Optional parameters must carry their defaults on this function — the worker
    wire omits arguments the caller didn't supply.
-2. Add one entry to the `_OPS` table in `worker.py`:
+2. Add a typed stub method on `WorkerSession` in `worker.py`:
    ```python
-   "<name>": _OpSpec(_tool("build123d_mcp.tools.<name>:<name>"), _GEOMETRY_TIMEOUT, ("arg1", "arg2")),
+   @_op(_tool(f"{_T}.<name>:<name>"), _GEOMETRY_TIMEOUT)
+   def <name>(self, arg1: str, arg2: float = 0.0) -> str:
+       raise NotImplementedError
    ```
-   The `WorkerSession.<name>()` proxy method is generated from this entry; ops
-   that need more than `fn(session, **args)` get a small `_op_<name>` handler
+   The `@_op` decorator registers the op in `_OPS` and replaces the body with
+   bind-and-send — the signature is the single typed wire interface, so keep
+   its defaults equal to the tool function's. Ops that need more than
+   `fn(session, **args)` in the worker get a small `_op_<name>` handler
    instead of `_tool(...)`.
 3. Register in `server.py`:
    ```python

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,25 @@ tools/interference.py — Boolean intersection check between two named shapes
 ## Adding a new tool
 
 1. Create `tools/<name>.py` with a function `def <name>(session, ...) -> str`.
-2. Import and register in `server.py`:
+   Optional parameters must carry their defaults on this function — the worker
+   wire omits arguments the caller didn't supply.
+2. Add one entry to the `_OPS` table in `worker.py`:
    ```python
-   from tools.<name> import <name> as <name>_fn
-
+   "<name>": _OpSpec(_tool("build123d_mcp.tools.<name>:<name>"), _GEOMETRY_TIMEOUT, ("arg1", "arg2")),
+   ```
+   The `WorkerSession.<name>()` proxy method is generated from this entry; ops
+   that need more than `fn(session, **args)` get a small `_op_<name>` handler
+   instead of `_tool(...)`.
+3. Register in `server.py`:
+   ```python
    @mcp.tool()
    def <name>(...) -> str:
        """Docstring shown to MCP clients."""
-       return <name>_fn(_session, ...)
+       return _session.<name>(...)
    ```
+4. Classify the op in `tests/test_worker_boundary_coverage.py` (add it to the
+   smoke inventory, `SESSION_STATEFUL_TOOLS`, or the reasoned allowlist) —
+   `test_every_dispatch_op_is_classified` fails until you do.
 
 ## Session model
 

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -19,9 +19,11 @@ above: the Session and OCC run inside the server process, with no crash
 containment and no operation timeouts.
 """
 
+import functools
+import inspect
 import multiprocessing
 from collections.abc import Callable
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypeVar, cast
 
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
@@ -129,9 +131,10 @@ class _OpSpec(NamedTuple):
     handler: (session, args, library_index) -> result, run inside the worker.
     timeout: parent-side wait budget in seconds, or a callable on the
         WorkerSession for budgets derived from the exec-timeout knob.
-    params: positional parameter order of the generated WorkerSession proxy
-        method — the wire-interface documentation. Optionals a caller omits
-        fall through to the tool function's own defaults.
+    params: positional parameter order of the WorkerSession proxy method,
+        derived from the stub signature by @_op — the wire-interface
+        documentation. Optionals a caller omits fall through to the tool
+        function's own defaults.
     """
 
     handler: "Callable[[Any, dict, Any], Any]"
@@ -227,128 +230,45 @@ def _op_render_drawing(session: Any, args: dict, library_index: Any) -> Any:
 
 _T = "build123d_mcp.tools"
 
+# Populated by the @_op decorator on WorkerSession's typed stub methods, plus
+# the two ops whose proxies need parent-side logic and are written by hand.
 _OPS: dict[str, _OpSpec] = {
     "execute": _OpSpec(_op_execute, _exec_budget, ("code",)),
-    "render_view": _OpSpec(
-        _tool(f"{_T}.render:render_view"),
-        _RENDER_TIMEOUT,
-        (
-            "direction",
-            "objects",
-            "quality",
-            "clip_plane",
-            "clip_at",
-            "azimuth",
-            "elevation",
-            "save_to",
-            "format",
-            "label_objects",
-            "highlights",
-            "colors",
-            "mode",
-        ),
-    ),
-    "export_file": _OpSpec(
-        _tool(f"{_T}.export:export_file"),
-        _EXPORT_TIMEOUT,
-        ("filename", "format", "object_name"),
-    ),
-    "interference": _OpSpec(
-        _tool(f"{_T}.interference:interference"),
-        _INTERFERENCE_TIMEOUT,
-        ("object_a", "object_b"),
-    ),
-    "measure": _OpSpec(
-        _tool(f"{_T}.measure:measure"),
-        _GEOMETRY_TIMEOUT,
-        ("object_name", "density", "material"),
-    ),
-    "clearance": _OpSpec(
-        _tool(f"{_T}.measure:clearance"), _GEOMETRY_TIMEOUT, ("object_a", "object_b")
-    ),
-    "cross_sections": _OpSpec(
-        _tool(f"{_T}.cross_sections:cross_sections"),
-        _GEOMETRY_TIMEOUT,
-        ("object_name", "axis", "num_slices"),
-    ),
-    "save_snapshot": _OpSpec(_op_save_snapshot, _GEOMETRY_TIMEOUT, ("name",)),
-    "restore_snapshot": _OpSpec(_op_restore_snapshot, _SHORT_TIMEOUT, ("name",)),
     "reset": _OpSpec(_op_reset, _SHORT_TIMEOUT, ()),
-    "search_library": _OpSpec(_op_search_library, _SHORT_TIMEOUT, ("query",)),
-    "load_part": _OpSpec(_op_load_part, _load_part_budget, ("name", "params")),
-    "diff_snapshot": _OpSpec(
-        _tool(f"{_T}.diff:diff_snapshot"),
-        _GEOMETRY_TIMEOUT,
-        ("snapshot_a", "snapshot_b", "format"),
-    ),
-    "session_state": _OpSpec(_tool(f"{_T}.session_state:session_state"), _SHORT_TIMEOUT, ()),
-    "objects_types": _OpSpec(_op_objects_types, _SHORT_TIMEOUT, ()),
-    "health_check": _OpSpec(_tool(f"{_T}.health_check:health_check"), _RENDER_TIMEOUT, ()),
-    "last_error": _OpSpec(_tool(f"{_T}.last_error:last_error"), _SHORT_TIMEOUT, ()),
-    "shape_compare": _OpSpec(
-        _tool(f"{_T}.shape_compare:shape_compare"), _GEOMETRY_TIMEOUT, ("object_a", "object_b")
-    ),
-    "import_cad_file": _OpSpec(
-        _tool(f"{_T}.import_step:import_cad_file"), _import_cad_budget, ("path", "name")
-    ),
-    "inspect_drawing": _OpSpec(
-        _tool(f"{_T}.inspect_drawing:inspect_drawing"), _SHORT_TIMEOUT, ("objects", "svg_path")
-    ),
-    "view_axes": _OpSpec(
-        _op_view_axes, _SHORT_TIMEOUT, ("viewport_origin", "viewport_up", "look_at")
-    ),
-    "lint_drawing": _OpSpec(
-        _tool(f"{_T}.lint_drawing:lint_drawing"),
-        _SHORT_TIMEOUT,
-        ("svg_path", "drawing_scale", "view_shape_names"),
-    ),
-    "render_drawing": _OpSpec(
-        _op_render_drawing, _RENDER_TIMEOUT, ("svg_path", "width", "save_to")
-    ),
-    "save_drawing_annotations": _OpSpec(
-        _tool(f"{_T}.save_drawing_annotations:save_drawing_annotations"),
-        _SHORT_TIMEOUT,
-        ("svg_path",),
-    ),
-    "align_check": _OpSpec(
-        _tool(f"{_T}.align_check:align_check"),
-        _GEOMETRY_TIMEOUT,
-        ("object_a", "object_b", "axis", "mode"),
-    ),
-    "resolve": _OpSpec(
-        _tool(f"{_T}.resolve:resolve"), _GEOMETRY_TIMEOUT, ("object_name", "selector", "label")
-    ),
-    "suggest_view_layout": _OpSpec(
-        _tool(f"{_T}.suggest_view_layout:suggest_view_layout"),
-        _GEOMETRY_TIMEOUT,
-        (
-            "object_name",
-            "page_w",
-            "page_h",
-            "scale",
-            "views",
-            "title_block_w",
-            "title_block_h",
-            "margin",
-            "extents",
-            "centroid",
-        ),
-    ),
-    "script": _OpSpec(_tool(f"{_T}.script:script"), _SHORT_TIMEOUT, ("save_to",)),
-    "analyze_printability": _OpSpec(
-        _tool(f"{_T}.analyze_printability:analyze_printability"),
-        _GEOMETRY_TIMEOUT,
-        (
-            "object_name",
-            "support_angle",
-            "nozzle",
-            "min_perimeters",
-            "build_volume",
-            "bed_tol",
-            "min_feature",
-        ),
-    ),
 }
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _op(
+    handler: "Callable[[Any, dict, Any], Any]",
+    timeout: "int | Callable[[WorkerSession], int]",
+) -> "Callable[[_F], _F]":
+    """Register a typed WorkerSession stub method as a worker-routed op.
+
+    Records the op in ``_OPS`` (handler + timeout + parameter order from the
+    signature) and replaces the body — which never runs — with bind-and-send:
+    supplied arguments are mapped through the real signature and shipped to
+    the worker; omitted optionals are not sent, falling through to the tool
+    function's own defaults. The ``Callable[[_F], _F]`` typing keeps the
+    declared signature visible to mypy and IDEs at every call site.
+    """
+
+    def deco(fn: _F) -> _F:
+        name = fn.__name__
+        sig = inspect.signature(fn)
+        _OPS[name] = _OpSpec(handler, timeout, tuple(sig.parameters)[1:])
+
+        @functools.wraps(fn)
+        def proxy(self: "WorkerSession", *args: Any, **kwargs: Any) -> Any:
+            bound = sig.bind(self, *args, **kwargs)
+            payload = {k: v for k, v in bound.arguments.items() if k != "self"}
+            t = timeout(self) if callable(timeout) else timeout
+            return self._call(name, payload, t)
+
+        return cast(_F, proxy)
+
+    return deco
 
 
 def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
@@ -475,11 +395,11 @@ class WorkerSession:
 
     # --- Session-compatible interface ---
     #
-    # Proxy methods are generated from _OPS via __getattr__: positional args
-    # map through spec.params, the timeout comes from the table, and optionals
-    # the caller omits fall through to the tool-function defaults in the
-    # worker. Only ops needing parent-side behaviour beyond "send and wait"
-    # (execute, reset) are written out explicitly.
+    # Methods below are typed stubs registered with the @_op decorator: the
+    # signature is the single typed definition of the wire interface; the
+    # decorator records the op in _OPS and replaces the body (which never
+    # runs) with bind-and-send. Only ops needing parent-side behaviour beyond
+    # "send and wait" (execute, reset) are written out by hand.
 
     def execute(self, code: str) -> str:
         from build123d_mcp.security import ExecutionTimeout
@@ -495,29 +415,161 @@ class WorkerSession:
             return "Session reset."
         return self._call("reset", {}, _SHORT_TIMEOUT)
 
-    def __getattr__(self, name: str) -> Any:
-        # Fires only for attributes not found normally, so explicit methods
-        # and instance attributes take precedence. The Any return type also
-        # lets mypy accept the generated methods at call sites.
-        spec = _OPS.get(name)
-        if spec is None:
-            raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+    @_op(_tool(f"{_T}.render:render_view"), _RENDER_TIMEOUT)
+    def render_view(
+        self,
+        direction: str = "iso",
+        objects: str = "",
+        quality: str = "standard",
+        clip_plane: str = "",
+        clip_at: float | None = None,
+        azimuth: float = 0.0,
+        elevation: float = 0.0,
+        save_to: str = "",
+        format: str = "png",
+        label_objects: bool = False,
+        highlights: list[dict] | None = None,
+        colors: dict[str, str] | None = None,
+        mode: str = "auto",
+    ) -> dict:
+        raise NotImplementedError
 
-        def proxy(*args: Any, **kwargs: Any) -> Any:
-            if len(args) > len(spec.params):
-                raise TypeError(f"{name}() takes at most {len(spec.params)} positional argument(s)")
-            payload = dict(zip(spec.params, args))
-            for key in kwargs:
-                if key in payload:
-                    raise TypeError(f"{name}() got multiple values for argument '{key}'")
-                if key not in spec.params:
-                    raise TypeError(f"{name}() got an unexpected keyword argument '{key}'")
-            payload.update(kwargs)
-            timeout = spec.timeout(self) if callable(spec.timeout) else spec.timeout
-            return self._call(name, payload, timeout)
+    @_op(_tool(f"{_T}.export:export_file"), _EXPORT_TIMEOUT)
+    def export_file(self, filename: str, format: str = "step", object_name: str = "") -> str:
+        raise NotImplementedError
 
-        proxy.__name__ = name
-        return proxy
+    @_op(_tool(f"{_T}.interference:interference"), _INTERFERENCE_TIMEOUT)
+    def interference(self, object_a: str, object_b: str) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.measure:measure"), _GEOMETRY_TIMEOUT)
+    def measure(self, object_name: str = "", density: float = 0.0, material: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.measure:clearance"), _GEOMETRY_TIMEOUT)
+    def clearance(self, object_a: str, object_b: str) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.cross_sections:cross_sections"), _GEOMETRY_TIMEOUT)
+    def cross_sections(self, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
+        raise NotImplementedError
+
+    @_op(_op_save_snapshot, _GEOMETRY_TIMEOUT)
+    def save_snapshot(self, name: str) -> str:
+        raise NotImplementedError
+
+    @_op(_op_restore_snapshot, _SHORT_TIMEOUT)
+    def restore_snapshot(self, name: str) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.diff:diff_snapshot"), _GEOMETRY_TIMEOUT)
+    def diff_snapshot(self, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.session_state:session_state"), _SHORT_TIMEOUT)
+    def session_state(self) -> str:
+        raise NotImplementedError
+
+    @_op(_op_objects_types, _SHORT_TIMEOUT)
+    def objects_types(self) -> dict:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.analyze_printability:analyze_printability"), _GEOMETRY_TIMEOUT)
+    def analyze_printability(
+        self,
+        object_name: str = "",
+        support_angle: float = 45.0,
+        nozzle: float = 0.4,
+        min_perimeters: int = 2,
+        build_volume: str = "",
+        bed_tol: float = 0.001,
+        min_feature: float = 0.5,
+    ) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.health_check:health_check"), _RENDER_TIMEOUT)
+    def health_check(self) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.last_error:last_error"), _SHORT_TIMEOUT)
+    def last_error(self) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.shape_compare:shape_compare"), _GEOMETRY_TIMEOUT)
+    def shape_compare(self, object_a: str, object_b: str) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.import_step:import_cad_file"), _import_cad_budget)
+    def import_cad_file(self, path: str, name: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.inspect_drawing:inspect_drawing"), _SHORT_TIMEOUT)
+    def inspect_drawing(self, objects: str = "", svg_path: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_op_view_axes, _SHORT_TIMEOUT)
+    def view_axes(
+        self,
+        viewport_origin: tuple,
+        viewport_up: tuple = (0.0, 1.0, 0.0),
+        look_at: tuple = (0.0, 0.0, 0.0),
+    ) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.lint_drawing:lint_drawing"), _SHORT_TIMEOUT)
+    def lint_drawing(
+        self,
+        svg_path: str = "",
+        drawing_scale: float = 1.0,
+        view_shape_names: list[str] | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    @_op(_op_render_drawing, _RENDER_TIMEOUT)
+    def render_drawing(self, svg_path: str, width: int = 0, save_to: str = "") -> dict:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.save_drawing_annotations:save_drawing_annotations"), _SHORT_TIMEOUT)
+    def save_drawing_annotations(self, svg_path: str) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.align_check:align_check"), _GEOMETRY_TIMEOUT)
+    def align_check(
+        self, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush"
+    ) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.resolve:resolve"), _GEOMETRY_TIMEOUT)
+    def resolve(self, object_name: str, selector: str, label: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.suggest_view_layout:suggest_view_layout"), _GEOMETRY_TIMEOUT)
+    def suggest_view_layout(
+        self,
+        object_name: str = "",
+        page_w: float = 297.0,
+        page_h: float = 210.0,
+        scale: float = 1.0,
+        views: list[str] | None = None,
+        title_block_w: float = 150.0,
+        title_block_h: float = 30.0,
+        margin: float = 10.0,
+        extents: list[float] | None = None,
+        centroid: list[float] | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    @_op(_tool(f"{_T}.script:script"), _SHORT_TIMEOUT)
+    def script(self, save_to: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_op_search_library, _SHORT_TIMEOUT)
+    def search_library(self, query: str = "") -> str:
+        raise NotImplementedError
+
+    @_op(_op_load_part, _load_part_budget)
+    def load_part(self, name: str, params: str = "") -> str:
+        raise NotImplementedError
 
 
 class InProcessSession(WorkerSession):

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -20,7 +20,8 @@ containment and no operation timeouts.
 """
 
 import multiprocessing
-from typing import Any
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 _WORKER_READY_TIMEOUT = 60  # seconds to wait for worker import + ready signal
 
@@ -88,205 +89,273 @@ def worker_main(
             conn.send({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
+# --------------------------------------------------------------------------- #
+# Op table — single source of truth for worker-routed operations (issue #220). #
+# --------------------------------------------------------------------------- #
+
+# Parent-side time budgets (seconds). Geometry-heavy queries (boolean ops,
+# per-face walks, BREP analysis, part construction) can legitimately exceed
+# 10s on complex parts, and a timeout here kills the worker and destroys all
+# session state — so the budget errs generous (issue #214). _SHORT_TIMEOUT is
+# only for ops that read session bookkeeping without touching geometry kernels.
+_RENDER_TIMEOUT = 120
+_EXPORT_TIMEOUT = 60
+_INTERFERENCE_TIMEOUT = 30
+_GEOMETRY_TIMEOUT = 60
+_SHORT_TIMEOUT = 10
+
+
+def _exec_budget(ws: "WorkerSession") -> int:
+    return ws._exec_timeout
+
+
+def _import_cad_budget(ws: "WorkerSession") -> int:
+    # STEP import of heavy geometry (threads, gears — lots of BSpline faces)
+    # can outlast _EXPORT_TIMEOUT, and a timeout kills the whole session.
+    # Honour the user's exec-timeout knob (--exec-timeout /
+    # BUILD123D_EXEC_TIMEOUT) when it is the larger budget (#229).
+    return max(_EXPORT_TIMEOUT, ws._exec_timeout)
+
+
+def _load_part_budget(ws: "WorkerSession") -> int:
+    # Library part scripts can build heavy geometry (threads, gears) just
+    # like a STEP import, so honour the exec-timeout knob here too (#229).
+    return max(_GEOMETRY_TIMEOUT, ws._exec_timeout)
+
+
+class _OpSpec(NamedTuple):
+    """One worker-routed operation.
+
+    handler: (session, args, library_index) -> result, run inside the worker.
+    timeout: parent-side wait budget in seconds, or a callable on the
+        WorkerSession for budgets derived from the exec-timeout knob.
+    params: positional parameter order of the generated WorkerSession proxy
+        method — the wire-interface documentation. Optionals a caller omits
+        fall through to the tool function's own defaults.
+    """
+
+    handler: "Callable[[Any, dict, Any], Any]"
+    timeout: "int | Callable[[WorkerSession], int]"
+    params: tuple[str, ...]
+
+
+def _tool(path: str) -> "Callable[[Any, dict, Any], Any]":
+    """Handler for the common case: lazily import ``module:function`` and call
+    ``fn(session, **args)``. Wire arg names must equal the function's parameter
+    names, with defaults living on the function itself."""
+    module_name, _, func_name = path.partition(":")
+
+    def handler(session: Any, args: dict, library_index: Any) -> Any:
+        import importlib
+
+        fn = getattr(importlib.import_module(module_name), func_name)
+        return fn(session, **args)
+
+    return handler
+
+
+# --- Ops with logic beyond fn(session, **args) ---
+
+
+def _op_execute(session: Any, args: dict, library_index: Any) -> Any:
+    return session.execute(args["code"])
+
+
+def _op_objects_types(session: Any, args: dict, library_index: Any) -> Any:
+    return session.objects_types()
+
+
+def _op_save_snapshot(session: Any, args: dict, library_index: Any) -> Any:
+    name = args["name"]
+    session.save_snapshot(name)
+    saved = (["current_shape"] if session.current_shape is not None else []) + list(
+        session.snapshots[name]["objects"].keys()
+    )
+    return f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
+
+
+def _op_restore_snapshot(session: Any, args: dict, library_index: Any) -> Any:
+    name = args["name"]
+    try:
+        session.restore_snapshot(name)
+    except KeyError as e:
+        return f"Error: {e}"
+    restored = (["current_shape"] if session.current_shape is not None else []) + list(
+        session.objects.keys()
+    )
+    return f"Snapshot '{name}' restored. Active geometry: {', '.join(restored) if restored else 'none'}."
+
+
+def _op_reset(session: Any, args: dict, library_index: Any) -> Any:
+    session.reset()
+    return "Session reset."
+
+
+def _op_search_library(session: Any, args: dict, library_index: Any) -> Any:
+    if library_index is None:
+        return "No part library configured."
+    from build123d_mcp.tools.library import search_library
+
+    return search_library(library_index, args.get("query", ""))
+
+
+def _op_load_part(session: Any, args: dict, library_index: Any) -> Any:
+    if library_index is None:
+        return "No part library configured."
+    from build123d_mcp.tools.library import load_part
+
+    return load_part(session, library_index, args["name"], args.get("params", ""))
+
+
+def _op_view_axes(session: Any, args: dict, library_index: Any) -> Any:
+    # Pure helper: takes no session; sequence args normalised to tuples.
+    from build123d_mcp.tools.view_axes import view_axes
+
+    return view_axes(
+        tuple(args["viewport_origin"]),
+        tuple(args.get("viewport_up", (0.0, 1.0, 0.0))),
+        tuple(args.get("look_at", (0.0, 0.0, 0.0))),
+    )
+
+
+def _op_render_drawing(session: Any, args: dict, library_index: Any) -> Any:
+    # Pure helper: rasterises an SVG file from disk; takes no session.
+    from build123d_mcp.tools.render_drawing import render_drawing
+
+    return render_drawing(args["svg_path"], args.get("width", 0), args.get("save_to", ""))
+
+
+_T = "build123d_mcp.tools"
+
+_OPS: dict[str, _OpSpec] = {
+    "execute": _OpSpec(_op_execute, _exec_budget, ("code",)),
+    "render_view": _OpSpec(
+        _tool(f"{_T}.render:render_view"),
+        _RENDER_TIMEOUT,
+        (
+            "direction",
+            "objects",
+            "quality",
+            "clip_plane",
+            "clip_at",
+            "azimuth",
+            "elevation",
+            "save_to",
+            "format",
+            "label_objects",
+            "highlights",
+            "colors",
+            "mode",
+        ),
+    ),
+    "export_file": _OpSpec(
+        _tool(f"{_T}.export:export_file"),
+        _EXPORT_TIMEOUT,
+        ("filename", "format", "object_name"),
+    ),
+    "interference": _OpSpec(
+        _tool(f"{_T}.interference:interference"),
+        _INTERFERENCE_TIMEOUT,
+        ("object_a", "object_b"),
+    ),
+    "measure": _OpSpec(
+        _tool(f"{_T}.measure:measure"),
+        _GEOMETRY_TIMEOUT,
+        ("object_name", "density", "material"),
+    ),
+    "clearance": _OpSpec(
+        _tool(f"{_T}.measure:clearance"), _GEOMETRY_TIMEOUT, ("object_a", "object_b")
+    ),
+    "cross_sections": _OpSpec(
+        _tool(f"{_T}.cross_sections:cross_sections"),
+        _GEOMETRY_TIMEOUT,
+        ("object_name", "axis", "num_slices"),
+    ),
+    "save_snapshot": _OpSpec(_op_save_snapshot, _GEOMETRY_TIMEOUT, ("name",)),
+    "restore_snapshot": _OpSpec(_op_restore_snapshot, _SHORT_TIMEOUT, ("name",)),
+    "reset": _OpSpec(_op_reset, _SHORT_TIMEOUT, ()),
+    "search_library": _OpSpec(_op_search_library, _SHORT_TIMEOUT, ("query",)),
+    "load_part": _OpSpec(_op_load_part, _load_part_budget, ("name", "params")),
+    "diff_snapshot": _OpSpec(
+        _tool(f"{_T}.diff:diff_snapshot"),
+        _GEOMETRY_TIMEOUT,
+        ("snapshot_a", "snapshot_b", "format"),
+    ),
+    "session_state": _OpSpec(_tool(f"{_T}.session_state:session_state"), _SHORT_TIMEOUT, ()),
+    "objects_types": _OpSpec(_op_objects_types, _SHORT_TIMEOUT, ()),
+    "health_check": _OpSpec(_tool(f"{_T}.health_check:health_check"), _RENDER_TIMEOUT, ()),
+    "last_error": _OpSpec(_tool(f"{_T}.last_error:last_error"), _SHORT_TIMEOUT, ()),
+    "shape_compare": _OpSpec(
+        _tool(f"{_T}.shape_compare:shape_compare"), _GEOMETRY_TIMEOUT, ("object_a", "object_b")
+    ),
+    "import_cad_file": _OpSpec(
+        _tool(f"{_T}.import_step:import_cad_file"), _import_cad_budget, ("path", "name")
+    ),
+    "inspect_drawing": _OpSpec(
+        _tool(f"{_T}.inspect_drawing:inspect_drawing"), _SHORT_TIMEOUT, ("objects", "svg_path")
+    ),
+    "view_axes": _OpSpec(
+        _op_view_axes, _SHORT_TIMEOUT, ("viewport_origin", "viewport_up", "look_at")
+    ),
+    "lint_drawing": _OpSpec(
+        _tool(f"{_T}.lint_drawing:lint_drawing"),
+        _SHORT_TIMEOUT,
+        ("svg_path", "drawing_scale", "view_shape_names"),
+    ),
+    "render_drawing": _OpSpec(
+        _op_render_drawing, _RENDER_TIMEOUT, ("svg_path", "width", "save_to")
+    ),
+    "save_drawing_annotations": _OpSpec(
+        _tool(f"{_T}.save_drawing_annotations:save_drawing_annotations"),
+        _SHORT_TIMEOUT,
+        ("svg_path",),
+    ),
+    "align_check": _OpSpec(
+        _tool(f"{_T}.align_check:align_check"),
+        _GEOMETRY_TIMEOUT,
+        ("object_a", "object_b", "axis", "mode"),
+    ),
+    "resolve": _OpSpec(
+        _tool(f"{_T}.resolve:resolve"), _GEOMETRY_TIMEOUT, ("object_name", "selector", "label")
+    ),
+    "suggest_view_layout": _OpSpec(
+        _tool(f"{_T}.suggest_view_layout:suggest_view_layout"),
+        _GEOMETRY_TIMEOUT,
+        (
+            "object_name",
+            "page_w",
+            "page_h",
+            "scale",
+            "views",
+            "title_block_w",
+            "title_block_h",
+            "margin",
+            "extents",
+            "centroid",
+        ),
+    ),
+    "script": _OpSpec(_tool(f"{_T}.script:script"), _SHORT_TIMEOUT, ("save_to",)),
+    "analyze_printability": _OpSpec(
+        _tool(f"{_T}.analyze_printability:analyze_printability"),
+        _GEOMETRY_TIMEOUT,
+        (
+            "object_name",
+            "support_angle",
+            "nozzle",
+            "min_perimeters",
+            "build_volume",
+            "bed_tol",
+            "min_feature",
+        ),
+    ),
+}
+
+
 def _dispatch(session: Any, op: str, args: dict, library_index: Any) -> Any:
-    if op == "execute":
-        return session.execute(args["code"])
-
-    if op == "render_view":
-        from build123d_mcp.tools.render import render_view
-
-        return render_view(session, **args)
-
-    if op == "export_file":
-        from build123d_mcp.tools.export import export_file
-
-        return export_file(session, **args)
-
-    if op == "interference":
-        from build123d_mcp.tools.interference import interference
-
-        return interference(session, **args)
-
-    if op == "measure":
-        from build123d_mcp.tools.measure import measure
-
-        return measure(session, **args)
-
-    if op == "clearance":
-        from build123d_mcp.tools.measure import clearance
-
-        return clearance(session, **args)
-
-    if op == "cross_sections":
-        from build123d_mcp.tools.cross_sections import cross_sections
-
-        return cross_sections(session, **args)
-
-    if op == "save_snapshot":
-        name = args["name"]
-        session.save_snapshot(name)
-        saved = (["current_shape"] if session.current_shape is not None else []) + list(
-            session.snapshots[name]["objects"].keys()
-        )
-        return (
-            f"Snapshot '{name}' saved. Geometry captured: {', '.join(saved) if saved else 'none'}."
-        )
-
-    if op == "restore_snapshot":
-        name = args["name"]
-        try:
-            session.restore_snapshot(name)
-        except KeyError as e:
-            return f"Error: {e}"
-        restored = (["current_shape"] if session.current_shape is not None else []) + list(
-            session.objects.keys()
-        )
-        return f"Snapshot '{name}' restored. Active geometry: {', '.join(restored) if restored else 'none'}."
-
-    if op == "reset":
-        session.reset()
-        return "Session reset."
-
-    if op == "search_library":
-        if library_index is None:
-            return "No part library configured."
-        from build123d_mcp.tools.library import search_library
-
-        return search_library(library_index, args.get("query", ""))
-
-    if op == "load_part":
-        if library_index is None:
-            return "No part library configured."
-        from build123d_mcp.tools.library import load_part
-
-        return load_part(session, library_index, args["name"], args.get("params", ""))
-
-    if op == "diff_snapshot":
-        from build123d_mcp.tools.diff import diff_snapshot
-
-        return diff_snapshot(
-            session, args["snapshot_a"], args.get("snapshot_b", ""), args.get("format", "text")
-        )
-
-    if op == "session_state":
-        from build123d_mcp.tools.session_state import session_state
-
-        return session_state(session)
-
-    if op == "objects_types":
-        return session.objects_types()
-
-    if op == "health_check":
-        from build123d_mcp.tools.health_check import health_check
-
-        return health_check(session)
-
-    if op == "last_error":
-        from build123d_mcp.tools.last_error import last_error
-
-        return last_error(session)
-
-    if op == "shape_compare":
-        from build123d_mcp.tools.shape_compare import shape_compare
-
-        return shape_compare(session, args["object_a"], args["object_b"])
-
-    if op == "import_cad_file":
-        from build123d_mcp.tools.import_step import import_cad_file
-
-        return import_cad_file(session, args["path"], args.get("name", ""))
-
-    if op == "inspect_drawing":
-        from build123d_mcp.tools.inspect_drawing import inspect_drawing
-
-        return inspect_drawing(session, args.get("objects", ""), args.get("svg_path", ""))
-
-    if op == "view_axes":
-        from build123d_mcp.tools.view_axes import view_axes
-
-        return view_axes(
-            tuple(args["viewport_origin"]),
-            tuple(args.get("viewport_up", (0.0, 1.0, 0.0))),
-            tuple(args.get("look_at", (0.0, 0.0, 0.0))),
-        )
-
-    if op == "lint_drawing":
-        from build123d_mcp.tools.lint_drawing import lint_drawing
-
-        return lint_drawing(
-            session,
-            args.get("svg_path", ""),
-            args.get("drawing_scale", 1.0),
-            args.get("view_shape_names"),
-        )
-
-    if op == "render_drawing":
-        from build123d_mcp.tools.render_drawing import render_drawing
-
-        return render_drawing(
-            args["svg_path"],
-            args.get("width", 0),
-            args.get("save_to", ""),
-        )
-
-    if op == "save_drawing_annotations":
-        from build123d_mcp.tools.save_drawing_annotations import save_drawing_annotations
-
-        return save_drawing_annotations(session, args["svg_path"])
-
-    if op == "align_check":
-        from build123d_mcp.tools.align_check import align_check
-
-        return align_check(
-            session,
-            args["object_a"],
-            args["object_b"],
-            axis=args.get("axis", "Z"),
-            mode=args.get("mode", "flush"),
-        )
-
-    if op == "resolve":
-        from build123d_mcp.tools.resolve import resolve
-
-        return resolve(session, args["object_name"], args["selector"], label=args.get("label", ""))
-
-    if op == "suggest_view_layout":
-        from build123d_mcp.tools.suggest_view_layout import suggest_view_layout
-
-        return suggest_view_layout(
-            session,
-            args["object_name"],
-            args.get("page_w", 297.0),
-            args.get("page_h", 210.0),
-            args.get("scale", 1.0),
-            args.get("views"),
-            args.get("title_block_w", 150.0),
-            args.get("title_block_h", 30.0),
-            args.get("margin", 10.0),
-            args.get("extents"),
-            args.get("centroid"),
-        )
-
-    if op == "script":
-        from build123d_mcp.tools.script import script
-
-        return script(session, save_to=args.get("save_to", ""))
-
-    if op == "analyze_printability":
-        from build123d_mcp.tools.analyze_printability import analyze_printability
-
-        return analyze_printability(
-            session,
-            object_name=args.get("object_name", ""),
-            support_angle=args.get("support_angle", 45.0),
-            nozzle=args.get("nozzle", 0.4),
-            min_perimeters=args.get("min_perimeters", 2),
-            build_volume=args.get("build_volume", ""),
-            bed_tol=args.get("bed_tol", 0.001),
-            min_feature=args.get("min_feature", 0.5),
-        )
-
-    raise ValueError(f"Unknown operation: '{op}'")
+    spec = _OPS.get(op)
+    if spec is None:
+        raise ValueError(f"Unknown operation: '{op}'")
+    return spec.handler(session, args, library_index)
 
 
 class WorkerSession:
@@ -294,17 +363,6 @@ class WorkerSession:
 
     Exposes the same interface as Session so server.py can use either.
     """
-
-    _RENDER_TIMEOUT = 120
-    _EXPORT_TIMEOUT = 60
-    _INTERFERENCE_TIMEOUT = 30
-    # Geometry-heavy queries (boolean ops, per-face walks, BREP analysis, part
-    # construction) can legitimately exceed 10s on complex parts, and a timeout
-    # here kills the worker and destroys all session state — so the budget errs
-    # generous (issue #214). _SHORT_TIMEOUT is only for ops that read session
-    # bookkeeping without touching geometry kernels.
-    _GEOMETRY_TIMEOUT = 60
-    _SHORT_TIMEOUT = 10
 
     def __init__(
         self,
@@ -416,6 +474,12 @@ class WorkerSession:
         raise RuntimeError(response["error"])
 
     # --- Session-compatible interface ---
+    #
+    # Proxy methods are generated from _OPS via __getattr__: positional args
+    # map through spec.params, the timeout comes from the table, and optionals
+    # the caller omits fall through to the tool-function defaults in the
+    # worker. Only ops needing parent-side behaviour beyond "send and wait"
+    # (execute, reset) are written out explicitly.
 
     def execute(self, code: str) -> str:
         from build123d_mcp.security import ExecutionTimeout
@@ -425,249 +489,35 @@ class WorkerSession:
         except (RuntimeError, ExecutionTimeout) as e:
             return f"Error: {e}"
 
-    def render_view(
-        self,
-        direction: str = "iso",
-        objects: str = "",
-        quality: str = "standard",
-        clip_plane: str = "",
-        clip_at: float | None = None,
-        azimuth: float = 0.0,
-        elevation: float = 0.0,
-        save_to: str = "",
-        format: str = "png",
-        label_objects: bool = False,
-        highlights: list[dict] | None = None,
-        colors: dict[str, str] | None = None,
-        mode: str = "auto",
-    ) -> dict:
-        return self._call(
-            "render_view",
-            {
-                "direction": direction,
-                "objects": objects,
-                "quality": quality,
-                "clip_plane": clip_plane,
-                "clip_at": clip_at,
-                "azimuth": azimuth,
-                "elevation": elevation,
-                "save_to": save_to,
-                "format": format,
-                "label_objects": label_objects,
-                "highlights": highlights,
-                "colors": colors,
-                "mode": mode,
-            },
-            self._RENDER_TIMEOUT,
-        )
-
-    def export_file(self, filename: str, format: str = "step", object_name: str = "") -> str:
-        return self._call(
-            "export_file",
-            {"filename": filename, "format": format, "object_name": object_name},
-            self._EXPORT_TIMEOUT,
-        )
-
-    def interference(self, object_a: str, object_b: str) -> str:
-        return self._call(
-            "interference",
-            {"object_a": object_a, "object_b": object_b},
-            self._INTERFERENCE_TIMEOUT,
-        )
-
-    def measure(self, object_name: str = "", density: float = 0.0, material: str = "") -> str:
-        return self._call(
-            "measure",
-            {"object_name": object_name, "density": density, "material": material},
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def clearance(self, object_a: str, object_b: str) -> str:
-        return self._call(
-            "clearance", {"object_a": object_a, "object_b": object_b}, self._GEOMETRY_TIMEOUT
-        )
-
-    def cross_sections(self, object_name: str = "", axis: str = "Z", num_slices: int = 10) -> str:
-        return self._call(
-            "cross_sections",
-            {"object_name": object_name, "axis": axis, "num_slices": num_slices},
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def save_snapshot(self, name: str) -> str:
-        return self._call("save_snapshot", {"name": name}, self._GEOMETRY_TIMEOUT)
-
-    def restore_snapshot(self, name: str) -> str:
-        return self._call("restore_snapshot", {"name": name}, self._SHORT_TIMEOUT)
-
     def reset(self) -> str:
         if not self._proc.is_alive():
             self._start_worker()
             return "Session reset."
-        return self._call("reset", {}, self._SHORT_TIMEOUT)
+        return self._call("reset", {}, _SHORT_TIMEOUT)
 
-    def diff_snapshot(self, snapshot_a: str, snapshot_b: str = "", format: str = "text") -> str:
-        return self._call(
-            "diff_snapshot",
-            {"snapshot_a": snapshot_a, "snapshot_b": snapshot_b, "format": format},
-            self._GEOMETRY_TIMEOUT,
-        )
+    def __getattr__(self, name: str) -> Any:
+        # Fires only for attributes not found normally, so explicit methods
+        # and instance attributes take precedence. The Any return type also
+        # lets mypy accept the generated methods at call sites.
+        spec = _OPS.get(name)
+        if spec is None:
+            raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
 
-    def session_state(self) -> str:
-        return self._call("session_state", {}, self._SHORT_TIMEOUT)
+        def proxy(*args: Any, **kwargs: Any) -> Any:
+            if len(args) > len(spec.params):
+                raise TypeError(f"{name}() takes at most {len(spec.params)} positional argument(s)")
+            payload = dict(zip(spec.params, args))
+            for key in kwargs:
+                if key in payload:
+                    raise TypeError(f"{name}() got multiple values for argument '{key}'")
+                if key not in spec.params:
+                    raise TypeError(f"{name}() got an unexpected keyword argument '{key}'")
+            payload.update(kwargs)
+            timeout = spec.timeout(self) if callable(spec.timeout) else spec.timeout
+            return self._call(name, payload, timeout)
 
-    def objects_types(self) -> dict:
-        return self._call("objects_types", {}, self._SHORT_TIMEOUT)
-
-    def analyze_printability(
-        self,
-        object_name: str = "",
-        support_angle: float = 45.0,
-        nozzle: float = 0.4,
-        min_perimeters: int = 2,
-        build_volume: str = "",
-        bed_tol: float = 0.001,
-        min_feature: float = 0.5,
-    ) -> str:
-        return self._call(
-            "analyze_printability",
-            {
-                "object_name": object_name,
-                "support_angle": support_angle,
-                "nozzle": nozzle,
-                "min_perimeters": min_perimeters,
-                "build_volume": build_volume,
-                "bed_tol": bed_tol,
-                "min_feature": min_feature,
-            },
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def health_check(self) -> str:
-        return self._call("health_check", {}, self._RENDER_TIMEOUT)
-
-    def last_error(self) -> str:
-        return self._call("last_error", {}, self._SHORT_TIMEOUT)
-
-    def shape_compare(self, object_a: str, object_b: str) -> str:
-        return self._call(
-            "shape_compare", {"object_a": object_a, "object_b": object_b}, self._GEOMETRY_TIMEOUT
-        )
-
-    def import_cad_file(self, path: str, name: str = "") -> str:
-        # STEP import of heavy geometry (threads, gears — lots of BSpline faces)
-        # can outlast _EXPORT_TIMEOUT, and a timeout kills the whole session.
-        # Honour the user's exec-timeout knob (--exec-timeout /
-        # BUILD123D_EXEC_TIMEOUT) when it is the larger budget (#229).
-        timeout = max(self._EXPORT_TIMEOUT, self._exec_timeout)
-        return self._call("import_cad_file", {"path": path, "name": name}, timeout)
-
-    def inspect_drawing(self, objects: str = "", svg_path: str = "") -> str:
-        return self._call(
-            "inspect_drawing",
-            {"objects": objects, "svg_path": svg_path},
-            self._SHORT_TIMEOUT,
-        )
-
-    def view_axes(
-        self,
-        viewport_origin: tuple,
-        viewport_up: tuple = (0.0, 1.0, 0.0),
-        look_at: tuple = (0.0, 0.0, 0.0),
-    ) -> str:
-        return self._call(
-            "view_axes",
-            {"viewport_origin": viewport_origin, "viewport_up": viewport_up, "look_at": look_at},
-            self._SHORT_TIMEOUT,
-        )
-
-    def lint_drawing(
-        self,
-        svg_path: str = "",
-        drawing_scale: float = 1.0,
-        view_shape_names: list[str] | None = None,
-    ) -> str:
-        return self._call(
-            "lint_drawing",
-            {
-                "svg_path": svg_path,
-                "drawing_scale": drawing_scale,
-                "view_shape_names": view_shape_names,
-            },
-            self._SHORT_TIMEOUT,
-        )
-
-    def render_drawing(self, svg_path: str, width: int = 0, save_to: str = "") -> dict:
-        return self._call(
-            "render_drawing",
-            {"svg_path": svg_path, "width": width, "save_to": save_to},
-            self._RENDER_TIMEOUT,
-        )
-
-    def save_drawing_annotations(self, svg_path: str) -> str:
-        return self._call(
-            "save_drawing_annotations",
-            {"svg_path": svg_path},
-            self._SHORT_TIMEOUT,
-        )
-
-    def align_check(
-        self, object_a: str, object_b: str, axis: str = "Z", mode: str = "flush"
-    ) -> str:
-        return self._call(
-            "align_check",
-            {"object_a": object_a, "object_b": object_b, "axis": axis, "mode": mode},
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def resolve(self, object_name: str, selector: str, label: str = "") -> str:
-        return self._call(
-            "resolve",
-            {"object_name": object_name, "selector": selector, "label": label},
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def suggest_view_layout(
-        self,
-        object_name: str,
-        page_w: float = 297.0,
-        page_h: float = 210.0,
-        scale: float = 1.0,
-        views: list[str] | None = None,
-        title_block_w: float = 150.0,
-        title_block_h: float = 30.0,
-        margin: float = 10.0,
-        extents: list[float] | None = None,
-        centroid: list[float] | None = None,
-    ) -> str:
-        return self._call(
-            "suggest_view_layout",
-            {
-                "object_name": object_name,
-                "page_w": page_w,
-                "page_h": page_h,
-                "scale": scale,
-                "views": views,
-                "title_block_w": title_block_w,
-                "title_block_h": title_block_h,
-                "margin": margin,
-                "extents": extents,
-                "centroid": centroid,
-            },
-            self._GEOMETRY_TIMEOUT,
-        )
-
-    def script(self, save_to: str = "") -> str:
-        return self._call("script", {"save_to": save_to}, self._SHORT_TIMEOUT)
-
-    def search_library(self, query: str = "") -> str:
-        return self._call("search_library", {"query": query}, self._SHORT_TIMEOUT)
-
-    def load_part(self, name: str, params: str = "") -> str:
-        # Library part scripts can build heavy geometry (threads, gears) just
-        # like a STEP import, so honour the exec-timeout knob here too (#229).
-        timeout = max(self._GEOMETRY_TIMEOUT, self._exec_timeout)
-        return self._call("load_part", {"name": name, "params": params}, timeout)
+        proxy.__name__ = name
+        return proxy
 
 
 class InProcessSession(WorkerSession):
@@ -704,7 +554,7 @@ class InProcessSession(WorkerSession):
     def reset(self) -> str:
         # The base method short-circuits via self._proc.is_alive(); there is
         # no process here, so always dispatch the real reset.
-        return self._call("reset", {}, self._SHORT_TIMEOUT)
+        return self._call("reset", {}, _SHORT_TIMEOUT)
 
     def _call(self, op: str, args: dict, timeout: int) -> Any:
         # Same error contract as the worker path: tool exceptions surface as

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -154,6 +154,8 @@ def _tool(path: str) -> "Callable[[Any, dict, Any], Any]":
         fn = getattr(importlib.import_module(module_name), func_name)
         return fn(session, **args)
 
+    # Lets tests pin stub defaults to the tool function's (the operative ones).
+    handler.__tool_path__ = path  # type: ignore[attr-defined]
     return handler
 
 
@@ -546,7 +548,7 @@ class WorkerSession:
     @_op(_tool(f"{_T}.suggest_view_layout:suggest_view_layout"), _GEOMETRY_TIMEOUT)
     def suggest_view_layout(
         self,
-        object_name: str = "",
+        object_name: str,
         page_w: float = 297.0,
         page_h: float = 210.0,
         scale: float = 1.0,

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -11,8 +11,8 @@ because the helper and the state share a process. This module pins the worker
 boundary instead:
 
 1. ``test_every_op_reachable_via_proxy`` — every op in the ``worker._OPS`` table
-   resolves to a callable ``WorkerSession`` proxy (generated or explicit), and
-   unknown attributes still raise ``AttributeError`` (no silent op-name typos).
+   resolves to a callable ``WorkerSession`` proxy (an ``@_op``-decorated stub or
+   an explicit method), so no table entry is unreachable from server.py.
 2. ``test_session_stateful_tool_sees_worker_state`` — each listed stateful tool,
    invoked through a real ``WorkerSession``, sees state that was created with
    ``execute()`` in the worker.
@@ -47,16 +47,13 @@ def _dispatch_ops() -> set[str]:
 def test_every_op_reachable_via_proxy():
     """Every table op resolves to a callable on ``WorkerSession``.
 
-    Generated proxies (``__getattr__``) and explicit methods (execute, reset)
-    both count; an op that resolves to nothing would make the tool unreachable
-    from server.py. Unknown attributes must still raise ``AttributeError`` so
-    an op-name typo at a call site fails loudly rather than dispatching.
+    ``@_op``-decorated stubs and explicit methods (execute, reset) both count;
+    an op registered in ``_OPS`` without a corresponding method would make the
+    tool unreachable from server.py.
     """
     ws = WorkerSession.__new__(WorkerSession)  # attribute access only; no worker spawned
     for op in sorted(_dispatch_ops()):
         assert callable(getattr(ws, op)), f"op '{op}' has no callable proxy"
-    with pytest.raises(AttributeError):
-        ws.not_a_real_op
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -10,8 +10,9 @@ Helper-level tests against an in-process ``Session`` cannot catch that: they pas
 because the helper and the state share a process. This module pins the worker
 boundary instead:
 
-1. ``test_dispatch_ops_match_proxy_methods`` — every worker dispatch op has a
-   matching ``WorkerSession`` proxy method and vice-versa (1:1, AST-derived).
+1. ``test_every_op_reachable_via_proxy`` — every op in the ``worker._OPS`` table
+   resolves to a callable ``WorkerSession`` proxy (generated or explicit), and
+   unknown attributes still raise ``AttributeError`` (no silent op-name typos).
 2. ``test_session_stateful_tool_sees_worker_state`` — each listed stateful tool,
    invoked through a real ``WorkerSession``, sees state that was created with
    ``execute()`` in the worker.
@@ -26,8 +27,6 @@ guarded by tests/test_worker_session_tools.py and tests/test_session_resource.py
 this module guards the worker-routed pattern that is now the established norm.
 """
 
-import ast
-import inspect
 import json
 
 import pytest
@@ -36,59 +35,28 @@ from build123d_mcp import worker
 from build123d_mcp.worker import WorkerSession
 
 # --------------------------------------------------------------------------- #
-# AST extraction of the dispatch / proxy op sets (single source of truth)      #
+# The op table (single source of truth)                                        #
 # --------------------------------------------------------------------------- #
 
 
 def _dispatch_ops() -> set[str]:
-    """Op strings compared in ``worker._dispatch`` (``if op == "...":``)."""
-    tree = ast.parse(inspect.getsource(worker._dispatch))
-    ops: set[str] = set()
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Compare)
-            and isinstance(node.left, ast.Name)
-            and node.left.id == "op"
-            and len(node.comparators) == 1
-            and isinstance(node.comparators[0], ast.Constant)
-            and isinstance(node.comparators[0].value, str)
-        ):
-            ops.add(node.comparators[0].value)
-    return ops
+    """Ops registered in the ``worker._OPS`` table (handler + timeout + params)."""
+    return set(worker._OPS)
 
 
-def _proxy_ops() -> set[str]:
-    """Op strings each ``WorkerSession`` method passes to ``self._call(op, ...)``."""
-    tree = ast.parse(inspect.getsource(WorkerSession))
-    ops: set[str] = set()
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "_call"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "self"
-            and node.args
-            and isinstance(node.args[0], ast.Constant)
-            and isinstance(node.args[0].value, str)
-        ):
-            ops.add(node.args[0].value)
-    return ops
+def test_every_op_reachable_via_proxy():
+    """Every table op resolves to a callable on ``WorkerSession``.
 
-
-def test_dispatch_ops_match_proxy_methods():
-    """Every worker dispatch op is reachable through a proxy method and vice-versa.
-
-    Adding a ``_dispatch`` branch without a ``WorkerSession`` method (the tool is
-    unreachable from server.py), or a proxy method whose op string has no handler
-    (every call raises ``Unknown operation``), breaks this 1:1 mapping.
+    Generated proxies (``__getattr__``) and explicit methods (execute, reset)
+    both count; an op that resolves to nothing would make the tool unreachable
+    from server.py. Unknown attributes must still raise ``AttributeError`` so
+    an op-name typo at a call site fails loudly rather than dispatching.
     """
-    dispatch = _dispatch_ops()
-    proxy = _proxy_ops()
-    assert dispatch == proxy, (
-        f"dispatch-only ops (no proxy method): {sorted(dispatch - proxy)}; "
-        f"proxy-only ops (no dispatch handler): {sorted(proxy - dispatch)}"
-    )
+    ws = WorkerSession.__new__(WorkerSession)  # attribute access only; no worker spawned
+    for op in sorted(_dispatch_ops()):
+        assert callable(getattr(ws, op)), f"op '{op}' has no callable proxy"
+    with pytest.raises(AttributeError):
+        ws.not_a_real_op
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -56,6 +56,41 @@ def test_every_op_reachable_via_proxy():
         assert callable(getattr(ws, op)), f"op '{op}' has no callable proxy"
 
 
+def test_stub_defaults_match_tool_function_defaults():
+    """Stub-signature defaults must equal the tool function's own defaults.
+
+    Omitted optionals are not sent over the wire, so the tool function's
+    defaults are what actually applies; the stub defaults are the documented
+    interface. If they drift, behaviour silently depends on whether a caller
+    passes the argument explicitly.
+    """
+    import importlib
+    import inspect
+
+    checked = 0
+    for op, spec in worker._OPS.items():
+        path = getattr(spec.handler, "__tool_path__", None)
+        if path is None:
+            continue  # custom _op_<name> handler validates its own args
+        module_name, _, func_name = path.partition(":")
+        fn = getattr(importlib.import_module(module_name), func_name)
+        fn_params = inspect.signature(fn).parameters
+        # signature() follows __wrapped__ back to the @_op-decorated stub.
+        stub_params = inspect.signature(getattr(WorkerSession, op)).parameters
+        for pname, stub_p in stub_params.items():
+            if pname == "self":
+                continue
+            assert pname in fn_params, f"{op}: stub param '{pname}' not on the tool function"
+            if stub_p.default is inspect.Parameter.empty:
+                continue
+            assert stub_p.default == fn_params[pname].default, (
+                f"{op}.{pname}: stub default {stub_p.default!r} != "
+                f"tool-function default {fn_params[pname].default!r}"
+            )
+            checked += 1
+    assert checked > 20, "default-sync check matched suspiciously few parameters"
+
+
 # --------------------------------------------------------------------------- #
 # Smoke inventory: each stateful tool must SEE worker-owned state              #
 # --------------------------------------------------------------------------- #

--- a/tests/test_worker_timeouts.py
+++ b/tests/test_worker_timeouts.py
@@ -14,7 +14,13 @@ import inspect
 import pytest
 
 from build123d_mcp.security import ExecutionTimeout
-from build123d_mcp.worker import WorkerSession
+from build123d_mcp.worker import (
+    _EXPORT_TIMEOUT,
+    _GEOMETRY_TIMEOUT,
+    _RENDER_TIMEOUT,
+    _SHORT_TIMEOUT,
+    WorkerSession,
+)
 
 _STATE_LOSS_MARKER = "has been lost"
 
@@ -47,8 +53,8 @@ def test_geometry_heavy_ops_use_geometry_timeout():
     ws.resolve("a", ".faces()")
     ws.suggest_view_layout("a")
 
-    assert all(t == WorkerSession._GEOMETRY_TIMEOUT for _op, t in record), record
-    assert WorkerSession._GEOMETRY_TIMEOUT > WorkerSession._SHORT_TIMEOUT
+    assert all(t == _GEOMETRY_TIMEOUT for _op, t in record), record
+    assert _GEOMETRY_TIMEOUT > _SHORT_TIMEOUT
 
 
 def test_import_cad_file_honours_exec_timeout():
@@ -66,7 +72,7 @@ def test_import_cad_file_keeps_export_floor():
     record = []
     ws = _proxy_session(record, exec_timeout=10)
     ws.import_cad_file("part.step")
-    assert record == [("import_cad_file", WorkerSession._EXPORT_TIMEOUT)]
+    assert record == [("import_cad_file", _EXPORT_TIMEOUT)]
 
 
 def test_load_part_honours_exec_timeout():
@@ -81,7 +87,7 @@ def test_load_part_keeps_geometry_floor():
     record = []
     ws = _proxy_session(record, exec_timeout=10)
     ws.load_part("worm_gear")
-    assert record == [("load_part", WorkerSession._GEOMETRY_TIMEOUT)]
+    assert record == [("load_part", _GEOMETRY_TIMEOUT)]
 
 
 def test_bookkeeping_ops_keep_short_timeout():
@@ -95,7 +101,7 @@ def test_bookkeeping_ops_keep_short_timeout():
     ws.restore_snapshot("s")
     ws.search_library("q")
 
-    assert all(t == WorkerSession._SHORT_TIMEOUT for _op, t in record), record
+    assert all(t == _SHORT_TIMEOUT for _op, t in record), record
 
 
 class _StubConn:
@@ -165,4 +171,4 @@ def test_vtk_subprocess_timeout_below_render_poll():
     from build123d_mcp.tools.render import _vtk_render_subprocess
 
     inner = inspect.signature(_vtk_render_subprocess).parameters["timeout"].default
-    assert inner < WorkerSession._RENDER_TIMEOUT
+    assert inner < _RENDER_TIMEOUT


### PR DESCRIPTION
Closes #220.

## What

Replaces worker.py's 28-branch `_dispatch` if-chain and ~28 hand-written `WorkerSession` proxy methods with a single `_OPS` table populated by an `@_op` decorator on typed stub methods.

Each op is now defined exactly once, as a real typed method:

```python
@_op(_tool(f"{_T}.measure:measure"), _GEOMETRY_TIMEOUT)
def measure(self, object_name: str = "", density: float = 0.0, material: str = "") -> str:
    raise NotImplementedError  # body replaced by @_op
```

The decorator records the op in `_OPS` (handler + timeout + param order from the signature) and replaces the body with bind-and-send. `_dispatch` becomes a table lookup. Ops needing worker-side logic beyond `fn(session, **args)` keep small `_op_<name>` handlers; `execute`/`reset` keep explicit parent-side methods.

## Why this shape

- **One definition site per op** — signature, timeout, and worker handler live together; the dispatch/proxy/timeout drift class (#179/#182) is structurally impossible.
- **Full static typing retained** — the `Callable[[F], F]` decorator typing keeps the declared signature visible to mypy and IDEs; wrong-typed args, unknown kwargs, and typo'd op names all fail `mypy` (verified).
- **No positional-order fragility** — args map through the real Python signature via `sig.bind`, not a hand-maintained tuple.

## Behaviour

Unchanged. All timeouts identical to the old proxies (incl. the #229 `max(..., exec_timeout)` budgets). Omitted optionals are no longer sent over the wire and fall through to the tool-function defaults — verified equal to the old proxy defaults for all 27 ops. server.py needed zero changes.

## Tests

- Boundary test now reads `worker._OPS` directly instead of AST-scraping the if-chain; new `test_every_op_reachable_via_proxy` pins that every table op resolves to a callable method.
- `tests/test_worker_timeouts.py` re-pointed at the module-level timeout constants.
- Full suite: 699 passed; ruff + mypy clean.

CLAUDE.md's "Adding a new tool" recipe updated to the decorator pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
