### PR TITLE
feat: --no-sandbox flag; allow hasattr in execute(); fix blocked-call hint (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## v0.3.53 — 2026-06-22
+## v0.3.54 — 2026-06-22
+
+### Features
+
+- **`--no-sandbox` flag (`BUILD123D_NO_SANDBOX`).** Disables all `execute()` sandbox layers — the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). For trusted, isolated environments only (e.g. a benchmark harness); never expose to untrusted input. The exec timeout is unaffected (use `--exec-timeout`).
+
+### Fixed
+
+- **`hasattr()` is no longer blocked in `execute()`.** It returns only a `bool` and cannot *return* an object, so — unlike `getattr`/`vars` — it can't reach `__class__`/`__subclasses__` to escape the sandbox. Blocking it forced agents into try/except rewrites for ordinary build123d introspection (e.g. `hasattr(part, 'solids')`). `getattr`/`vars` stay blocked (they remain genuine dunder-bypass vectors; use `--no-sandbox` if you need them). (#265)
+- **Blocked-call errors no longer emit a misleading "Import blocked" hint.** A `Call to 'x' is not allowed` / dunder-access rejection matched the import-error hint rule, telling the agent to fix a nonexistent import. Call/attribute blocks now get a call-specific hint and a distinct `call_blocked` classification. (#265)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - **`hasattr()` is no longer blocked in `execute()`.** It returns only a `bool` and cannot *return* an object, so — unlike `getattr`/`vars` — it can't reach `__class__`/`__subclasses__` to escape the sandbox. Blocking it forced agents into try/except rewrites for ordinary build123d introspection (e.g. `hasattr(part, 'solids')`). `getattr`/`vars` stay blocked (they remain genuine dunder-bypass vectors; use `--no-sandbox` if you need them). (#265)
 - **Blocked-call errors no longer emit a misleading "Import blocked" hint.** A `Call to 'x' is not allowed` / dunder-access rejection matched the import-error hint rule, telling the agent to fix a nonexistent import. Call/attribute blocks now get a call-specific hint and a distinct `call_blocked` classification. (#265)
 
+## v0.3.53 — 2026-06-22
+
 ### Fixed
 
 - **Export gate validates the written-and-reimported STEP, not the in-memory shape.** `export()`'s validity gate ran on the in-memory shape, but a CAD scorer re-imports the written file — and serialization can degrade a shape that passed in memory (drop a solid, break BRep validity), giving a false PASS while shipping an invalid file. Verified on the sweep corpus: a shape with a solid that passed the gate re-imported as zero solids; another valid-in-memory BRep was invalid in the file — both shipped with a clean gate. The gate now re-imports the just-written STEP and validates that artifact, warning if it can't be re-imported. (#284)

--- a/README.md
+++ b/README.md
@@ -146,8 +146,11 @@ Two CLI flags let you adjust the import policy without giving up the rest of the
 
 - `--allow-imports scipy,pandas` — extend the allowlist with named modules. Each entry permits the named root and all its submodules. Use for CAD scripts that need extra packages.
 - `--allow-all-imports` — disable the import allowlist entirely. The other layers (restricted builtins for `open`/`eval`/etc, exec timeout, dunder-attribute block) still apply. **Use only in trusted environments or under OS-level isolation** (see below).
+- `--no-sandbox` — disable **all** sandbox layers: the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). The exec timeout still applies. **Dangerous — for trusted, isolated environments only** (e.g. a benchmark harness); never expose to untrusted input. Implies `--allow-all-imports`.
 
-Both flags also accept their values via env var (`BUILD123D_ALLOW_IMPORTS`, `BUILD123D_ALLOW_ALL_IMPORTS`).
+These flags also accept their values via env var (`BUILD123D_ALLOW_IMPORTS`, `BUILD123D_ALLOW_ALL_IMPORTS`, `BUILD123D_NO_SANDBOX`).
+
+> Note: `hasattr()` and `dir()` are permitted by the default sandbox; `getattr`/`vars`/`eval`/`exec`/`open` and explicit dunder access are blocked. Use `--no-sandbox` if you need the blocked ones.
 
 ### Stronger isolation: OS-level sandboxing
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Two CLI flags let you adjust the import policy without giving up the rest of the
 
 - `--allow-imports scipy,pandas` — extend the allowlist with named modules. Each entry permits the named root and all its submodules. Use for CAD scripts that need extra packages.
 - `--allow-all-imports` — disable the import allowlist entirely. The other layers (restricted builtins for `open`/`eval`/etc, exec timeout, dunder-attribute block) still apply. **Use only in trusted environments or under OS-level isolation** (see below).
-- `--no-sandbox` — disable **all** sandbox layers: the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). The exec timeout still applies. **Dangerous — for trusted, isolated environments only** (e.g. a benchmark harness); never expose to untrusted input. Implies `--allow-all-imports`.
+- `--no-sandbox` — disable **all** sandbox layers: the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). The exec timeout still applies. **Dangerous — for trusted, isolated environments only** (e.g. a benchmark harness); never expose to untrusted input. The import allowlist is lifted too (the AST check is skipped entirely), so `--allow-all-imports` is redundant alongside it.
 
 These flags also accept their values via env var (`BUILD123D_ALLOW_IMPORTS`, `BUILD123D_ALLOW_ALL_IMPORTS`, `BUILD123D_NO_SANDBOX`).
 

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -118,6 +118,15 @@ Part library file format (Python, any .py file under --library path):
         "Overrides BUILD123D_ALLOW_IMPORTS env var.",
     )
     parser.add_argument(
+        "--no-sandbox",
+        action="store_true",
+        default=os.environ.get("BUILD123D_NO_SANDBOX", "").lower() in ("1", "true", "yes"),
+        help="Disable ALL execute() sandbox layers: the AST check is skipped and user "
+        "code runs with unrestricted builtins (open/eval/exec/__import__ available). "
+        "DANGEROUS — for trusted, isolated environments only (e.g. a benchmark harness). "
+        "Implies --allow-all-imports. Overrides BUILD123D_NO_SANDBOX env var.",
+    )
+    parser.add_argument(
         "--exec-timeout",
         metavar="SECONDS",
         type=int,
@@ -192,9 +201,11 @@ Part library file format (Python, any .py file under --library path):
 
     extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
 
-    if args.allow_all_imports or extra_imports:
+    if args.allow_all_imports or extra_imports or args.no_sandbox:
         import build123d_mcp.security as _sec
 
+        if args.no_sandbox:
+            _sec.DISABLE_SANDBOX = True
         if args.allow_all_imports:
             _sec.ALLOW_ALL_IMPORTS = True
         if extra_imports:
@@ -206,6 +217,7 @@ Part library file format (Python, any .py file under --library path):
         "allow_all_imports": args.allow_all_imports,
         "extra_allowed_imports": extra_imports,
         "exec_timeout": args.exec_timeout,
+        "no_sandbox": args.no_sandbox,
     }
     if not args.in_process:
         if args.memory_limit_mb is not None:

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -160,6 +160,12 @@ OCP_ALLOWLIST = frozenset(
 # When True, import checks are skipped entirely.  Set via --allow-all-imports.
 ALLOW_ALL_IMPORTS: bool = False
 
+# When True, ALL sandbox layers are disabled: the AST check is skipped and the
+# exec namespace gets unrestricted builtins (open/eval/exec/__import__).  Set via
+# --no-sandbox / BUILD123D_NO_SANDBOX. For trusted environments only (e.g. an
+# isolated benchmark harness); never expose to untrusted input.
+DISABLE_SANDBOX: bool = False
+
 # Extra root modules added to the allowlist by the user, on top of IMPORT_ALLOWLIST.
 # Set via --allow-imports. Each entry is a top-level module name; submodules of an
 # allowed root are permitted (e.g. allowing "scipy" lets "scipy.optimize" through).
@@ -315,12 +321,13 @@ _BLOCKED_BUILTINS = frozenset(
         "open",
         "breakpoint",
         "input",
-        # getattr/vars/hasattr can bypass the dunder-attribute AST block via string arguments
+        # getattr/vars can bypass the dunder-attribute AST block via string arguments
         # (e.g. getattr(obj, '__class__')). dir() is safe: it only enumerates names already
         # in scope; dunder attribute *access* is still blocked at the AST level.
+        # hasattr is permitted: it returns only a bool and cannot *return* an object,
+        # so it can't be used to reach __class__/__subclasses__ (issue #265).
         "getattr",
         "vars",
-        "hasattr",
     }
 )
 
