### PR TITLE
chore: bump build123d-drafting-helpers pin to >=0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Bundled at runtime so `inspect_drawing`'s docstring promise — and the
     # build123d://drafting cookbook — actually work out of the box.
     # Import name remains `build123d_drafting` (install name ≠ import name).
-    "build123d-drafting-helpers>=0.7.0",
+    "build123d-drafting-helpers>=0.10.0",
     "defusedxml>=0.7.1",
     "augura>=0.1.3",
 ]

--- a/tests/test_drafting_api.py
+++ b/tests/test_drafting_api.py
@@ -16,7 +16,7 @@ def test_reference_carries_signatures_not_just_names():
     ref = drafting_api(None)
     # Keyword names are the whole point of the resource (#260).
     assert "label" in ref
-    assert ".add_view(" in ref or "add_view(" in ref
+    assert "drawing_scale" in ref  # lint_drawing keyword — proves signatures, not just names
 
 
 def test_resource_uses_worker_routing():


### PR DESCRIPTION
0.10.0 is the first release without the drawing engine (`make_drawing`, `build_drawing`, etc.) — pinning below this could pull in a version that still exports those names but is missing the engine's dependencies (kiwisolver). This MCP server doesn't use the engine directly, but a consistent floor avoids confusing environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)