### PR TITLE
docs: Codex usability — hasattr sandbox doc, AGENTS.md setup, HTTP single-session warning (#292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,30 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
 }
 ```
 
+### Codex CLI / Antigravity / Copilot / Cline (AGENTS.md)
+
+These agents read project guidance from `AGENTS.md`. Add the server to your agent's MCP config with the same launch command as the clients above:
+
+```
+command: uv
+args:    ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
+```
+
+Then install the workflow guidance into `AGENTS.md` so the agent follows the build → `validate()` → `export()` loop:
+
+```
+install_skill(target="agents-md", skill="modeling")   # 3D modeling from a spec / drawing
+install_skill(target="agents-md", skill="drawing")    # engineering drawings from geometry
+```
+
+(`install_skill` also supports `target="claude"`, `"cursor"`, and `"windsurf"`.)
+
+### HTTP transport (advanced)
+
+By default the server runs over **stdio** — one isolated session per client process. With `--transport http` it serves streamable-HTTP for web/embedded deployments.
+
+> ⚠️ **HTTP mode uses one shared CAD session for every request** unless your host installs middleware that sets a per-request `WorkerSession` on the `_session_var` contextvar (see `http_app()`). Do **not** expose HTTP mode to more than one user without that middleware — they would all read and mutate the same session state.
+
 ---
 
 ## System prompt

--- a/llms.md
+++ b/llms.md
@@ -7,7 +7,7 @@ build123d-mcp is an MCP server that wraps the [build123d](https://github.com/gum
 This server enforces a Python-level sandbox on every `execute()` call. Three layers run before your code:
 
 1. **Import allowlist** — only `build123d`, `bd_warehouse`, `math`, `numpy`, `inspect`, the safe stdlib subset (collections, itertools, functools, copy, typing, dataclasses, enum, re, json, base64, hashlib, …), and curated geometric OCP submodules are importable. Filesystem (`os`, `pathlib`, `shutil`), networking (`socket`, `urllib`, `requests`), and shell access (`subprocess`) are blocked. The full allowlist is in the error message of any blocked import.
-2. **Restricted builtins** — `open`, `eval`, `exec`, `compile`, `breakpoint`, `input`, and the introspection helpers `getattr`/`vars`/`hasattr` are removed (the last three because string arguments would let you bypass the dunder-attribute block).
+2. **Restricted builtins** — `open`, `eval`, `exec`, `compile`, `breakpoint`, `input`, and the introspection helpers `getattr`/`vars` are removed (string arguments to them would bypass the dunder-attribute block). `hasattr` and `dir()` are **allowed**: `hasattr` returns only a bool so it cannot extract `__class__`/`__subclasses__`, and `dir()` only lists names already in scope. (Run with `--no-sandbox` in a trusted environment to lift all of these.)
 3. **Execution timeout** — wall-clock limit (default 120 s).
 
 If a script truly needs an extra package (e.g. `scipy.optimize` to size a parametric part), the server operator can extend the allowlist via `--allow-imports scipy,pandas` — the LLM doesn't control this, but a blocked-import error message names the attempted module so the user can decide whether to add it.


### PR DESCRIPTION
Closes #292 (findings 2, 3, 4; finding 1 deliberately deferred — see below).

### 3. Sandbox doc contradiction (the one real correctness bug)
`llms.md` said the restricted builtins remove `getattr`/`vars`/`hasattr`, but since **v0.3.54 (#265)** `hasattr` is **allowed** (it returns only a bool, can't reach `__class__`). README already said so — Codex would internalize whichever it saw last. Fixed `llms.md` to match reality (only `getattr`/`vars` removed; `hasattr`/`dir()` allowed; `--no-sandbox` lifts all).

### 4. Codex setup under-documented
Added a README section for **Codex CLI / Antigravity / Copilot / Cline** (the `AGENTS.md` agents): the MCP launch command + `install_skill(target="agents-md", skill="modeling"|"drawing")` to write the workflow guidance into `AGENTS.md`.

### 2. HTTP shared-session caveat easy to miss
Added a prominent README warning that `--transport http` uses **one shared session for all requests** unless the host installs per-request `WorkerSession` middleware (`_session_var`). The caveat previously lived only in the `http_app()` docstring.

### 1. Long tool docstrings — deferred (not done)
That verbosity demonstrably drives correct tool selection (the `validate()`/`export()` loop). Trimming it risks regressing agent behavior, so I'd want to measure before cutting rather than trim blind. Flagging, not actioning.

Docs-only; no code/behavior change.