### PR TITLE
test: cover #268 untested acceptance criteria + draftwright allowlist

### DIFF
--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,0 +1,122 @@
+"""HTTP/ASGI transport and per-request session acceptance coverage (#268).
+
+#268 added FastMCP HTTP hosting hooks (shipped in v0.3.50). Two of its
+acceptance criteria had no regression test:
+
+  1. Concurrent requests with different session keys resolve to different
+     WorkerSessions, with no cross-talk (the per-request ContextVar resolver).
+  2. ``http_app()`` returns an ASGI app that mounts in an external ASGI
+     application and is wired as a streamable-HTTP handler.
+
+These tests pin both at the mechanism level — the ContextVar routing and the
+ASGI app construction — without spawning real worker subprocesses or a live
+HTTP server.
+"""
+
+import contextvars
+import threading
+
+from build123d_mcp import server
+
+
+def _set_singleton(value):
+    """Set the module-level session singleton, returning the previous state so
+    a test can restore it (other tests rely on a configured ``_session``)."""
+    had = hasattr(server, "_session")
+    prev = getattr(server, "_session", None)
+    server.configure(value)
+    return had, prev
+
+
+def _restore_singleton(state):
+    had, prev = state
+    if had:
+        server._session = prev
+    elif hasattr(server, "_session"):
+        del server._session
+
+
+def test_resolve_session_falls_back_to_singleton():
+    """With no per-request var set (stdio mode), the singleton is used."""
+    sentinel = object()
+    state = _set_singleton(sentinel)
+    try:
+        assert server._session_var.get() is None
+        assert server._resolve_session() is sentinel
+    finally:
+        _restore_singleton(state)
+
+
+def test_resolve_session_prefers_per_request_var():
+    """A per-request session set on the ContextVar wins over the singleton, and
+    resetting the var restores singleton resolution."""
+    singleton = object()
+    per_request = object()
+    state = _set_singleton(singleton)
+    token = server._session_var.set(per_request)
+    try:
+        assert server._resolve_session() is per_request
+    finally:
+        server._session_var.reset(token)
+    try:
+        assert server._resolve_session() is singleton
+    finally:
+        _restore_singleton(state)
+
+
+def test_concurrent_requests_isolated_no_crosstalk():
+    """Acceptance criterion 1: two concurrent 'requests' (each in its own
+    context, as an ASGI task) set distinct sessions and each resolves only its
+    own — no leakage between them or onto the shared singleton."""
+    singleton = object()
+    state = _set_singleton(singleton)
+    sessions = {"a": object(), "b": object()}
+    seen: dict[str, object] = {}
+    both_set = threading.Barrier(2)
+
+    def handle(key: str) -> None:
+        def run() -> None:
+            server._session_var.set(sessions[key])
+            # Both requests have set their var before either reads, so a leak
+            # would surface as a wrong/observed value here.
+            both_set.wait(timeout=5)
+            seen[key] = server._resolve_session()
+
+        # copy_context() models the ASGI server running each request in its own
+        # context; the var set inside never escapes to the base context.
+        contextvars.copy_context().run(run)
+
+    try:
+        threads = [threading.Thread(target=handle, args=(k,)) for k in sessions]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert seen["a"] is sessions["a"]
+        assert seen["b"] is sessions["b"]
+        # The per-request vars never touched the base context's resolution.
+        assert server._session_var.get() is None
+        assert server._resolve_session() is singleton
+    finally:
+        _restore_singleton(state)
+
+
+def test_http_app_is_mountable_asgi():
+    """Acceptance criterion 2: http_app() returns an ASGI app that mounts in an
+    external ASGI application under a sub-path."""
+    from starlette.applications import Starlette
+    from starlette.routing import Mount
+
+    app = server.http_app()
+    assert callable(app)  # ASGI app is callable (scope, receive, send)
+
+    parent = Starlette(routes=[Mount("/mcp", app=app)])
+    assert any(getattr(r, "path", None) == "/mcp" for r in parent.routes)
+
+
+def test_fastmcp_is_stateless_http():
+    """http_app() relies on stateless HTTP (session identity comes from the
+    embedder's headers, not MCP session IDs) — pin that the server is built
+    that way so the ASGI hook stays embeddable."""
+    assert server.mcp.settings.stateless_http is True

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -72,15 +72,21 @@ def test_concurrent_requests_isolated_no_crosstalk():
     state = _set_singleton(singleton)
     sessions = {"a": object(), "b": object()}
     seen: dict[str, object] = {}
+    errors: dict[str, BaseException] = {}
+    # The barrier forces both requests to set their var BEFORE either reads.
+    # That ordering is what gives this test teeth: a plain module global would
+    # be overwritten by the second setter, so both reads would return the same
+    # value and the assertions below would fail. A ContextVar keeps them apart.
     both_set = threading.Barrier(2)
 
     def handle(key: str) -> None:
         def run() -> None:
-            server._session_var.set(sessions[key])
-            # Both requests have set their var before either reads, so a leak
-            # would surface as a wrong/observed value here.
-            both_set.wait(timeout=5)
-            seen[key] = server._resolve_session()
+            try:
+                server._session_var.set(sessions[key])
+                both_set.wait(timeout=10)
+                seen[key] = server._resolve_session()
+            except BaseException as exc:  # surface thread failures, incl. barrier timeout
+                errors[key] = exc
 
         # copy_context() models the ASGI server running each request in its own
         # context; the var set inside never escapes to the base context.
@@ -91,8 +97,10 @@ def test_concurrent_requests_isolated_no_crosstalk():
         for t in threads:
             t.start()
         for t in threads:
-            t.join(timeout=10)
+            t.join(timeout=30)
 
+        assert not any(t.is_alive() for t in threads), "request thread hung"
+        assert not errors, f"request thread(s) errored: {errors}"
         assert seen["a"] is sessions["a"]
         assert seen["b"] is sessions["b"]
         # The per-request vars never touched the base context's resolution.
@@ -109,10 +117,13 @@ def test_http_app_is_mountable_asgi():
     from starlette.routing import Mount
 
     app = server.http_app()
-    assert callable(app)  # ASGI app is callable (scope, receive, send)
+    # A real ASGI app, not just any callable — Mount would accept anything.
+    assert isinstance(app, Starlette)
 
     parent = Starlette(routes=[Mount("/mcp", app=app)])
-    assert any(getattr(r, "path", None) == "/mcp" for r in parent.routes)
+    mount = next((r for r in parent.routes if getattr(r, "path", None) == "/mcp"), None)
+    assert mount is not None
+    assert mount.app is app  # the FastMCP app is what got mounted
 
 
 def test_fastmcp_is_stateless_http():

--- a/tests/test_transitive_imports.py
+++ b/tests/test_transitive_imports.py
@@ -54,6 +54,19 @@ def test_nonexistent_module_is_blocked():
     assert _is_transitively_safe("no_such_module_xyz_abc_999") is False
 
 
+def test_draftwright_is_allowlisted():
+    """draftwright (the AGPL drawing engine spun out of build123d-drafting-helpers,
+    #270) is a deliberate bring-your-own dependency: not installed by this Apache
+    server, but permitted in the sandbox so users who install it can
+    `from draftwright import make_drawing` without --allow-imports. The membership
+    check must short-circuit before the transitive find_spec, so the import passes
+    even when draftwright is absent."""
+    assert _sec._is_root_allowed("draftwright") is True
+    # check_ast validates the name against the allowlist without importing it,
+    # so this does not require draftwright to be installed.
+    _sec.check_ast("from draftwright import make_drawing")
+
+
 def test_safe_package_allowed(tmp_path, monkeypatch):
     pkg = _make_pkg(
         tmp_path,


### PR DESCRIPTION
## Why

#268 (HTTP/ASGI hosting hooks) was fully implemented in #272 and hardened in #273, shipping in **v0.3.50** — but the issue is still open and two of its four acceptance criteria had **no regression test**. Criteria 3 (per-worker rlimits) and 4 (FS root) are covered by `test_resource_limits.py` / `test_path_safety.py`; criteria 1 and 2 were not.

This PR adds that coverage. **No production code changes** — tests only, at the mechanism level (no worker subprocess spawned, no live HTTP server bound).

## What

`tests/test_http_session.py`:
- **Criterion 1 — per-request session isolation.** `_resolve_session()` falls back to the stdio singleton when no per-request var is set; prefers a per-request `_session_var`; and two concurrent "requests" in separate `contextvars` contexts each resolve to their own session with no cross-talk and no leakage onto the shared singleton.
- **Criterion 2 — mountable ASGI app.** `http_app()` returns a callable ASGI app that mounts under `/mcp` in an external Starlette app; FastMCP is built `stateless_http=True` (the property the per-request header-based identity relies on — found to live at `mcp.settings.stateless_http`).

`tests/test_transitive_imports.py`:
- Pins that `draftwright` (#270) is in `IMPORT_ALLOWLIST` and that `check_ast("from draftwright import make_drawing")` passes **without** draftwright being installed — locking in the deliberate bring-your-own arrangement (AGPL engine, kept out of this Apache server's deps, permitted in the sandbox).

## Tests

26 new/affected pass; full suite **728 passed**; ruff clean.

Once this merges I'll close #268 (it shipped in v0.3.50; #272 said "Implements" rather than "Closes", so it never auto-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)