### PR TITLE
fix: correct resource limits and expose via CLI (review of #272)

### DIFF
--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -212,6 +212,12 @@ Part library file format (Python, any .py file under --library path):
             session_kwargs["memory_limit_mb"] = args.memory_limit_mb
         if args.cpu_limit_s is not None:
             session_kwargs["cpu_limit_s"] = args.cpu_limit_s
+    elif args.memory_limit_mb is not None or args.cpu_limit_s is not None:
+        print(
+            "WARNING: --memory-limit-mb and --cpu-limit-s are ignored in --in-process mode "
+            "(no worker subprocess to limit).",
+            file=sys.stderr,
+        )
     server.configure(session_cls(**session_kwargs))
 
     if args.transport == "http":

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -180,6 +180,11 @@ Part library file format (Python, any .py file under --library path):
     if args.library and not os.path.isdir(args.library):
         parser.error(f"Library path is not a directory: {args.library}")
 
+    if args.transport not in ("stdio", "http"):
+        parser.error(
+            f"invalid BUILD123D_TRANSPORT value '{args.transport}'; must be 'stdio' or 'http'"
+        )
+
     if args.memory_limit_mb is not None and args.memory_limit_mb <= 0:
         parser.error(f"--memory-limit-mb must be a positive integer, got {args.memory_limit_mb}")
     if args.cpu_limit_s is not None and args.cpu_limit_s <= 0:

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -159,7 +159,7 @@ Part library file format (Python, any .py file under --library path):
         "--memory-limit-mb",
         metavar="MB",
         type=int,
-        default=int(os.environ.get("BUILD123D_MEMORY_LIMIT_MB", "0")) or None,
+        default=int(os.environ.get("BUILD123D_MEMORY_LIMIT_MB") or "0") or None,
         help="Cap the worker's heap/data segment in MB via RLIMIT_DATA (POSIX only; "
         "ignored on Windows). Note: mmap-backed allocations (large OCC buffers) are "
         "not covered — use container cgroup limits for comprehensive memory control. "
@@ -169,7 +169,7 @@ Part library file format (Python, any .py file under --library path):
         "--cpu-limit-s",
         metavar="SECONDS",
         type=int,
-        default=int(os.environ.get("BUILD123D_CPU_LIMIT_S", "0")) or None,
+        default=int(os.environ.get("BUILD123D_CPU_LIMIT_S") or "0") or None,
         help="Cap total CPU time for the worker subprocess in seconds via RLIMIT_CPU "
         "(POSIX only; ignored on Windows). The worker receives SIGXCPU when the soft "
         "limit is reached and is killed at the hard limit. "
@@ -179,6 +179,11 @@ Part library file format (Python, any .py file under --library path):
 
     if args.library and not os.path.isdir(args.library):
         parser.error(f"Library path is not a directory: {args.library}")
+
+    if args.memory_limit_mb is not None and args.memory_limit_mb <= 0:
+        parser.error(f"--memory-limit-mb must be a positive integer, got {args.memory_limit_mb}")
+    if args.cpu_limit_s is not None and args.cpu_limit_s <= 0:
+        parser.error(f"--cpu-limit-s must be a positive integer, got {args.cpu_limit_s}")
 
     extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
 
@@ -205,8 +210,6 @@ Part library file format (Python, any .py file under --library path):
     server.configure(session_cls(**session_kwargs))
 
     if args.transport == "http":
-        import sys
-
         import uvicorn
 
         print(

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -151,7 +151,7 @@ Part library file format (Python, any .py file under --library path):
     parser.add_argument(
         "--port",
         type=int,
-        default=int(os.environ.get("BUILD123D_PORT", "8000")),
+        default=int(os.environ.get("BUILD123D_PORT") or "8000"),
         help="Port to bind when --transport http (default: 8000). "
         "Overrides BUILD123D_PORT env var.",
     )

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -121,7 +121,7 @@ Part library file format (Python, any .py file under --library path):
         "--exec-timeout",
         metavar="SECONDS",
         type=int,
-        default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT", "120")),
+        default=int(os.environ.get("BUILD123D_EXEC_TIMEOUT") or "120"),
         help="Execution time limit in seconds for user code (default: 120). "
         "Overrides BUILD123D_EXEC_TIMEOUT env var.",
     )

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -155,6 +155,26 @@ Part library file format (Python, any .py file under --library path):
         help="Port to bind when --transport http (default: 8000). "
         "Overrides BUILD123D_PORT env var.",
     )
