### PR TITLE
feat: pre-export validity gate (validate tool + export warning)

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -152,7 +152,7 @@ Check whether a shape would pass a CAD validity gate before exporting it. The ga
 
 **Input:** `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
 
-**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `is_manifold`, `brep_valid`, and `reasons` (actionable failure causes).
+**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `is_manifold`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task).
 
 A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off; `export()` re-runs the gate and warns on a 3D export that would fail.
 

--- a/llms.md
+++ b/llms.md
@@ -147,6 +147,17 @@ Prefer `measure()` over `render_view()` for verifying geometry — numbers are u
 
 ---
 
+### `validate`
+Check whether a shape would pass a CAD validity gate before exporting it. The gate mirrors what CAD scorers and downstream tools require — a well-formed (BRepCheck), watertight, manifold solid with non-zero volume.
+
+**Input:** `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
+
+**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `is_manifold`, `brep_valid`, and `reasons` (actionable failure causes).
+
+A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off; `export()` re-runs the gate and warns on a 3D export that would fail.
+
+---
+
 ### `clearance`
 Spatial relationship between two named shapes — distance, containment, and overlap in one call.
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -117,6 +117,12 @@ def measure(object_name: str = "", density: float = 0.0, material: str = "") -> 
 
 
 @mcp.tool()
+def validate(object_name: str = "") -> str:
+    """Check whether a shape would pass a CAD validity gate before exporting it. Returns a PASS/FAIL verdict plus JSON (passes_gate, n_solids, volume, is_manifold, brep_valid, reasons). The gate mirrors what CAD scorers and downstream tools require: a well-formed (BRepCheck), watertight, manifold solid with non-zero volume. A FAIL means a STEP/STL export would be rejected outright (e.g. CADGenBench scores it zero) — common causes are a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before export() on any part you intend to submit or hand off. object_name: named object from show() (default: current shape)."""
+    return _resolve_session().validate(object_name)
+
+
+@mcp.tool()
 def clearance(object_a: str, object_b: str) -> str:
     """Spatial relationship between two named shapes. Returns JSON with `clearance` (mm), `status` (one of: apart, touching, containing, interpenetrating), `containment` (a_in_b, b_in_a, or neither), and `intersection_volume` / `a_volume_outside_b` / `b_volume_outside_a` for overlap quantification. Reads `clearance` differently per status: apart=gap, containing=wall thickness from inner surface to outer hull (use this to verify a pocket fits inside a plate), touching=0, interpenetrating=0 (check intersection_volume + a_volume_outside_b for the wall-piercing case). object_a, object_b: names from show()."""
     return _resolve_session().clearance(object_a, object_b)

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -111,7 +111,14 @@ The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
 ## Step 6 — Finish
 
 1. Final `measure()` against the spec: envelope, volume sanity, hole inventory.
