### PR TITLE
docs: list all registered tools in README; cover SVG inspection in drawing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 - `measure` — full geometric summary: volume, area, topology, bounding box, centre of mass, inertia tensor, face-type inventory
 - `clearance` — minimum distance (mm) between two named shapes
 - `cross_sections` — cross-sectional areas at evenly spaced planes along X/Y/Z; useful for detecting voids and wall-thickness variation
+- `resolve` — evaluate a selector expression (e.g. `.faces().filter_by(Axis.Z).last()`) against a named object and return a geometry descriptor
+- `analyze_printability` — BREP-exact FDM printability analysis: overhangs, thin walls, minimum features, bed fit, tip-over risk
 - `session_state` — full JSON snapshot of active shapes, named objects, snapshot names, and Python namespace variables
 - `last_error` — details of the last failed `execute()`: type, message, line number, and code excerpt
 
 **Viewing**
 - `render_view` — render one or more shapes as PNG / SVG / DXF; auto-detects 3D vs 2D inputs (composed dimensioned drawings via `build123d.drafting` rasterise via ezdxf+matplotlib); supports assembly compositing, high-quality tessellation, cross-section clip planes, and optional labels for named shapes or specific faces/edges
+
+**Engineering drawings**
+- `suggest_view_layout` — auto-calculate safe page positions for a standard multi-view drawing layout
+- `view_axes` — world-to-page axis mapping for a projected view, computed analytically before rendering
+- `render_drawing` — rasterise an SVG file from disk to PNG
+- `inspect_drawing` — structured bbox/annotation report for a 2D drawing (session objects or an SVG on disk)
+- `lint_drawing` — structural drawing-quality checks: label/geometry divergence, overlapping annotations, page overshoot
+- `save_drawing_annotations` — write a `.dims.json` sidecar capturing label metadata alongside an exported SVG
 
 **Import / export**
 - `export` — export as STEP / STL / DXF / SVG (or comma-separated like `step,stl`); auto-detects 2D vs 3D shape and routes to the appropriate format; targets a named object, the current shape, or `*` for all objects as an assembly
@@ -34,6 +44,7 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 
 **Comparison**
 - `shape_compare` — compare two named shapes by volume, bbox, topology, and centre offset
+- `align_check` — check alignment between two named objects along an axis (flush / center / clearance modes)
 
 **Session checkpoints**
 - `save_snapshot` / `restore_snapshot` / `diff_snapshot` — checkpoint, recover, and compare geometric state
@@ -47,6 +58,8 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 - `health_check` — verify VTK/SVG/STEP/STL dependencies work end-to-end
 - `repair_hints` — get targeted fix suggestions for a given `execute()` error message
 - `workflow_hints` — guidance on using the tools effectively
+- `script` — assemble a reproducible Python script from the session's executed code blocks
+- `install_skill` — copy a b123d workflow skill (modeling or drawing) into the current project
 
 ## Resources
 

--- a/src/build123d_mcp/skills/b123d-drawing/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-drawing/SKILL.md
@@ -133,6 +133,18 @@ complete, dimensions are legible and not colliding, and the title block reads
 correctly. `view_annotation_overlap` warnings from the lint step usually show up
 here as cramped leaders — fix them with the builder (Step 2) if they matter.
 
+Then preserve the label metadata and check the exported file itself:
+
+```
+mcp__build123d-mcp__save_drawing_annotations(svg_path='drawings/part_name.svg')
+mcp__build123d-mcp__inspect_drawing(svg_path='drawings/part_name.svg')
+```
+
+build123d renders text as glyph paths, so label strings are irrecoverable from
+a finished SVG — `save_drawing_annotations` writes a `.dims.json` sidecar that
+`inspect_drawing(svg_path=...)` reads back, letting you (or a later session)
+inspect page size, layers, and annotation content without rebuilding anything.
+
 ---
 
 ## Step 4 — Save a standalone regeneration script (default)


### PR DESCRIPTION
Audit follow-up: the README's **Tools** section documented 20 of the 31 registered tools — it predated the drawing-tooling and printability features. This adds the missing 11:

- new **Engineering drawings** category: `suggest_view_layout`, `view_axes`, `render_drawing`, `inspect_drawing`, `lint_drawing`, `save_drawing_annotations`
- **Geometry inspection**: `resolve`, `analyze_printability`
- **Comparison**: `align_check`
- **Utility**: `script`, `install_skill`

Also extends the drawing skill's Verify step with `save_drawing_annotations` + `inspect_drawing(svg_path=...)` so label metadata survives the export (build123d renders text as glyph paths, so labels are otherwise irrecoverable from the SVG).

Stacked on #253 to avoid README conflicts — GitHub will retarget this to `main` when #253 merges. Docs-only otherwise; full suite still 694 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)