### PR TITLE
docs: changelog for v0.3.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.3.48 — 2026-06-11
+## v0.3.49 — 2026-06-12
 
 ### Features
 
@@ -14,6 +14,11 @@
 - **`find_hole_patterns` tool** — bolt-circle / linear-array recognition over
   the hole records (`{type, holes, center/diameter | pitch/direction}`).
 - **`find_holes` / `find_bosses` tools** — feature recognition on session objects via build123d-drafting-helpers ≥ 0.6.0 (#264). Coaxial internal cylinders are grouped into one record per drilled hole (drill + counterbore + spotface; keyway-split and crossing-hole-interrupted bores count once) with axis, opening location, diameter, depth, and bottom classification (`through` / `flat` / `drill_point` / `unknown`); `find_bosses` reports external segments with height. Replaces the hand-rolled `BRepAdaptor_Surface` hole detection that dominated the NIST CTC-02 benchmark session.
+
+## v0.3.48 — 2026-06-11
+
+### Features
+
 - **`save_json(name, obj)` sandbox helper** — the sanctioned structured-output channel for `execute()` (#259). JSON-serializes analysis data (face inventories, hole tables, section data) to a per-process server scratch dir with a validated stem and 10 MB cap, returning the path for the caller to read back. `open()`/`os` remain blocked.
 - **`build123d://drafting-api` MCP resource** — API reference for build123d-drafting-helpers generated from the installed library with `inspect`, so signatures never drift across releases (#260). Pointed to from the drawing skill.
 - **`suggest_view_layout` now reports per-view `free_space` bands** — the empty rectangle outside each view edge, clipped against neighbouring views, the title block, and the page margins, so agents can budget dimension tiers before placing annotations (#261).


### PR DESCRIPTION
Splits the post-release entries (#266 find tools, #267 guidance + find_hole_patterns) out of the already-shipped v0.3.48 section into a new v0.3.49 section, ahead of cutting the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)