-2. `export("part.step", "step", object_name="part")` — STEP for CAD interchange,
+2. **`validate("part")` before exporting.** A STEP/STL that is not a watertight,
+   manifold, single solid is rejected outright by CAD scorers and downstream
+   tooling (CADGenBench scores it zero) — no matter how close the geometry is.
+   A `FAIL` here almost always means the current shape is a leftover 2D sketch,
+   an open shell, an un-fused compound (`Part() + ...`), or a degenerate boolean
+   result; fix it and re-validate until it passes. `export()` re-runs this gate
+   and warns, but catch it here rather than shipping a zero.
+3. `export("part.step", "step", object_name="part")` — STEP for CAD interchange,
    STL for printing. If the project slices with
    [estampo](https://github.com/estampo/estampo) (`estampo.toml` present),
    add/update the `[[parts]]` entry for the exported file and run `estampo run`
@@ -130,14 +137,14 @@ The ceiling can be raised with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`
    The fragment sets `enable_support`, `brim_type`, and advisory
    `[slicer.overrides]` comments — review and merge it into the `[[parts]]`
    entry rather than pasting blindly (see estampo's skill).
-3. Unless the user opts out, save a clean regeneration script to
+4. Unless the user opts out, save a clean regeneration script to
    `scripts/<part>.py`: the parameter block, the build steps, and the export
    call. Follow the project's existing script layout, and pick a non-colliding
    name if one exists. The part should live in version control as code, not
    only as a STEP artifact.
-4. If the part will be FDM printed, run `analyze_printability("part")` and
+5. If the part will be FDM printed, run `analyze_printability("part")` and
    report overhangs / thin walls / bed-fit findings.
-5. For an engineering drawing of the finished part, switch to the b123d-drawing
+6. For an engineering drawing of the finished part, switch to the b123d-drawing
    skill (or the `build123d://skill/drawing` resource).
 
 ---

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -145,6 +145,19 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
     # sanity check that the right, non-degenerate object landed in the file (#241).
     sanity = _sanity_line(shape)
     suffix = f"\n{sanity}" if sanity else ""
+    # For 3D solids, run the validity gate: a CAD scorer rejects a non-watertight
+    # / non-manifold / non-solid STEP or STL outright (score zero), so flag it at
+    # the last possible moment rather than letting an invalid artifact ship.
+    if not is_2d:
+        from build123d_mcp.tools.validate import _gate_report
+
+        report = _gate_report(shape)
+        if not report["passes_gate"]:
+            suffix += (
+                "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
+                + "; ".join(report["reasons"])
+                + ". Fix the solid and re-export (run validate() for detail)."
+            )
     if len(exported) == 1:
         return f"Exported to {exported[0]}{suffix}"
     return "Exported to:\n" + "\n".join(exported) + suffix

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -1,0 +1,102 @@
+"""Pre-export validity gate.
+
+CADGenBench (and most CAD scorers) apply a hard validity gate before any
+geometric scoring: a submission that is not a well-formed, watertight,
+manifold solid scores ZERO regardless of how close the geometry is. The most
+common ways a build123d session produces an invalid artifact are silent —
+an un-fused compound, a leftover 2D sketch as the current shape, an open
+shell, or a degenerate boolean result — so this gate lets the agent confirm
+the artifact is solid before exporting and submitting.
+
+The checks mirror the gate: BRepCheck well-formedness, a closed manifold, a
+real solid body, and non-degenerate volume.
+"""
+
+import json
+
+_EPS = 1e-9
+
+
+def _gate_report(shape) -> dict:
+    """Return the validity-gate verdict for a shape as a plain dict.
+
+    Reused by the export tool so a 3D export can warn when the written solid
+    would fail the gate.
+    """
+    from OCP.BRepCheck import BRepCheck_Analyzer
+
+    try:
+        n_solids = len(shape.solids())
+    except Exception:
+        n_solids = 0
+    try:
+        volume = round(float(shape.volume), 4)
+    except Exception:
+        volume = 0.0
+    try:
+        is_manifold = bool(shape.is_manifold)
+    except Exception:
+        is_manifold = False
+    try:
+        brep_valid = bool(BRepCheck_Analyzer(shape.wrapped).IsValid())
+    except Exception:
+        brep_valid = False
+
+    reasons: list[str] = []
+    if not brep_valid:
+        reasons.append("B-rep is not well-formed (BRepCheck failed)")
+    if volume <= _EPS:
+        reasons.append("zero/degenerate volume")
+    if not is_manifold:
+        reasons.append("not a closed manifold — open shell, 2D sketch, or non-manifold edges")
+    if n_solids == 0:
+        if is_manifold and volume > _EPS:
+            reasons.append(
+                "closed surface but no solid body — wrap the faces in Solid() before export"
+            )
+        else:
+            reasons.append("no solid body — the current shape is 2D/open geometry, not a solid")
+
+    passes = brep_valid and is_manifold and volume > _EPS and n_solids >= 1
+    return {
+        "passes_gate": passes,
+        "n_solids": n_solids,
+        "volume": volume,
+        "is_manifold": is_manifold,
+        "brep_valid": brep_valid,
+        "reasons": reasons,
+    }
+
+
+def _resolve_shape(session, object_name: str):
+    if object_name:
+        if object_name not in session.objects:
+            return None, json.dumps(
+                {
+                    "error": f"Unknown object '{object_name}'. Registered: {list(session.objects.keys())}"
+                }
+            )
+        return session.objects[object_name], None
+    if session.current_shape is None:
+        return None, json.dumps(
+            {"error": "No shape in session. Execute code to create geometry first."}
+        )
+    return session.current_shape, None
+
+
+def validate(session, object_name: str = "") -> str:
+    """Report whether a shape would pass a watertight-manifold-solid validity gate.
+
+    Returns a one-line PASS/FAIL verdict followed by a JSON report. A FAIL means
+    a STEP/STL export of this shape would be rejected by a CAD scorer (and score
+    zero), so fix it before exporting.
+    """
+    shape, err = _resolve_shape(session, object_name)
+    if err is not None:
+        return err
+    report = _gate_report(shape)
+    verdict = "PASS" if report["passes_gate"] else "FAIL"
+    summary = f"Validity gate: {verdict}"
+    if report["reasons"]:
+        summary += " — " + "; ".join(report["reasons"])
+    return summary + "\n" + json.dumps(report, indent=2)

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -57,6 +57,18 @@ def _gate_report(shape) -> dict:
         else:
             reasons.append("no solid body — the current shape is 2D/open geometry, not a solid")
 
+    # Non-fatal advisories: things that pass the watertight-manifold gate but
+    # still hurt the geometric score. Disjoint solids are each watertight, so a
+    # mesh scorer accepts them — but a single-part task expects ONE body, and the
+    # extra components tank the topology (component-count) score. Almost always an
+    # un-fused result. (Intentional assembly exports via '*' will see this too.)
+    warnings: list[str] = []
+    if n_solids > 1:
+        warnings.append(
+            f"{n_solids} disjoint solid bodies — a single-part task expects one fused "
+            "solid; fuse them (Part() + ... or a.fuse(b)) or the topology score suffers"
+        )
+
     passes = brep_valid and is_manifold and volume > _EPS and n_solids >= 1
     return {
         "passes_gate": passes,
@@ -64,6 +76,7 @@ def _gate_report(shape) -> dict:
         "volume": volume,
         "is_manifold": is_manifold,
         "brep_valid": brep_valid,
+        "warnings": warnings,
         "reasons": reasons,
     }
 
@@ -99,4 +112,6 @@ def validate(session, object_name: str = "") -> str:
     summary = f"Validity gate: {verdict}"
     if report["reasons"]:
         summary += " — " + "; ".join(report["reasons"])
+    if report["warnings"]:
+        summary += " (warning: " + "; ".join(report["warnings"]) + ")"
     return summary + "\n" + json.dumps(report, indent=2)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -532,6 +532,10 @@ class WorkerSession:
     def measure(self, object_name: str = "", density: float = 0.0, material: str = "") -> str:
         raise NotImplementedError
 
+    @_op(_tool(f"{_T}.validate:validate"), _GEOMETRY_TIMEOUT)
+    def validate(self, object_name: str = "") -> str:
+        raise NotImplementedError
+
     @_op(_tool(f"{_T}.measure:clearance"), _GEOMETRY_TIMEOUT)
     def clearance(self, object_a: str, object_b: str) -> str:
         raise NotImplementedError

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -608,6 +608,7 @@ def test_mcp_lists_all_tools():
         "execute",
         "render_view",
         "measure",
+        "validate",
         "export",
         "reset",
         "save_snapshot",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,106 @@
+"""Pre-export validity gate (validate tool + export warning).
+
+The gate mirrors the hard validity check CAD scorers apply before any geometric
+scoring: a non-watertight / non-manifold / non-solid artifact scores zero. These
+tests pin that a real solid passes and the common invalid-artifact shapes (2D
+sketch, open shell, un-fused/degenerate result) fail with actionable reasons.
+"""
+
+import json
+import os
+
+import pytest
+
+from build123d_mcp.session import Session
+from build123d_mcp.tools.execute import execute_code
+from build123d_mcp.tools.export import export_file
+from build123d_mcp.tools.validate import _gate_report, validate
+
+
+@pytest.fixture
+def session():
+    s = Session()
+    s.execute("from build123d import *")
+    return s
+
+
+def test_solid_box_passes(session):
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+    out = validate(session, "part")
+    assert out.startswith("Validity gate: PASS")
+    report = json.loads(out.split("\n", 1)[1])
+    assert report["passes_gate"] is True
+    assert report["n_solids"] == 1
+    assert report["is_manifold"] is True
+    assert report["brep_valid"] is True
+    assert report["reasons"] == []
+
+
+def test_2d_sketch_fails(session):
+    execute_code(session, "show(Rectangle(5, 5), 'sk')")
+    out = validate(session, "sk")
+    assert out.startswith("Validity gate: FAIL")
+    report = json.loads(out.split("\n", 1)[1])
+    assert report["passes_gate"] is False
+    assert report["n_solids"] == 0
+    assert any("solid" in r for r in report["reasons"])
+
+
+def test_open_shell_fails(session):
+    # Five of a box's six faces — an open (non-watertight) shell.
+    execute_code(session, "b = Box(10, 10, 10)\nshow(Shell(b.faces()[:5]), 'open')")
+    report = _gate_report(session.objects["open"])
+    assert report["passes_gate"] is False
+    assert report["is_manifold"] is False
+
+
+def test_degenerate_result_fails(session):
+    # Intersection of disjoint solids → empty/degenerate.
+    execute_code(
+        session,
+        "a = Box(10, 10, 10)\n"
+        "b = Box(10, 10, 10).move(Location((100, 0, 0)))\n"
+        "show(a & b, 'empty')",
+    )
+    report = _gate_report(session.objects["empty"])
+    assert report["passes_gate"] is False
+    assert any("volume" in r or "solid" in r for r in report["reasons"])
+
+
+def test_validate_unknown_object_reports_error(session):
+    out = validate(session, "nope")
+    assert "error" in out and "nope" in out
+
+
+def test_validate_uses_current_shape_when_unnamed(session):
+    execute_code(session, "result = Box(4, 4, 4)")
+    out = validate(session)
+    assert out.startswith("Validity gate: PASS")
+
+
+def test_export_3d_warns_when_gate_fails(session, tmp_path, monkeypatch):
+    """A 3D export consults the gate and appends a warning when it fails, so the
+    agent never silently ships a zero-scoring artifact. The no-solids cases are
+    already blocked earlier by the 2D/3D format guard, so the reachable case is a
+    solid that fails the gate — inject one to test the wiring deterministically."""
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+    import build123d_mcp.tools.validate as v
+
+    monkeypatch.setattr(
+        v,
+        "_gate_report",
+        lambda shape: {"passes_gate": False, "reasons": ["injected non-manifold solid"]},
+    )
+    out = export_file(session, "out", "step", object_name="part")
+    assert os.path.exists("out.step")  # the file is still written
+    assert "VALIDITY GATE FAIL" in out
+    assert "injected non-manifold solid" in out
+
+
+def test_export_3d_valid_no_warning(session, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+    out = export_file(session, "out", "step", object_name="part")
+    assert os.path.exists("out.step")
+    assert "VALIDITY GATE FAIL" not in out

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -67,6 +67,24 @@ def test_degenerate_result_fails(session):
     assert any("volume" in r or "solid" in r for r in report["reasons"])
 
 
+def test_multi_body_passes_with_advisory(session):
+    """Two disjoint solids are each watertight (gate passes), but a single-part
+    task wants one body — surface a non-fatal advisory, not a FAIL."""
+    execute_code(
+        session,
+        "a = Box(10, 10, 10)\n"
+        "b = Box(10, 10, 10).move(Location((30, 0, 0)))\n"
+        "show(Compound([a, b]), 'two')",
+    )
+    report = _gate_report(session.objects["two"])
+    assert report["n_solids"] == 2
+    assert report["passes_gate"] is True  # disjoint closed solids are still watertight
+    assert any("disjoint" in w for w in report["warnings"])
+    out = validate(session, "two")
+    assert out.startswith("Validity gate: PASS")
+    assert "warning" in out and "disjoint" in out
+
+
 def test_validate_unknown_object_reports_error(session):
     out = validate(session, "nope")
     assert "error" in out and "nope" in out

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -106,6 +106,11 @@ def _measure(ws, tmp_path):
     assert "error" not in r and r["volume"] > 0
 
 
+def _validate(ws, tmp_path):
+    r = ws.validate("a")
+    assert "PASS" in r  # 'a' is a seeded unit box → valid solid
+
+
 def _clearance(ws, tmp_path):
     r = json.loads(ws.clearance("a", "b"))
     assert "error" not in r and "status" in r
@@ -226,6 +231,7 @@ def _render_view(ws, tmp_path):
 # op name -> check function. The op name MUST match the dispatch/proxy op string.
 SESSION_STATEFUL_TOOLS = {
     "measure": _measure,
+    "validate": _validate,
     "clearance": _clearance,
     "shape_compare": _shape_compare,
     "align_check": _align_check,


### PR DESCRIPTION
## Why

CADGenBench (and CAD scorers generally) apply a **hard validity gate** before any geometric scoring: an artifact that isn't a well-formed, watertight, manifold solid scores **zero** regardless of how close the geometry is. The benchmark harness legs sit at **84–86% validity** while the raw model is **96.3%** — so ~10% of otherwise-good solutions are scoring zero on the *gate*, not the geometry. Closing that gap is the highest expected-value change available, and needs no model improvement.

The silent killers are exactly the cases build123d sessions hit: a leftover 2D sketch or open shell left as `current_shape`, an un-fused compound, or a degenerate boolean result — all export "successfully" to a STEP that the gate then rejects.

## What

- **`validate(object_name="")` tool** — returns a `PASS`/`FAIL` verdict plus JSON (`passes_gate`, `n_solids`, `volume`, `is_manifold`, `brep_valid`, `reasons`). The checks mirror the scorer's gate: `BRepCheck` well-formedness, closed manifold (`is_manifold`), a real solid body (`n_solids ≥ 1`), and non-degenerate volume. `reasons` are actionable (e.g. "no solid body — the current shape is 2D/open geometry").
- **`export()` warning** — a 3D export re-runs the gate and appends a prominent `⚠ VALIDITY GATE FAIL …` line when the written STEP/STL would be rejected, so an invalid artifact can't ship silently. (The no-solids cases are already blocked by the 2D/3D format guard; this catches a solid that fails the gate.)
- **Modeling skill Step 6** now mandates `validate("part")` before export.
- Shared `_gate_report(shape)` backs both, so the tool and the export warning never diverge.

Wired via the standard `@_op` stub + server tool, classified in the worker boundary smoke inventory (`test_worker_boundary_coverage`), documented in `llms.md`.

## Tests

`tests/test_validate.py` (8): solid passes; 2D sketch / open shell / degenerate boolean fail with the right reasons; unknown-object error; current-shape fallback; export warns when the gate fails (injected) and is silent for a valid solid. Full suite: **738 passed**; ruff clean.

Part of the benchmark push — the cheapest path to recovering the validity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)