### PR TITLE
fix: export gate validates the written-and-reimported STEP, not the in-memory shape (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.53 — 2026-06-22
+
+### Fixed
+
+- **Export gate validates the written-and-reimported STEP, not the in-memory shape.** `export()`'s validity gate ran on the in-memory shape, but a CAD scorer re-imports the written file — and serialization can degrade a shape that passed in memory (drop a solid, break BRep validity), giving a false PASS while shipping an invalid file. Verified on the sweep corpus: a shape with a solid that passed the gate re-imported as zero solids; another valid-in-memory BRep was invalid in the file — both shipped with a clean gate. The gate now re-imports the just-written STEP and validates that artifact, warning if it can't be re-imported. (#284)
+
 ## v0.3.52 — 2026-06-21
 
 ### Fixed

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -151,16 +151,34 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
     if not is_2d:
         from build123d_mcp.tools.validate import _gate_report
 
-        # Export is the authoritative gate (it decides if the written file ships),
-        # and runs once, so use the accurate topology-stitch mesh check here even
-        # though it is slower than the fast check interactive validate() uses.
-        report = _gate_report(shape, exact=True)
-        if not report["passes_gate"]:
+        # Gate the WRITTEN-AND-REIMPORTED STEP, not the in-memory shape. A CAD
+        # scorer re-imports the file, and serialization can degrade a shape that
+        # passed in memory (drop a solid, break BRep validity) — so validating the
+        # in-memory object gives a false PASS while shipping an invalid file. Re-
+        # import what we just wrote and gate that; it is the authoritative artifact
+        # (export runs once, so the extra import + exact mesh check is fine).
+        step_path = next((p for p in exported if p.lower().endswith((".step", ".stp"))), None)
+        gate_shape = shape
+        if step_path is not None:
+            try:
+                from build123d import import_step
+
+                gate_shape = import_step(step_path)
+            except Exception:
+                gate_shape = None  # not even loadable — a scorer would reject it
+        if gate_shape is None:
             suffix += (
-                "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
-                + "; ".join(report["reasons"])
-                + ". Fix the solid and re-export (run validate() for detail)."
+                "\n⚠ VALIDITY GATE FAIL — the written STEP could not be re-imported; "
+                "a CAD scorer would reject this file (score zero). Fix the solid and re-export."
             )
+        else:
+            report = _gate_report(gate_shape, exact=True)
+            if not report["passes_gate"]:
+                suffix += (
+                    "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
+                    + "; ".join(report["reasons"])
+                    + ". Fix the solid and re-export (run validate() for detail)."
+                )
     if len(exported) == 1:
         return f"Exported to {exported[0]}{suffix}"
     return "Exported to:\n" + "\n".join(exported) + suffix

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -246,4 +246,38 @@ def test_export_3d_valid_no_warning(session, tmp_path, monkeypatch):
     execute_code(session, "show(Box(10, 10, 10), 'part')")
     out = export_file(session, "out", "step", object_name="part")
     assert os.path.exists("out.step")
-    assert "VALIDITY GATE FAIL" not in out
+    assert "VALIDITY GATE FAIL" not in out  # a real box round-trips valid
+
+
+def test_export_gate_validates_reimported_file_not_memory(session, tmp_path, monkeypatch):
+    """Regression for #284: export() must gate the written-and-reimported STEP, not
+    the in-memory shape. A valid in-memory solid whose written file degrades on
+    serialization must still trigger the warning. Simulated by patching import_step
+    to return an invalid (open-shell) shape — under the old in-memory gate this
+    box would pass clean."""
+    import build123d
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+    bad = build123d.Shell(build123d.Box(10, 10, 10).faces()[:5])  # 0 solids, open -> invalid
+    monkeypatch.setattr(build123d, "import_step", lambda _p: bad)
+    out = export_file(session, "out", "step", object_name="part")
+    assert os.path.exists("out.step")  # file is still written
+    assert "VALIDITY GATE FAIL" in out  # gate caught the (degraded) re-imported file
+
+
+def test_export_gate_warns_when_reimport_fails(session, tmp_path, monkeypatch):
+    """If the written STEP can't even be re-imported, a scorer would reject it —
+    the gate must warn rather than silently pass."""
+    import build123d
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+
+    def boom(_p):
+        raise RuntimeError("corrupt STEP")
+
+    monkeypatch.setattr(build123d, "import_step", boom)
+    out = export_file(session, "out", "step", object_name="part")
+    assert "VALIDITY GATE FAIL" in out
+    assert "could not be re-imported" in out


### PR DESCRIPTION
Closes #284.

`export()`'s validity gate ran on the **in-memory shape**, but a CAD scorer re-imports the written file — and serialization can degrade a shape that passed in memory (drop a solid, break BRep validity). So the gate gave a **false PASS** while shipping an invalid file.

**Evidence (full sweep):** 122's in-memory shape had a solid and passed the gate, but the written STEP re-imports as **zero solids**; 249's BRep was valid in memory, **invalid** in the file. Both shipped with a clean gate.

**Fix:** re-import the just-written STEP and gate *that* — the artifact the scorer actually reads. If it can't even be re-imported, warn.

**Tests:** the gate now fires when the re-imported file is invalid even though the in-memory shape is a valid box (would pass under the old code); warns when re-import fails; a real box still round-trips clean. Full suite green (750).

🤖 Generated with [Claude Code](https://claude.com/claude-code)