### PR TITLE
fix: validity gate ignores free wire edges (PMI annotation curves)

### DIFF
--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -114,6 +114,13 @@ def _edge_defects(shape) -> tuple[int, int, bool]:
     by exactly two faces. Returns (open_edges, nonmanifold_edges, ok) where
     ``ok`` is False if the map could not be built (then the caller treats the
     shape as failing rather than silently passing).
+
+    Edges with NO incident face are free wires — annotation/PMI curves (leader
+    and dimension lines carried by an imported STEP) or stray construction
+    geometry — not shell boundaries, so they are skipped. Counting them as open
+    edges false-FAILed clean solids imported from PMI-annotated STEP (verified on
+    the NIST CAD models, where the solid is watertight but the file carries dozens
+    of free annotation edges). Only a one-face edge is a genuine open boundary.
     """
     try:
         from OCP.BRep import BRep_Tool
@@ -130,7 +137,9 @@ def _edge_defects(shape) -> tuple[int, int, bool]:
             if BRep_Tool.Degenerated_s(edge):  # seam/pole edges are not boundaries
                 continue
             faces = m.FindFromIndex(i).Extent()
-            if faces < 2:
+            if faces == 0:
+                continue  # free wire / PMI annotation curve, not a shell boundary
+            if faces == 1:
                 open_edges += 1
             elif faces > 2:
                 nonmanifold_edges += 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -49,6 +49,25 @@ def test_curved_solid_no_mesh_false_positive(session):
     assert report["passes_gate"] is True
 
 
+def test_free_annotation_edges_ignored(session):
+    """A clean solid carrying free wire edges (PMI annotation curves from an
+    imported STEP, or stray construction geometry) must still PASS — free edges
+    have no incident face and are not open boundaries. Regression for the gate
+    false-FAILing clean NIST solids whose AP203 file carried dozens of annotation
+    edges."""
+    execute_code(
+        session,
+        "from build123d import Edge, Compound\n"
+        "solid = Box(20, 20, 20)\n"
+        "wire1 = Edge.make_line((40, 0, 0), (60, 0, 0))\n"
+        "wire2 = Edge.make_line((0, 40, 0), (0, 60, 0))\n"
+        "show(Compound(children=[solid, wire1, wire2]), 'annotated')",
+    )
+    report = _gate_report(session.objects["annotated"])
+    assert report["open_edges"] == 0
+    assert report["passes_gate"] is True
+
+
 def test_mesh_nonmanifold_edge_fails(session):
     """Two solids meeting along a shared edge tessellate to a mesh edge shared by
     >2 triangles — the dominant invalid-but-watertight CADGenBench failure mode."""


### PR DESCRIPTION
## Why

While scoring a NIST CTC fixture locally I hit a false FAIL: the AP203 "geometry only" STEP still carries **PMI annotation entities** (leader/dimension lines) that import as **free edges with no incident face**. `_edge_defects` counted those as open edges, so a perfectly watertight imported solid failed the gate — `ctc_01` reported **78 "open edges," all annotation curves**, while the solid itself has 0. (The inflated 1170×650×150 bounding box vs the true 800×450×150 solid was the same annotations.)

A gate that false-FAILs clean imported solids is the #236 mistake — and imported STEP is exactly where this gate is meant to help.

## Fix

An edge with **zero** incident faces is a free wire (annotation/PMI curve or stray construction geometry), not a shell boundary — skip it. Only a **one-face** edge is a genuine open boundary; **3+** is still non-manifold. One-line distinction in `_edge_defects`.

## Verified

- The real NIST `ctc_01` compound now **PASSES** (`open_edges` 0) where it previously FAILed with 78.
- New test: a solid + free annotation edges passes.
- Unchanged: genuine open shells (one-face boundary edges) and non-manifold edges still FAIL; mesh check already PMI-immune (curves don't tessellate to faces).

Full suite: **743 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)