### PR TITLE
fix: sync uv.lock build123d-mcp version to 0.3.51.dev0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "build123d-mcp"
-version = "0.3.52.dev0"
+version = "0.3.51.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "augura" },


### PR DESCRIPTION
The revert in `a5365cb` ("revert bot's erroneous 0.3.52.dev0 bump") corrected `pyproject.toml` back to `0.3.51.dev0` but left `uv.lock` still pinning the editable `build123d-mcp` package at `0.3.52.dev0`. Regenerated `uv.lock` via `uv lock` so it matches `pyproject.toml`.

Single line, version field only — no dependency resolution changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)