+    parser.add_argument(
+        "--memory-limit-mb",
+        metavar="MB",
+        type=int,
+        default=int(os.environ.get("BUILD123D_MEMORY_LIMIT_MB", "0")) or None,
+        help="Cap the worker's heap/data segment in MB via RLIMIT_DATA (POSIX only; "
+        "ignored on Windows). Note: mmap-backed allocations (large OCC buffers) are "
+        "not covered — use container cgroup limits for comprehensive memory control. "
+        "Overrides BUILD123D_MEMORY_LIMIT_MB env var.",
+    )
+    parser.add_argument(
+        "--cpu-limit-s",
+        metavar="SECONDS",
+        type=int,
+        default=int(os.environ.get("BUILD123D_CPU_LIMIT_S", "0")) or None,
+        help="Cap total CPU time for the worker subprocess in seconds via RLIMIT_CPU "
+        "(POSIX only; ignored on Windows). The worker receives SIGXCPU when the soft "
+        "limit is reached and is killed at the hard limit. "
+        "Overrides BUILD123D_CPU_LIMIT_S env var.",
+    )
     args = parser.parse_args()
 
     if args.library and not os.path.isdir(args.library):
@@ -171,18 +191,30 @@ Part library file format (Python, any .py file under --library path):
             _sec.EXTRA_ALLOWED_IMPORTS.update(extra_imports)
 
     session_cls = InProcessSession if args.in_process else WorkerSession
-    server.configure(
-        session_cls(
-            library_path=args.library,
-            allow_all_imports=args.allow_all_imports,
-            extra_allowed_imports=extra_imports,
-            exec_timeout=args.exec_timeout,
-        )
-    )
+    session_kwargs: dict = {
+        "library_path": args.library,
+        "allow_all_imports": args.allow_all_imports,
+        "extra_allowed_imports": extra_imports,
+        "exec_timeout": args.exec_timeout,
+    }
+    if not args.in_process:
+        if args.memory_limit_mb is not None:
+            session_kwargs["memory_limit_mb"] = args.memory_limit_mb
+        if args.cpu_limit_s is not None:
+            session_kwargs["cpu_limit_s"] = args.cpu_limit_s
+    server.configure(session_cls(**session_kwargs))
 
     if args.transport == "http":
+        import sys
+
         import uvicorn
 
+        print(
+            "WARNING: HTTP transport runs a single shared CAD session. "
+            "Concurrent clients will share the same build123d namespace — "
+            "suitable for single-user deployments only.",
+            file=sys.stderr,
+        )
         uvicorn.run(server.http_app(), host=args.host, port=args.port)
     else:
         server.mcp.run()

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -53,9 +53,15 @@ def configure(session: WorkerSession) -> None:
 def http_app():
     """Return the FastMCP ASGI app for use with an ASGI server (e.g. uvicorn).
 
-    The app is stateless: each HTTP request resolves its WorkerSession via
-    ``_session_var`` (set by host middleware) and falls back to the module-level
-    singleton when the ContextVar is unset.
+    **Single-session mode (default)**: all HTTP requests share the module-level
+    WorkerSession set by ``configure()``.  This is correct for single-user
+    deployments (one operator, one CAD namespace).  Concurrent clients will
+    interleave operations in the same session.
+
+    **Multi-session mode**: host middleware can isolate tenants by setting
+    ``_session_var`` to a per-request ``WorkerSession`` before the MCP handler
+    runs; ``_resolve_session()`` will then return that session instead of the
+    singleton.  No such middleware is included — this hook exists for embedders.
     """
     return mcp.streamable_http_app()
 

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -403,6 +403,16 @@ class WorkerSession:
 
             print(f"WARNING: {msg['warning']}", file=_sys.stderr)
             # Warning message is followed by the real ready/error signal.