@@ -339,11 +346,10 @@ _BLOCKED_CALL_NAMES = frozenset(
         "open",
         "breakpoint",
         "input",
-        # Same rationale as _BLOCKED_BUILTINS: getattr/vars/hasattr bypass the dunder check
-        # via string arguments. dir() allowed.
+        # Same rationale as _BLOCKED_BUILTINS: getattr/vars bypass the dunder check
+        # via string arguments. dir() and hasattr (bool-only, issue #265) allowed.
         "getattr",
         "vars",
-        "hasattr",
     }
 )
 
@@ -359,6 +365,8 @@ def check_ast(code: str) -> None:
     Catches the most common injection patterns before exec() is ever called.
     Syntax errors are left for exec() to report with better messages.
     """
+    if DISABLE_SANDBOX:
+        return
     try:
         tree = ast.parse(code)
     except SyntaxError:
@@ -433,6 +441,9 @@ def make_restricted_builtins() -> dict[str, Any]:
     import builtins
 
     safe = vars(builtins).copy()
+
+    if DISABLE_SANDBOX:
+        return safe  # unrestricted: open/eval/exec/__import__ all available
 
     for name in _BLOCKED_BUILTINS:
         safe.pop(name, None)

--- a/src/build123d_mcp/tools/execute.py
+++ b/src/build123d_mcp/tools/execute.py
@@ -34,6 +34,11 @@ _SUGGESTED_FIXES = {
         "That import is not in the allowlist; "
         "use only build123d, math, numpy, or other permitted modules."
     ),
+    "call_blocked": (
+        "That builtin/attribute is blocked by the sandbox (getattr, vars, eval, exec, "
+        "open, explicit dunders); hasattr() and dir() are allowed. Probe attributes with "
+        "hasattr/try-except/isinstance, or run the server with --no-sandbox if trusted."
+    ),
     "unknown": (
         "Review the full error message and traceback for clues; "
         "call last_error() for the line number and excerpt."
@@ -58,6 +63,8 @@ def _classify_from_error_string(error_result: str) -> dict:
         cls = "fillet_fail"
     elif "ExecutionTimeout" in msg:
         cls = "timeout"
+    elif ("Call to" in msg or "dunder attribute" in msg) and "not allowed" in msg:
+        cls = "call_blocked"
     elif "not allowed" in msg:
         cls = "import_blocked"
     else:

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -52,7 +52,15 @@ _HINTS: list[tuple[list[str], str]] = [
         "or include it in this snippet.",
     ),
     (
-        [r"ImportError", r"SecurityError", r"not allowed.*import", r"import.*not allowed"],
+        [r"Call to '.*' is not allowed", r"Access to dunder attribute .* is not allowed"],
+        "Blocked by the execute() sandbox — this is a call/attribute block, NOT an import. "
+        "getattr, vars, eval, exec, compile, open and explicit dunder access are blocked; "
+        "hasattr() and dir() ARE allowed. Probe attributes with hasattr/try-except/isinstance "
+        "and use operators or syntax instead of explicit dunders. In a trusted environment the "
+        "server can run with --no-sandbox / BUILD123D_NO_SANDBOX=1 to lift all sandbox layers.",
+    ),
+    (
+        [r"ImportError", r"Import of .* is not allowed", r"not allowed.*import", r"import.*not allowed"],
         "Import blocked. Allowed modules include: build123d, bd_warehouse, math, numpy, "
         "json, re, collections, itertools, functools, copy, typing, dataclasses, enum, "
         "and most OCP geometry sub-modules (OCP.gp, OCP.BRepGProp, OCP.TopExp, etc.). "

--- a/src/build123d_mcp/tools/repair_hints.py
+++ b/src/build123d_mcp/tools/repair_hints.py
@@ -60,7 +60,12 @@ _HINTS: list[tuple[list[str], str]] = [
         "server can run with --no-sandbox / BUILD123D_NO_SANDBOX=1 to lift all sandbox layers.",
     ),
     (
-        [r"ImportError", r"Import of .* is not allowed", r"not allowed.*import", r"import.*not allowed"],
+        [
+            r"ImportError",
+            r"Import of .* is not allowed",
+            r"not allowed.*import",
+            r"import.*not allowed",
+        ],
         "Import blocked. Allowed modules include: build123d, bd_warehouse, math, numpy, "
         "json, re, collections, itertools, functools, copy, typing, dataclasses, enum, "
         "and most OCP geometry sub-modules (OCP.gp, OCP.BRepGProp, OCP.TopExp, etc.). "

--- a/src/build123d_mcp/tools/validate_code.py
+++ b/src/build123d_mcp/tools/validate_code.py
@@ -1,7 +1,7 @@
 import ast
 import json
 
-from build123d_mcp.security import _BLOCKED_CALL_NAMES, IMPORT_ALLOWLIST
+import build123d_mcp.security as _sec
 
 
 def validate_code(code: str) -> str:
@@ -22,24 +22,26 @@ def validate_code(code: str) -> str:
     blocked = []
     warnings = []
 
-    # Security: blocked imports and calls
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                root = alias.name.split(".")[0]
-                if root not in IMPORT_ALLOWLIST:
-                    blocked.append(f"import '{alias.name}' is not allowed")
-        elif isinstance(node, ast.ImportFrom):
-            if node.module:
-                root = node.module.split(".")[0]
-                if root not in IMPORT_ALLOWLIST:
-                    blocked.append(f"import '{node.module}' is not allowed")
-        elif isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Name) and node.func.id in _BLOCKED_CALL_NAMES:
-                blocked.append(f"call to '{node.func.id}' is not allowed")
-        elif isinstance(node, ast.Attribute):
-            if node.attr.startswith("__") and node.attr.endswith("__"):
-                blocked.append(f"dunder attribute access '{node.attr}' is not allowed")
+    # Security: blocked imports and calls. Skipped entirely under --no-sandbox so
+    # this advisory check agrees with what execute() will actually run.
+    if not _sec.DISABLE_SANDBOX:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    if root not in _sec.IMPORT_ALLOWLIST:
+                        blocked.append(f"import '{alias.name}' is not allowed")
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    root = node.module.split(".")[0]
+                    if root not in _sec.IMPORT_ALLOWLIST:
+                        blocked.append(f"import '{node.module}' is not allowed")
+            elif isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id in _sec._BLOCKED_CALL_NAMES:
+                    blocked.append(f"call to '{node.func.id}' is not allowed")
+            elif isinstance(node, ast.Attribute):
+                if node.attr.startswith("__") and node.attr.endswith("__"):
+                    blocked.append(f"dunder attribute access '{node.attr}' is not allowed")
 
     # Advisory: no build123d import in this snippet
     has_b3d_import = any(

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -33,15 +33,18 @@ def _build_session(
     exec_timeout: int,
     allow_all_imports: bool,
     extra_allowed_imports: tuple[str, ...],
+    no_sandbox: bool = False,
 ) -> tuple[Any, Any]:
     """Apply security overrides and build the Session (+ optional library index).
 
     Shared by worker_main (subprocess mode) and InProcessSession so a future
     setup step cannot be added to one mode and forgotten in the other.
     """
-    if allow_all_imports or extra_allowed_imports:
+    if allow_all_imports or extra_allowed_imports or no_sandbox:
         import build123d_mcp.security as _sec
 
+        if no_sandbox:
+            _sec.DISABLE_SANDBOX = True
         if allow_all_imports:
             _sec.ALLOW_ALL_IMPORTS = True
         if extra_allowed_imports:
@@ -66,6 +69,7 @@ def worker_main(
     extra_allowed_imports: tuple[str, ...] = (),
     memory_limit_mb: int | None = None,
     cpu_limit_s: int | None = None,
+    no_sandbox: bool = False,
 ) -> None:
     """Entry point run in the worker subprocess.
 
