### PR TITLE
ci: bump all actions to current majors (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Sets up xvfb on Linux and Mesa3D on Windows (no-op on macOS).
       # vtk 9.3.1 ships no cp313 wheel, so pin Python below to 3.12.
-      - uses: pyvista/setup-headless-display-action@v3
+      - uses: pyvista/setup-headless-display-action@v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Set TestPyPI dev version
@@ -27,7 +27,7 @@ jobs:
           base="${current%.dev*}"
           uv version "$base"
       - run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -40,7 +40,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -56,7 +56,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -70,7 +70,7 @@ jobs:
       id-token: write   # for github-oidc auth to the MCP registry
       contents: read    # for checkout
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Sync server.json version with the release tag
         run: |
           tag=${{ github.event.release.tag_name }}
@@ -99,10 +99,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Bump patch version with .dev0 suffix


### PR DESCRIPTION
All five pinned actions were on Node 20-runtime majors, which GitHub is deprecating in favour of Node 24.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `astral-sh/setup-uv` | v5 | v8.2.0 |
| `pyvista/setup-headless-display-action` | v3 | v4 |

Breaking changes reviewed against our usage:

- **download-artifact v5**: path change only affects downloads **by ID** — we download by name (`dist`), unaffected.
- **download-artifact v8**: digest mismatches now *error* instead of warn — secure default, desirable for a publish pipeline. Non-zipped downloads are no longer unzipped — our artifacts are standard zipped uploads, unaffected.
- **upload-artifact v7**: ESM rewrite + optional `archive` input — our `name`/`path` usage unaffected.
- **setup-uv v6**: `python-version` no longer auto-activates a venv — our workflows only use `uv sync` / `uv run`, which never relied on it. v7 removed `server-url` (unused). **v8 stopped publishing major tags entirely** (supply-chain hardening), hence the exact `v8.2.0` pin.
- **checkout v5/v6**: Node 24 + credentials persisted to a separate file; no usage impact.
- **headless-display v4.x**: maintenance/bugfix releases only.

Verification: CI on this PR exercises checkout, headless-display, and setup-uv on all three OSes. The artifact + TestPyPI half of publish.yml runs on the merge to main; the PyPI-release half gets exercised on the next release after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)