### PR TITLE
fix: base validity gate on edge-face map, not build123d.is_manifold

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -152,7 +152,7 @@ Check whether a shape would pass a CAD validity gate before exporting it. The ga
 
 **Input:** `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
 
-**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `is_manifold`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task).
+**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `watertight_manifold`, `open_edges`, `nonmanifold_edges`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task). Watertightness is judged by the edge→face map (every non-degenerate edge shared by exactly two faces), not build123d's `is_manifold`, which false-negates on imported solids.
 
 A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off; `export()` re-runs the gate and warns on a 3D export that would fail.
 

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -33,10 +33,15 @@ def _gate_report(shape) -> dict:
         volume = round(float(shape.volume), 4)
     except Exception:
         volume = 0.0
-    try:
-        is_manifold = bool(shape.is_manifold)
-    except Exception:
-        is_manifold = False
+    # build123d's `is_manifold` false-negates on closed solids imported from STEP
+    # (verified on NIST CAD models — a single closed shell with zero open edges
+    # still reports is_manifold=False), so it is NOT a reliable gate. The
+    # authoritative test is the edge-face map: a watertight, manifold solid has
+    # every non-degenerate edge shared by exactly two faces. An open shell leaves
+    # boundary edges with one face; a non-manifold junction leaves an edge with
+    # three or more. Reported separately as `open_edges` / `nonmanifold_edges`.
+    open_edges, nonmanifold_edges, bad_edges_ok = _edge_defects(shape)
+    watertight_manifold = bad_edges_ok and open_edges == 0 and nonmanifold_edges == 0
     try:
         brep_valid = bool(BRepCheck_Analyzer(shape.wrapped).IsValid())
     except Exception:
@@ -47,15 +52,14 @@ def _gate_report(shape) -> dict:
         reasons.append("B-rep is not well-formed (BRepCheck failed)")
     if volume <= _EPS:
         reasons.append("zero/degenerate volume")
-    if not is_manifold:
-        reasons.append("not a closed manifold — open shell, 2D sketch, or non-manifold edges")
-    if n_solids == 0:
-        if is_manifold and volume > _EPS:
-            reasons.append(
-                "closed surface but no solid body — wrap the faces in Solid() before export"
-            )
-        else:
-            reasons.append("no solid body — the current shape is 2D/open geometry, not a solid")
+    if open_edges:
+        reasons.append(f"{open_edges} open edge(s) — not watertight (open shell or unsewn faces)")
+    if nonmanifold_edges:
+        reasons.append(f"{nonmanifold_edges} non-manifold edge(s) — edges shared by 3+ faces")
+    if n_solids == 0 and not open_edges and not nonmanifold_edges:
+        reasons.append("closed surface but no solid body — wrap the faces in Solid() before export")
+    elif n_solids == 0:
+        reasons.append("no solid body — the current shape is 2D/open geometry, not a solid")
 
     # Non-fatal advisories: things that pass the watertight-manifold gate but
     # still hurt the geometric score. Disjoint solids are each watertight, so a
@@ -69,16 +73,50 @@ def _gate_report(shape) -> dict:
             "solid; fuse them (Part() + ... or a.fuse(b)) or the topology score suffers"
         )
 
-    passes = brep_valid and is_manifold and volume > _EPS and n_solids >= 1
+    passes = brep_valid and watertight_manifold and volume > _EPS and n_solids >= 1
     return {
         "passes_gate": passes,
         "n_solids": n_solids,
         "volume": volume,
-        "is_manifold": is_manifold,
+        "watertight_manifold": watertight_manifold,
+        "open_edges": open_edges,
+        "nonmanifold_edges": nonmanifold_edges,
         "brep_valid": brep_valid,
         "warnings": warnings,
         "reasons": reasons,
     }
+
+
+def _edge_defects(shape) -> tuple[int, int, bool]:
+    """Count open and non-manifold edges via the edge→face map.
+
+    A watertight, manifold B-rep has every non-degenerate (non-seam) edge shared
+    by exactly two faces. Returns (open_edges, nonmanifold_edges, ok) where
+    ``ok`` is False if the map could not be built (then the caller treats the
+    shape as failing rather than silently passing).
+    """
+    try:
+        from OCP.BRep import BRep_Tool
+        from OCP.TopAbs import TopAbs_EDGE, TopAbs_FACE
+        from OCP.TopExp import TopExp
+        from OCP.TopoDS import TopoDS
+        from OCP.TopTools import TopTools_IndexedDataMapOfShapeListOfShape
+
+        m = TopTools_IndexedDataMapOfShapeListOfShape()
+        TopExp.MapShapesAndAncestors_s(shape.wrapped, TopAbs_EDGE, TopAbs_FACE, m)
+        open_edges = nonmanifold_edges = 0
+        for i in range(1, m.Extent() + 1):
+            edge = TopoDS.Edge_s(m.FindKey(i))
+            if BRep_Tool.Degenerated_s(edge):  # seam/pole edges are not boundaries
+                continue
+            faces = m.FindFromIndex(i).Extent()
+            if faces < 2:
+                open_edges += 1
+            elif faces > 2:
+                nonmanifold_edges += 1
+        return open_edges, nonmanifold_edges, True
+    except Exception:
+        return 0, 0, False
 
 
 def _resolve_shape(session, object_name: str):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -31,7 +31,9 @@ def test_solid_box_passes(session):
     report = json.loads(out.split("\n", 1)[1])
     assert report["passes_gate"] is True
     assert report["n_solids"] == 1
-    assert report["is_manifold"] is True
+    assert report["watertight_manifold"] is True
+    assert report["open_edges"] == 0
+    assert report["nonmanifold_edges"] == 0
     assert report["brep_valid"] is True
     assert report["reasons"] == []
 
@@ -47,11 +49,29 @@ def test_2d_sketch_fails(session):
 
 
 def test_open_shell_fails(session):
-    # Five of a box's six faces — an open (non-watertight) shell.
+    # Five of a box's six faces — an open (non-watertight) shell with boundary
+    # edges that belong to only one face.
     execute_code(session, "b = Box(10, 10, 10)\nshow(Shell(b.faces()[:5]), 'open')")
     report = _gate_report(session.objects["open"])
     assert report["passes_gate"] is False
-    assert report["is_manifold"] is False
+    assert report["open_edges"] > 0
+    assert report["watertight_manifold"] is False
+
+
+def test_closed_solid_with_unreliable_is_manifold_passes():
+    """Regression for the gate's reliance on build123d.is_manifold (#276): an
+    imported closed solid can report is_manifold=False while being watertight
+    (zero open/non-manifold edges). The edge-defect test must pass it where the
+    old is_manifold check would false-FAIL. Synthesized here as a fused solid;
+    the real-world trigger was NIST CAD model imports."""
+    from build123d import Box, Cylinder, Pos
+
+    part = Box(20, 20, 10) - Pos(0, 0, 0) * Cylinder(4, 10)
+    report = _gate_report(part)
+    assert report["open_edges"] == 0
+    assert report["nonmanifold_edges"] == 0
+    assert report["watertight_manifold"] is True
+    assert report["passes_gate"] is True
 
 
 def test_degenerate_result_fails(session):


### PR DESCRIPTION
## Why

Found while building a local NIST CTC/FTC eval harness (the benchmark push): build123d's `is_manifold` **false-negates on closed solids imported from STEP**. A NIST CAD model that is a single closed shell with **zero open edges** still reports `is_manifold == False`, so the validity gate shipped in #276 FAILed genuinely watertight solids.

That's the exact anti-pattern from #236: a gate that cries wolf trains agents to ignore it — and it's *especially* wrong here, since the imported-STEP / `import_cad_file` case is precisely what the gate exists to vet (and what the benchmark exercises).

## Fix

Replace the `is_manifold` check with the authoritative B-rep test: a watertight, manifold solid has **every non-degenerate edge shared by exactly two faces**. `_edge_defects()` walks the edge→face map and counts:
- **open edges** (1 face → not watertight: open shell / unsewn faces),
- **non-manifold edges** (3+ faces → T-junctions).

The report now carries `watertight_manifold`, `open_edges`, `nonmanifold_edges` (and actionable `reasons`) instead of the unreliable `is_manifold`. `_edge_defects` returns an `ok` flag and the gate fails closed if the map can't be built.

## Verified on real data

Against the NIST AP203 models: `ftc_07 / 08 / 10 / 11` now **PASS** (0 open edges) where `is_manifold` would have failed them; cases with genuine sewing gaps **FAIL** with an explicit open-edge count (e.g. `ctc_01: 78 open edges`). Existing behavior preserved — solid box passes, 2D sketch / open shell / degenerate boolean fail (now via the precise signal), multi-body advisory unchanged.

## Tests

`tests/test_validate.py` updated to the new fields + a regression test (`test_closed_solid_with_unreliable_is_manifold_passes`). Full suite: **740 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)