@@ -111,7 +115,7 @@ def worker_main(
             return
 
     session, library_index = _build_session(
-        library_path, exec_timeout, allow_all_imports, extra_allowed_imports
+        library_path, exec_timeout, allow_all_imports, extra_allowed_imports, no_sandbox
     )
 
     conn.send({"ready": True})
@@ -334,6 +338,7 @@ class WorkerSession:
         extra_allowed_imports: tuple[str, ...] = (),
         memory_limit_mb: int | None = None,
         cpu_limit_s: int | None = None,
+        no_sandbox: bool = False,
     ) -> None:
         self._exec_timeout = exec_timeout
         self._library_path = library_path
@@ -341,6 +346,7 @@ class WorkerSession:
         self._extra_allowed_imports = tuple(extra_allowed_imports)
         self._memory_limit_mb = memory_limit_mb
         self._cpu_limit_s = cpu_limit_s
+        self._no_sandbox = no_sandbox
         self._conn: Any = None
         self._proc: Any = None
         self._start_worker()
@@ -363,6 +369,7 @@ class WorkerSession:
                 self._extra_allowed_imports,
                 self._memory_limit_mb,
                 self._cpu_limit_s,
+                self._no_sandbox,
             ),
             daemon=True,
         )
@@ -704,6 +711,7 @@ class InProcessSession(WorkerSession):
             self._exec_timeout,
             self._allow_all_imports,
             self._extra_allowed_imports,