+            # Re-apply the timeout: poll() was already satisfied by the warning,
+            # so without a second poll() the recv() below would block forever if
+            # the worker hangs in _build_session() (e.g. loading a large library).
+            if not self._conn.poll(_WORKER_READY_TIMEOUT):
+                self._proc.kill()
+                self._proc.join(5)
+                raise RuntimeError(
+                    f"Worker process did not signal ready within {_WORKER_READY_TIMEOUT}s "
+                    "after sending a startup warning."
+                )
             try:
                 msg = self._conn.recv()
             except EOFError:

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -402,8 +402,16 @@ class WorkerSession:
             import sys as _sys
 
             print(f"WARNING: {msg['warning']}", file=_sys.stderr)
-            # Warning message is followed by the real ready signal.
-            msg = self._conn.recv()
+            # Warning message is followed by the real ready/error signal.
+            try:
+                msg = self._conn.recv()
+            except EOFError:
+                self._proc.join(5)
+                exitcode = self._proc.exitcode
+                raise RuntimeError(
+                    f"Worker process failed to start: exited with code {exitcode} "
+                    "after sending a startup warning but before signalling ready."
+                )
         if "error" in msg:
             self._proc.join(5)
             raise RuntimeError(

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -75,13 +75,24 @@ def worker_main(
         try:
             import resource
 
-            if memory_limit_mb is not None:
+            if memory_limit_mb is not None and memory_limit_mb > 0:
+                # RLIMIT_DATA caps the heap/BSS data segment.  It is safe to set on
+                # a process that has already loaded large shared libraries (OCC, Python)
+                # because those VAS mappings do not count against the data segment.
+                # Note: large mmap() allocations (>128 KB by default in glibc) are not
+                # covered; for comprehensive memory control use container cgroup limits.
                 limit = memory_limit_mb * 1024 * 1024
-                resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
-            if cpu_limit_s is not None:
+                resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
+            if cpu_limit_s is not None and cpu_limit_s > 0:
                 resource.setrlimit(resource.RLIMIT_CPU, (cpu_limit_s, cpu_limit_s))
         except (ImportError, AttributeError):
             pass  # Windows has no resource module
+        except (OSError, ValueError) as exc:
+            # OSError(EPERM): soft limit exceeds the container/system hard limit.
+            # ValueError: limit value is out of range.
+            # Both mean the limit was not applied — propagate so the caller sees a
+            # clear error rather than silently running without the requested cap.
+            raise RuntimeError(f"Failed to apply resource limit: {exc}") from exc
 
     session, library_index = _build_session(
         library_path, exec_timeout, allow_all_imports, extra_allowed_imports

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -76,13 +76,28 @@ def worker_main(
             import resource
 
             if memory_limit_mb is not None and memory_limit_mb > 0:
-                # RLIMIT_DATA caps the heap/BSS data segment.  It is safe to set on
-                # a process that has already loaded large shared libraries (OCC, Python)
-                # because those VAS mappings do not count against the data segment.
-                # Note: large mmap() allocations (>128 KB by default in glibc) are not
-                # covered; for comprehensive memory control use container cgroup limits.
-                limit = memory_limit_mb * 1024 * 1024
-                resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
+                import sys as _sys
+
+                if _sys.platform == "darwin":
+                    # macOS accepts setrlimit(RLIMIT_DATA) without error but silently
+                    # ignores it — the kernel never enforces it.  Skip the call and
+                    # send a warning so the parent can surface it to the operator.
+                    conn.send(
+                        {
+                            "warning": (
+                                "--memory-limit-mb has no effect on macOS: "
+                                "RLIMIT_DATA is a documented no-op on this platform. "
+                                "Use container/VM memory limits instead."
+                            )
+                        }
+                    )
+                else:
+                    # RLIMIT_DATA caps the heap/BSS data segment.  Safe to set after
+                    # shared libraries are loaded (VAS mappings don't count against it).
+                    # Note: large mmap() allocations (>128 KB glibc default) are not
+                    # covered; use container cgroup limits for comprehensive control.
+                    limit = memory_limit_mb * 1024 * 1024
+                    resource.setrlimit(resource.RLIMIT_DATA, (limit, limit))
             if cpu_limit_s is not None and cpu_limit_s > 0:
                 resource.setrlimit(resource.RLIMIT_CPU, (cpu_limit_s, cpu_limit_s))
         except (ImportError, AttributeError):
@@ -90,9 +105,10 @@ def worker_main(
         except (OSError, ValueError) as exc:
             # OSError(EPERM): soft limit exceeds the container/system hard limit.
             # ValueError: limit value is out of range.
-            # Both mean the limit was not applied — propagate so the caller sees a
-            # clear error rather than silently running without the requested cap.
-            raise RuntimeError(f"Failed to apply resource limit: {exc}") from exc
+            # Send the error over the pipe so the parent receives it before the
+            # worker exits — avoids the parent seeing a bare EOFError from recv().
+            conn.send({"error": f"Failed to apply resource limit: {exc}"})
+            return
 
     session, library_index = _build_session(
         library_path, exec_timeout, allow_all_imports, extra_allowed_imports
@@ -369,7 +385,31 @@ class WorkerSession:
                 "relaunch the server with --in-process or BUILD123D_IN_PROCESS=1 — a "
                 "degraded mode without crash containment or operation timeouts."
             )
-        self._conn.recv()  # consume the ready signal
+        try:
+            msg = self._conn.recv()  # ready signal or startup-error dict
+        except EOFError:
+            # Worker exited before sending any message (uncaught exception in
+            # worker_main before the rlimit try block, or a spawn failure).
+            self._proc.join(5)
+            exitcode = self._proc.exitcode
+            raise RuntimeError(
+                f"Worker process failed to start: exited with code {exitcode} "
+                "before signalling ready. If your MCP host blocks subprocess "
+                "creation (seen with sandboxed hosts on Windows, issue #143), "
+                "relaunch the server with --in-process or BUILD123D_IN_PROCESS=1."
+            )
+        if "warning" in msg:
+            import sys as _sys
+
+            print(f"WARNING: {msg['warning']}", file=_sys.stderr)
+            # Warning message is followed by the real ready signal.
+            msg = self._conn.recv()
+        if "error" in msg:
+            self._proc.join(5)
+            raise RuntimeError(
+                f"Worker process failed to start: {msg['error']}. "
+                "Relaunch with --in-process to skip subprocess resource limits."
+            )
 
     def _kill_worker(self) -> None:
         try:


### PR DESCRIPTION
## Summary

Addresses the 5 confirmed/plausible findings from the code review of PR #272.

**worker.py — 3 bugs in the rlimit block**

1. `RLIMIT_AS` → `RLIMIT_DATA`: `RLIMIT_AS` caps virtual address space; Python + OCC consume 2–4 GB of VAS at startup on 64-bit Linux, so any realistic limit (e.g. 512 MB) killed the worker before OCC finished loading. `RLIMIT_DATA` caps the heap/data segment only and is safe to set after shared libraries are already mapped. (Note: mmap-backed allocations are not covered — container cgroup limits are recommended for comprehensive control.)
2. Added `> 0` guards for both `memory_limit_mb` and `cpu_limit_s`. `cpu_limit_s=0` previously passed the `is not None` check and set `RLIMIT_CPU=(0,0)`, sending SIGXCPU on the first scheduling tick and killing the worker instantly.
3. `OSError` (EPERM — soft > hard limit) and `ValueError` were not caught. Both crash `worker_main` before it can send the ready signal, leaving the parent hanging until `_WORKER_READY_TIMEOUT`. Now re-raised as `RuntimeError` with a clear message.

**cli.py — 2 gaps**

4. `memory_limit_mb` / `cpu_limit_s` had no CLI flags or env-var wiring, making the feature completely unreachable from the CLI entry point. Added `--memory-limit-mb` / `BUILD123D_MEMORY_LIMIT_MB` and `--cpu-limit-s` / `BUILD123D_CPU_LIMIT_S`. Flags are silently skipped for `--in-process` mode (applying rlimits to the parent process would affect the MCP server itself).
5. HTTP transport now emits a `stderr` warning that all clients share one CAD session (single-user mode), matching the docstring intent in `http_app()`.

**server.py — documentation**

Clarified `http_app()` docstring to document both the default single-session mode and the multi-session middleware hook.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] `pytest tests/test_resource_limits.py tests/test_path_safety.py tests/test_drafting_api.py tests/test_packaging.py` — 39 passed
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)