### PR TITLE
fix: mesh-check large/complex parts out-of-process instead of skipping (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.56
+
+### Fixed
+
+- **Export gate now mesh-checks large/complex parts instead of skipping them.** v0.3.55's mesh check is wall-clock-bounded and returns `mesh_check="skipped"` (B-rep checks only) when a part is too large to tessellate-and-stitch in-process within the worker timeout — so a big invalid part could ship its mesh defect undetected. The dominant cost is OCC `BRepMesh`, an un-interruptible native call an in-process budget can't stop. `export()` now, *only when the in-process check skips*, retries the mesh check in a **separate process bounded by a hard `subprocess` timeout** (sized from `--exec-timeout`): a large part gets a generous budget and is actually checked, an over-budget part is killed cleanly (the worker is never blocked), and small exports pay no subprocess cost. Catches real defects on parts the in-process gate had skipped. (Very large parts whose closedness needs the finest tessellation rung still exceed even the out-of-process budget — that remaining tail needs a vectorized stitch, tracked in #294.) (#294)
+
 ## v0.3.55
 
 ### Fixed

--- a/src/build123d_mcp/_gate_subprocess.py
+++ b/src/build123d_mcp/_gate_subprocess.py
@@ -1,0 +1,53 @@
+"""Out-of-process mesh-validity check for the export gate.
+
+Run as ``python -m build123d_mcp._gate_subprocess <step_path>``. Loads the STEP,
+runs the exact mesh check (open-edge ladder + non-manifold + face-tessellation)
+with NO internal time deadline, and prints the result as a single
+``GATE_RESULT:{...}`` line on stdout.
+
+Why a separate process: the dominant cost is OCC ``BRepMesh`` tessellation, an
+un-interruptible native call that an in-process wall-clock budget cannot stop —
+so on a very large/complex part the in-process gate must SKIP the mesh check to
+avoid running past the worker op-timeout (which would kill the session). Running
+it here lets the caller bound it with a hard ``subprocess`` timeout: a large
+part gets a generous budget and is actually checked, and an over-budget part is
+killed cleanly (the worker is never blocked). The marker prefix lets the caller
+recover the JSON even though OCC writes progress noise to stdout.
+"""
+
+import json
+import sys
+
+_MARKER = "GATE_RESULT:"
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(_MARKER + json.dumps({"error": "no step_path"}))
+        return
+    step_path = sys.argv[1]
+    try:
+        from build123d import Compound, import_step
+
+        from build123d_mcp.tools.validate import _EXACT_EXPORT_MAX_TRIS, _mesh_defects_exact
+
+        shp = import_step(step_path)
+        solids = shp.solids()
+        if not solids:
+            shape = shp
+        elif len(solids) == 1:
+            shape = solids[0]
+        else:
+            shape = Compound(children=list(solids))
+        # deadline=inf: no in-process time bail — the parent's subprocess timeout
+        # bounds us. The triangle ceilings still apply (bound memory).
+        nm, open_edges, untri, ok = _mesh_defects_exact(
+            shape, max_triangles=_EXACT_EXPORT_MAX_TRIS, deadline=float("inf")
+        )
+        print(_MARKER + json.dumps({"nm": nm, "open": open_edges, "untri": untri, "ok": ok}))
+    except Exception as exc:  # noqa: BLE001 — report and exit cleanly
+        print(_MARKER + json.dumps({"error": f"{type(exc).__name__}: {exc}"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -1,5 +1,6 @@
 import copy
 import struct
+import time
 
 from build123d_mcp.tools._paths import safe_output_path
 
@@ -105,6 +106,7 @@ def _write_one(shape, abs_path: str, fmt: str) -> None:
 
 
 def export_file(session, filename: str, format: str = "step", object_name: str = "") -> str:
+    _t0 = time.monotonic()  # op entry — used to bound the out-of-process gate
     shape = _resolve_shape(session, object_name)
 
     formats = [f.strip().lower() for f in format.split(",") if f.strip()]
@@ -171,20 +173,47 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
                 "\n⚠ VALIDITY GATE FAIL — the written STEP could not be re-imported; "
                 "a CAD scorer would reject this file (score zero). Fix the solid and re-export."
             )
-        else:
-            report = _gate_report(gate_shape, exact=True)
-            # If the part was too large to mesh within the in-process budget, the
-            # mesh check was skipped (B-rep only). Retry it out-of-process with a
-            # hard timeout derived from the op budget, so large parts are actually
-            # checked instead of silently shipping a mesh defect. Only on skip, so
-            # normal exports pay no subprocess cost.
-            if report.get("mesh_check") == "skipped" and step_path is not None:
-                from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
+        elif step_path is not None:
+            # Run the mesh check OUT OF PROCESS for STEP exports. The mesh stitch is
+            # dominated by OCC BRepMesh — an un-interruptible native call no
+            # in-process budget can stop — so running it in-process risks blocking
+            # the worker past the op-timeout (which kills the session). Bound it by
+            # the time LEFT in this op's budget (NOT the full budget — the re-import
+            # and B-rep checks already spent some), so the subprocess is always
+            # killed before the parent kills the worker. B-rep checks run in-process
+            # (cheap). On timeout the mesh check is skipped (B-rep only) + a warning.
+            from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
 
-                _budget = max(60, getattr(session, "exec_timeout", 120))
-                _mesh = _run_mesh_gate_subprocess(step_path, timeout=_budget - 10)
-                if _mesh is not None:
-                    report = _gate_report(gate_shape, exact=True, mesh_override=_mesh)
+            # Margin covers the B-rep checks that still run in-process after this
+            # (fast — BRepCheck, not meshing) + subprocess teardown + parent poll
+            # granularity, so worker total stays under the parent op-budget.
+            _budget = max(60, getattr(session, "exec_timeout", 120))
+            _remaining = _budget - (time.monotonic() - _t0) - 15
+            _mesh = (
+                _run_mesh_gate_subprocess(step_path, timeout=_remaining)
+                if _remaining >= 10
+                else None
+            )
+            report = _gate_report(
+                gate_shape,
+                exact=True,
+                mesh_override=_mesh if _mesh is not None else (0, 0, 0, False),
+            )
+            if not report["passes_gate"]:
+                suffix += (
+                    "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
+                    + "; ".join(report["reasons"])
+                    + ". Fix the solid and re-export (run validate() for detail)."
+                )
+            elif report.get("mesh_check") == "skipped":
+                suffix += (
+                    "\n⚠ NOTE — the part was too large to mesh-check within the time "
+                    "budget, so only B-rep checks ran; a mesh-level defect (open/"
+                    "non-manifold) would not be caught here."
+                )
+        else:
+            # STL-only export (no STEP path to hand the subprocess): gate in-process.
+            report = _gate_report(gate_shape, exact=True)
             if not report["passes_gate"]:
                 suffix += (
                     "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -173,6 +173,18 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
             )
         else:
             report = _gate_report(gate_shape, exact=True)
+            # If the part was too large to mesh within the in-process budget, the
+            # mesh check was skipped (B-rep only). Retry it out-of-process with a
+            # hard timeout derived from the op budget, so large parts are actually
+            # checked instead of silently shipping a mesh defect. Only on skip, so
+            # normal exports pay no subprocess cost.
+            if report.get("mesh_check") == "skipped" and step_path is not None:
+                from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
+
+                _budget = max(60, getattr(session, "exec_timeout", 120))
+                _mesh = _run_mesh_gate_subprocess(step_path, timeout=_budget - 10)
+                if _mesh is not None:
+                    report = _gate_report(gate_shape, exact=True, mesh_override=_mesh)
             if not report["passes_gate"]:
                 suffix += (
                     "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -73,7 +73,40 @@ def _edge_incidence_counts(mf, n_nodes: int):
     return counts
 
 
-def _gate_report(shape, exact: bool = False) -> dict:
+def _run_mesh_gate_subprocess(step_path: str, timeout: float):
+    """Run the exact mesh check on a written STEP in a separate process, hard-
+    bounded by ``timeout`` seconds (the only way to bound the un-interruptible OCC
+    tessellation without risking the worker). Returns ``(nm, open, untri, ok)`` or
+    ``None`` if the subprocess timed out (was killed), errored, or its result
+    could not be parsed — ``None`` means UNDETERMINED, so the caller keeps its
+    safe in-process verdict rather than inventing one.
+    """
+    import json
+    import subprocess
+    import sys
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "build123d_mcp._gate_subprocess", step_path],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith("GATE_RESULT:"):
+            try:
+                d = json.loads(line[len("GATE_RESULT:") :])
+            except ValueError:
+                return None
+            if "error" in d:
+                return None
+            return int(d["nm"]), int(d["open"]), int(d["untri"]), bool(d["ok"])
+    return None
+
+
+def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None) -> dict:
     """Return the validity-gate verdict for a shape as a plain dict.
 
     Reused by the export tool so a 3D export can warn when the written solid
@@ -120,21 +153,28 @@ def _gate_report(shape, exact: bool = False) -> dict:
     # so the whole mesh analysis is bounded (not additive) and can never approach
     # the worker op-timeout. If both are over budget, the mesh check is skipped and
     # the gate relies on the B-rep checks above (never a false FAIL).
-    _cap = _EXACT_EXPORT_MAX_TRIS if exact else _EXACT_INLINE_MAX_TRIS
-    _mesh_deadline = time.monotonic() + _GATE_MESH_BUDGET_S
-    mesh_nm_edges, mesh_open_edges, mesh_untri_faces, mesh_ok = _mesh_defects_exact(
-        shape, max_triangles=_cap, deadline=_mesh_deadline
-    )
-    mesh_check = "exact"
-    if not mesh_ok:
-        # Exact check over budget / unbuildable — fall back to the fast
-        # non-manifold-only check (no open-edge / face-tessellation analysis),
-        # under the SAME deadline.
-        mesh_nm_edges, mesh_ok = _mesh_defects(shape, deadline=_mesh_deadline)
-        mesh_open_edges = mesh_untri_faces = 0
-        mesh_check = "fast" if mesh_ok else "skipped"
+    if mesh_override is not None:
+        # Mesh results computed out-of-process (export's subprocess retry for a
+        # part too large to mesh within the in-process budget). Bounded by a hard
+        # subprocess timeout there, so it can run the full check without skipping.
+        mesh_nm_edges, mesh_open_edges, mesh_untri_faces, mesh_ok = mesh_override
+        mesh_check = "exact-subprocess"
+    else:
+        _cap = _EXACT_EXPORT_MAX_TRIS if exact else _EXACT_INLINE_MAX_TRIS
+        _mesh_deadline = time.monotonic() + _GATE_MESH_BUDGET_S
+        mesh_nm_edges, mesh_open_edges, mesh_untri_faces, mesh_ok = _mesh_defects_exact(
+            shape, max_triangles=_cap, deadline=_mesh_deadline
+        )
+        mesh_check = "exact"
         if not mesh_ok:
-            mesh_nm_edges = 0  # neither check could run in budget — defer to B-rep
+            # Exact check over budget / unbuildable — fall back to the fast
+            # non-manifold-only check (no open-edge / face-tessellation analysis),
+            # under the SAME deadline.
+            mesh_nm_edges, mesh_ok = _mesh_defects(shape, deadline=_mesh_deadline)
+            mesh_open_edges = mesh_untri_faces = 0
+            mesh_check = "fast" if mesh_ok else "skipped"
+            if not mesh_ok:
+                mesh_nm_edges = 0  # neither check could run in budget — defer to B-rep
     mesh_nonmanifold = mesh_ok and mesh_nm_edges > 0
     mesh_open = mesh_ok and mesh_open_edges > 0
     mesh_incomplete = mesh_ok and mesh_untri_faces > 0
@@ -572,9 +612,11 @@ def _mesh_defects_exact(
                 return -1
             if open0 == 0:
                 return 0
-            if ntris0 > _LADDER_BASE_MAX_TRIS:
-                # Open at base, but too large to refine within budget — defer to
-                # the fast check rather than run the expensive finer rungs.
+            if ntris0 > _LADDER_BASE_MAX_TRIS and _open_deadline != float("inf"):
+                # Open at base, but too large to refine within the in-process time
+                # budget — defer rather than run the expensive finer rungs. Skipped
+                # when there is no time deadline (the export subprocess path, bounded
+                # by a hard kill instead), so large parts ARE laddered out-of-process.
                 return -1
             for d in (4, 16, 32):
                 if time.monotonic() > _open_deadline:
@@ -714,7 +756,10 @@ def _mesh_defects_exact(
         mf = mf[keep]
         if mf.shape[0] == 0:
             _ov = _open_ladder()
-            return (0, 0, 0, False) if _ov < 0 else (0, _ov, untriangulated, True)
+            if _ov >= 0:
+                return 0, _ov, untriangulated, True
+            # open undetermined — a face that failed to tessellate is still a defect
+            return (0, 0, untriangulated, True) if untriangulated else (0, 0, 0, False)
 
         # 4. Cancel opposite-winding flap pairs (a degenerate fold meshes to a
         #    triangle and its mirror; same 3 nodes, opposite parity). Same-winding
@@ -749,7 +794,10 @@ def _mesh_defects_exact(
         mf = mf[keep2]
         if mf.shape[0] == 0:
             _ov = _open_ladder()
-            return (0, 0, 0, False) if _ov < 0 else (0, _ov, untriangulated, True)
+            if _ov >= 0:
+                return 0, _ov, untriangulated, True
+            # open undetermined — a face that failed to tessellate is still a defect
+            return (0, 0, untriangulated, True) if untriangulated else (0, 0, 0, False)
 
         # 5. Non-manifold count from the index-stitched mesh: undirected edges
         #    shared by >2 triangles. (Closedness/open edges come from the
@@ -760,7 +808,13 @@ def _mesh_defects_exact(
         counts = _edge_incidence_counts(mf, n)
         nm_edges = int((counts > 2).sum())
         _ov = _open_ladder()
-        return (0, 0, 0, False) if _ov < 0 else (nm_edges, _ov, untriangulated, True)
+        if _ov >= 0:
+            return nm_edges, _ov, untriangulated, True
+        # open undetermined — a non-manifold or untriangulated face is still a
+        # definite defect, independent of the open-edge ladder
+        if nm_edges or untriangulated:
+            return nm_edges, 0, untriangulated, True
+        return 0, 0, 0, False
     except Exception:
         return 0, 0, 0, False
 

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -158,7 +158,10 @@ def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None)
         # part too large to mesh within the in-process budget). Bounded by a hard
         # subprocess timeout there, so it can run the full check without skipping.
         mesh_nm_edges, mesh_open_edges, mesh_untri_faces, mesh_ok = mesh_override
-        mesh_check = "exact-subprocess"
+        # ok=False means the out-of-process check timed out / couldn't determine —
+        # mark it "skipped" so the "mesh validity not verified" warning fires and the
+        # caller doesn't report false confidence on an unchecked part.
+        mesh_check = "exact-subprocess" if mesh_ok else "skipped"
     else:
         _cap = _EXACT_EXPORT_MAX_TRIS if exact else _EXACT_INLINE_MAX_TRIS
         _mesh_deadline = time.monotonic() + _GATE_MESH_BUDGET_S

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -255,9 +255,10 @@ def test_export_3d_warns_when_gate_fails(session, tmp_path, monkeypatch):
     monkeypatch.setattr(
         v,
         "_gate_report",
-        lambda shape, exact=False: {
+        lambda shape, exact=False, mesh_override=None: {
             "passes_gate": False,
             "reasons": ["injected non-manifold solid"],
+            "mesh_check": "exact-subprocess",
         },
     )
     out = export_file(session, "out", "step", object_name="part")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -347,3 +347,29 @@ def test_edge_incidence_nonmanifold_edge():
     mf = np.array([[0, 1, 2], [0, 1, 3], [0, 1, 4]], dtype=np.int64)
     counts = _edge_incidence_counts(mf, 5)
     assert int((counts > 2).sum()) > 0
+
+
+# --- out-of-process mesh gate (export retry for parts too large to mesh in-budget) ---
+
+
+def test_mesh_gate_subprocess_valid_step(tmp_path):
+    from build123d import Box, export_step
+
+    from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
+
+    p = tmp_path / "box.step"
+    export_step(Box(10, 10, 10), str(p))
+    # A clean solid: 0 non-manifold, 0 open, 0 untriangulated, ok=True.
+    assert _run_mesh_gate_subprocess(str(p), timeout=120) == (0, 0, 0, True)
+
+
+def test_mesh_gate_subprocess_timeout_returns_none(tmp_path):
+    from build123d import Box, export_step
+
+    from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
+
+    p = tmp_path / "box.step"
+    export_step(Box(10, 10, 10), str(p))
+    # A hard timeout kills the subprocess and returns None (undetermined),
+    # so the caller keeps its safe in-process verdict — never invents one.
+    assert _run_mesh_gate_subprocess(str(p), timeout=0.001) is None


### PR DESCRIPTION
Partially addresses #294. v0.3.55's mesh gate is wall-clock-bounded and **skips** (B-rep checks only) on parts too large to tessellate+stitch in-process within the worker timeout — so a large invalid part could ship its mesh defect undetected. The dominant cost is OCC `BRepMesh`, an **un-interruptible** native call no in-process budget can stop.

## Fix
`export()`, **only when the in-process check skipped**, retries the mesh check in a **separate process bounded by a hard `subprocess` timeout** (sized from `--exec-timeout`):
- large part → generous budget → actually checked;
- over-budget part → killed cleanly (worker never blocked);
- small export → no subprocess cost (in-process succeeds).

New `_gate_subprocess` module (marker-delimited JSON, robust to OCC stdout noise); `_run_mesh_gate_subprocess(path, timeout)` → result or `None` (undetermined → keep the safe in-process verdict); `_gate_report(..., mesh_override=)`.

Two bugs found by the fixture-240 repro and fixed: the `_LADDER_BASE_MAX_TRIS` guard now skips when there is no time deadline (so the subprocess actually ladders large parts), and a definite non-manifold / untriangulated defect is now reported even when the open-edge ladder is undetermined (it was being discarded).

## Verified
- **240** (non-manifold — previously *skipped → shipped invalid*) now **CAUGHT** out-of-process (70s).
- clean STEP → clean result (8s incl. startup); hard-timeout → `None`.
- corpus verdicts unchanged; full suite green (**776**).

## Remaining (tracked in #294)
Very large parts whose closedness needs the **finest** tessellation rung (e.g. fixture 202 — 18 MB, 558k-triangle `/32` rung) still exceed even the out-of-process budget, because the pure-Python stitch is too slow at that size. That tail needs the **vectorized stitch** — plan incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)