+            self._no_sandbox,
         )
 
     def _kill_worker(self) -> None:

--- a/tests/test_no_sandbox.py
+++ b/tests/test_no_sandbox.py
@@ -1,0 +1,96 @@
+"""hasattr is allowed in execute(); getattr/vars stay blocked; --no-sandbox lifts
+all layers; blocked-call errors get a call hint, not the import hint (#265)."""
+
+import pytest
+
+import build123d_mcp.security as _sec
+from build123d_mcp.security import check_ast, make_restricted_builtins
+
+
+@pytest.fixture
+def no_sandbox(monkeypatch):
+    """Enable DISABLE_SANDBOX for the test, auto-restored afterwards."""
+    monkeypatch.setattr(_sec, "DISABLE_SANDBOX", True)
+
+
+# --- #265: hasattr allowed by default, getattr/vars still blocked ---------------
+
+
+def test_hasattr_passes_ast():
+    check_ast("hasattr(part, 'solids')")  # must not raise
+
+
+def test_hasattr_in_restricted_builtins():
+    assert "hasattr" in make_restricted_builtins()
+
+
+def test_getattr_still_blocked():
+    with pytest.raises(ValueError, match="not allowed"):
+        check_ast("getattr(x, '__class__')")
+
+
+def test_vars_still_blocked():
+    with pytest.raises(ValueError, match="not allowed"):
+        check_ast("vars(x)")
+
+
+def test_getattr_absent_from_restricted_builtins():
+    assert "getattr" not in make_restricted_builtins()
+
+
+# --- --no-sandbox lifts every layer --------------------------------------------
+
+
+def test_no_sandbox_allows_arbitrary_import(no_sandbox):
+    check_ast("import os")  # must not raise
+
+
+def test_no_sandbox_allows_blocked_calls(no_sandbox):
+    check_ast("open('/etc/passwd'); getattr(x, '__class__')")  # must not raise
+
+
+def test_no_sandbox_allows_dunder_traversal(no_sandbox):
+    check_ast("().__class__.__base__.__subclasses__()")  # must not raise
+
+
+def test_no_sandbox_unrestricted_builtins(no_sandbox):
+    b = make_restricted_builtins()
+    assert {"open", "eval", "exec", "compile", "getattr"} <= set(b)
+
+
+def test_sandbox_on_keeps_builtins_restricted():
+    """Sanity: with the flag off (default), dangerous builtins are still removed."""
+    b = make_restricted_builtins()
+    assert "open" not in b and "eval" not in b
+
+
+# --- misleading-hint fix -------------------------------------------------------
+
+
+def test_blocked_call_hint_is_not_import_hint():
+    from build123d_mcp.tools.repair_hints import repair_hints
+
+    hint = repair_hints("Error: SecurityError: Call to 'getattr' is not allowed.")
+    assert "Import blocked" not in hint
+    assert "sandbox" in hint.lower()
+
+
+def test_import_error_still_gets_import_hint():
+    from build123d_mcp.tools.repair_hints import repair_hints
+
+    hint = repair_hints("Error: SecurityError: Import of 'os' is not allowed.")
+    assert "Import blocked" in hint
+
+
+def test_call_block_classified_as_call_blocked():
+    from build123d_mcp.tools.execute import _classify_from_error_string
+
+    c = _classify_from_error_string("Error: SecurityError: Call to 'getattr' is not allowed.")
+    assert c["failure_class"] == "call_blocked"
+
+
+def test_import_block_classified_as_import_blocked():
+    from build123d_mcp.tools.execute import _classify_from_error_string
+
+    c = _classify_from_error_string("Error: SecurityError: Import of 'os' is not allowed.")
+    assert c["failure_class"] == "import_blocked"

--- a/tests/test_no_sandbox.py
+++ b/tests/test_no_sandbox.py
@@ -94,3 +94,32 @@ def test_import_block_classified_as_import_blocked():
 
     c = _classify_from_error_string("Error: SecurityError: Import of 'os' is not allowed.")
     assert c["failure_class"] == "import_blocked"
+
+
+# --- end-to-end through a real spawned worker (locks in the positional plumbing) ---
+# WorkerSession runs in a subprocess, so its DISABLE_SANDBOX is set there and does
+# not leak into this test process. (An InProcessSession would poison global state.)
+
+
+def test_worker_session_no_sandbox_runs_blocked_code():
+    from build123d_mcp.worker import WorkerSession
+
+    s = WorkerSession(exec_timeout=30, no_sandbox=True)
+    try:
+        result = s.execute("import os\nprint('pid', os.getpid())")
+        assert "not allowed" not in result and "SecurityError" not in result, result
+        assert "pid" in result, result
+    finally:
+        s._kill_worker()
+
+
+def test_worker_session_default_blocks_import():
+    """Control: the same code is rejected without no_sandbox — proves the flag is load-bearing."""
+    from build123d_mcp.worker import WorkerSession
+
+    s = WorkerSession(exec_timeout=30)
+    try:
+        result = s.execute("import os")
+        assert "not allowed" in result, result
+    finally:
+        s._kill_worker()


### PR DESCRIPTION
Closes #265.

## hasattr is no longer blocked
The sandbox blocked `hasattr`/`getattr`/`vars` as one class because `getattr(o, '__class__')` can bypass the dunder-attribute AST guard via string args. But **`hasattr` returns only a `bool`** — it cannot *return* an object, so it can't reach `__class__`/`__subclasses__` and is safe to allow. Blocking it forced agents into try/except rewrites for ordinary build123d introspection (e.g. `hasattr(part, 'solids')`) — **34 wasted `execute()` calls across ~10 fixtures in a CADGenBench sweep**. `getattr`/`vars` stay blocked (still genuine dunder-bypass vectors).

## Misleading hint fixed
A `Call to 'x' is not allowed` / dunder rejection matched the **import**-error hint rule, telling the agent to fix a nonexistent import. Call/attribute blocks now get a call-specific hint and a distinct `call_blocked` classification.

## New `--no-sandbox` flag
`--no-sandbox` / `BUILD123D_NO_SANDBOX` disables **all** sandbox layers: the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). Exec timeout is unaffected. For trusted, isolated environments only (e.g. a benchmark harness). Plumbed through `cli` → `WorkerSession` → worker subprocess and `InProcessSession`. Documented in README.

There is no existing way to disable the sandbox wholesale today — `--allow-all-imports` only relaxes the import allowlist (the blocked-call and dunder layers still apply), so this fills a real gap for trusted batch runs.

## Tests
New `tests/test_no_sandbox.py`: hasattr passes / getattr/vars still blocked; `--no-sandbox` lifts imports, blocked calls, dunder traversal, and restores builtins; hint + classification distinguish call-blocks from import-blocks. Full suite green (**764 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)