### PR TITLE
[codex] Add localized surface deviation compare

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "build123d-drafting-helpers>=0.10.0",
     "defusedxml>=0.7.1",
     "augura>=0.1.5",
+    "scipy",
 ]
 
 [project.optional-dependencies]

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -144,6 +144,10 @@ def _regions(
 
 
 _EXACT_VOL_TOL = 1.0  # mm^3 — ignore boolean slivers below this
+# Below this displacement (mm) the change is a cut/flush-fill with ~0 surface
+# movement (the new surface sits where material was) — report volume, not a
+# misleading 0 displacement.
+_DISP_NULL_MM = 0.05
 
 
 def _chunk_displacement(chunk: Any, ref_solid: Any) -> float:
@@ -401,7 +405,21 @@ def compare_shapes(
             "~0 added/removed volume — likely tessellation noise the detector over-fired on, or a "
             "purely tangential rearrangement; treat as effectively unchanged."
         )
-    return _result(exact["displacement"], "exact_boolean", exact)
+        return _result(exact["displacement"], "exact_boolean", exact)
+
+    magnitude = exact["displacement"]
+    if magnitude < _DISP_NULL_MM:
+        # A cut / flush fill (drilled hole, blind pocket): the new surface lies where
+        # the removed material was, so the exact vertex displacement is ~0 even though
+        # volume changed. Surface displacement is the wrong magnitude here — reporting
+        # max_deviation=0 reads as "no change". Use the mesh estimate for the headline;
+        # the exact magnitude is the added/removed VOLUME.
+        magnitude = primary["max_deviation"]
+        warnings.append(
+            "this edit removes/adds material with ~0 net surface displacement (a cut or flush fill) — "
+            "max_deviation shown is the mesh estimate; the EXACT magnitude is removed_volume/added_volume."
+        )
+    return _result(magnitude, "exact_boolean", exact)
 
 
 def main(a_step: str, b_step: str, out_json: str, eps: str, budget_s: str = "0") -> None:

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -30,6 +30,13 @@ from typing import Any
 # of the op budget, skip it and report the (flagged) mesh estimate instead of risking
 # a hard subprocess kill that would lose the whole result.
 _BOOL_RESERVE_S = 25.0
+# Skip the exact boolean when the changed region's clip box spans more than this
+# fraction of the part diagonal AND the part is large enough for that to be slow:
+# boolean cost scales with clip-box size, so a spread or large-extent edit on a big
+# part overruns the op budget. Such edits fall back to the (flagged) mesh estimate.
+# Small parts are fast regardless of spread, so the gate ignores them.
+_MAX_CLIP_DIAG_FRAC = 0.35
+_MIN_DIAG_FOR_CLIP_GATE = 300.0
 
 # eps (the per-vertex "this point moved" threshold) = factor x mesh deflection,
 # placed above the independent-tessellation noise floor. Deflection is diag*1e-3
@@ -226,7 +233,11 @@ def _exact_region_magnitude(
 
 
 def compare_shapes(
-    shape_a: Any, shape_b: Any, eps: float = 0.0, deadline: float | None = None
+    shape_a: Any,
+    shape_b: Any,
+    eps: float = 0.0,
+    deadline: float | None = None,
+    on_mesh_ready: Any = None,
 ) -> dict:
     """Symmetric vertex-sampled surface diff, localized to significant changed regions,
     with an EXACT boolean magnitude in each region.
@@ -324,47 +335,71 @@ def compare_shapes(
             "have touched more than the requested feature; verify nothing unintended moved."
         )
 
-    # Exact magnitude: an EXACT boolean diff clipped to the located region(s) replaces
-    # the vertex-NN deviation, which inflates 10-100x on flat faces. Clipping to the
-    # tight region keeps it in budget even on huge parts; fall back to the mesh
-    # estimate (clearly flagged) only if the boolean fails.
-    skip_exact = deadline is not None and time.monotonic() > deadline - _BOOL_RESERVE_S
-    exact = None if skip_exact else _exact_region_magnitude(shape_a, shape_b, regions)
-    if exact is not None:
-        magnitude = exact["displacement"]
-        magnitude_method = "exact_boolean"
-    else:
-        magnitude = primary["max_deviation"]
-        magnitude_method = "mesh_estimate"
+    def _result(magnitude: float, method: str, exact: dict | None) -> dict:
+        return {
+            **base,
+            "max_deviation": round(magnitude, 4),
+            "magnitude_method": method,
+            "changed": {
+                "centroid": primary["centroid"],
+                "bbox": primary["bbox"],
+                "local_max_deviation": round(magnitude, 4),
+                "moved_fraction": moved_fraction,
+                "added_volume": exact["added_volume"] if exact else None,
+                "removed_volume": exact["removed_volume"] if exact else None,
+                "added_centroid": exact["added_centroid"] if exact else None,
+                "removed_centroid": exact["removed_centroid"] if exact else None,
+            },
+            "regions": regions[:5],
+            "region_count": len(regions),
+            "unchanged_elsewhere": unchanged_elsewhere,
+            "warnings": warnings,
+        }
+
+    # SALVAGE: hand the mesh-estimate result to the caller (which persists it) BEFORE
+    # the exact boolean runs, so a hard kill mid-boolean still leaves a usable, flagged
+    # result rather than nothing.
+    mesh_result = _result(primary["max_deviation"], "mesh_estimate", None)
+    if on_mesh_ready is not None:
+        on_mesh_ready(mesh_result)
+
+    # Gate the exact boolean: its cost scales with the CLIP-BOX size, so skip it when
+    # the change spans too much of the part (spread / large-extent edits, which
+    # otherwise overrun the op budget) or when too little budget remains — returning
+    # the flagged mesh estimate. The boolean runs only when the clip is genuinely tight.
+    union = [c for r in regions for c in r["bbox"]]
+    clip_diag = _bbox_diag(
+        [min(p[k] for p in union) for k in range(3)],
+        [max(p[k] for p in union) for k in range(3)],
+    )
+    too_wide = diag > _MIN_DIAG_FOR_CLIP_GATE and clip_diag > diag * _MAX_CLIP_DIAG_FRAC
+    low_budget = deadline is not None and time.monotonic() > deadline - _BOOL_RESERVE_S
+    if too_wide or low_budget:
         why = (
-            "skipped (insufficient op budget after tessellation)"
-            if skip_exact
-            else "unavailable (boolean failed)"
+            "the change spans a large/spread region"
+            if too_wide
+            else "insufficient op budget after tessellation"
         )
         warnings.append(
-            f"exact boolean magnitude {why}; max_deviation is a vertex-mesh estimate that can "
-            "overstate the true surface displacement on flat faces — cross-check the volume/bbox deltas."
+            f"exact boolean magnitude skipped ({why}); max_deviation is a vertex-mesh estimate that "
+            "can overstate displacement on flat faces — use the volume/bbox deltas for magnitude."
         )
+        return mesh_result
 
-    return {
-        **base,
-        "max_deviation": round(magnitude, 4),
-        "magnitude_method": magnitude_method,
-        "changed": {
-            "centroid": primary["centroid"],
-            "bbox": primary["bbox"],
-            "local_max_deviation": round(magnitude, 4),
-            "moved_fraction": moved_fraction,
-            "added_volume": exact["added_volume"] if exact else None,
-            "removed_volume": exact["removed_volume"] if exact else None,
-            "added_centroid": exact["added_centroid"] if exact else None,
-            "removed_centroid": exact["removed_centroid"] if exact else None,
-        },
-        "regions": regions[:5],
-        "region_count": len(regions),
-        "unchanged_elsewhere": unchanged_elsewhere,
-        "warnings": warnings,
-    }
+    exact = _exact_region_magnitude(shape_a, shape_b, regions)
+    if exact is None:
+        warnings.append(
+            "exact boolean magnitude unavailable (boolean failed); max_deviation is a vertex-mesh "
+            "estimate that can overstate displacement on flat faces — cross-check the volume/bbox deltas."
+        )
+        return mesh_result
+    if exact["added_volume"] + exact["removed_volume"] < _EXACT_VOL_TOL:
+        warnings.append(
+            f"the mesh detector flagged {len(regions)} changed region(s) but the exact boolean nets "
+            "~0 added/removed volume — likely tessellation noise the detector over-fired on, or a "
+            "purely tangential rearrangement; treat as effectively unchanged."
+        )
+    return _result(exact["displacement"], "exact_boolean", exact)
 
 
 def main(a_step: str, b_step: str, out_json: str, eps: str, budget_s: str = "0") -> None:
@@ -372,14 +407,24 @@ def main(a_step: str, b_step: str, out_json: str, eps: str, budget_s: str = "0")
 
     t0 = time.monotonic()
     deadline = t0 + float(budget_s) if float(budget_s) > 0 else None
+
+    def _persist(r: dict) -> None:
+        with open(out_json, "w") as f:
+            json.dump(r, f)
+
     try:
+        # _persist runs as on_mesh_ready (writes the mesh estimate before the boolean),
+        # so a hard kill mid-boolean leaves that flagged result on disk to salvage.
         result = compare_shapes(
-            import_step(a_step), import_step(b_step), float(eps), deadline=deadline
+            import_step(a_step),
+            import_step(b_step),
+            float(eps),
+            deadline=deadline,
+            on_mesh_ready=_persist,
         )
     except Exception as exc:  # noqa: BLE001 - convert worker failures to structured JSON
         result = {"error": f"{type(exc).__name__}: {exc}"}
-    with open(out_json, "w") as f:
-        json.dump(result, f)
+    _persist(result)
 
 
 if __name__ == "__main__":

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -408,18 +408,22 @@ def compare_shapes(
         return _result(exact["displacement"], "exact_boolean", exact)
 
     magnitude = exact["displacement"]
+    method = "exact_boolean"
     if magnitude < _DISP_NULL_MM:
         # A cut / flush fill (drilled hole, blind pocket): the new surface lies where
         # the removed material was, so the exact vertex displacement is ~0 even though
         # volume changed. Surface displacement is the wrong magnitude here — reporting
-        # max_deviation=0 reads as "no change". Use the mesh estimate for the headline;
-        # the exact magnitude is the added/removed VOLUME.
+        # max_deviation=0 reads as "no change". Use the mesh estimate for the headline
+        # (the VOLUMES stay exact) and label the method so consumers don't read
+        # max_deviation as exact.
         magnitude = primary["max_deviation"]
+        method = "exact_volume_mesh_displacement"
         warnings.append(
             "this edit removes/adds material with ~0 net surface displacement (a cut or flush fill) — "
-            "max_deviation shown is the mesh estimate; the EXACT magnitude is removed_volume/added_volume."
+            "max_deviation is a MESH estimate (not exact); the exact magnitude is "
+            "removed_volume/added_volume."
         )
-    return _result(magnitude, "exact_boolean", exact)
+    return _result(magnitude, method, exact)
 
 
 def main(a_step: str, b_step: str, out_json: str, eps: str, budget_s: str = "0") -> None:

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -1,0 +1,161 @@
+"""Out-of-process localized surface comparison for ``shape_compare``.
+
+Run as ``python -m build123d_mcp._shape_compare_subprocess <a.step> <b.step>
+<out.json> <eps>``. The two STEP files are imported, tessellated, and compared
+with a symmetric nearest-neighbour surface distance. This is isolated because
+OCC tessellation is an un-interruptible native call; the parent bounds this
+process with ``subprocess.run(timeout=...)`` so the worker session survives a
+large or pathological part.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from collections import deque
+from typing import Any
+
+
+def _round_pt(p: list[float] | tuple[float, float, float], digits: int = 4) -> list[float]:
+    return [round(float(p[0]), digits), round(float(p[1]), digits), round(float(p[2]), digits)]
+
+
+def _bbox_diag(mins: list[float], maxs: list[float]) -> float:
+    return math.dist(mins, maxs)
+
+
+def _shape_diag(shape: Any) -> float:
+    bb = shape.bounding_box()
+    return math.dist((bb.min.X, bb.min.Y, bb.min.Z), (bb.max.X, bb.max.Y, bb.max.Z))
+
+
+def _tessellate_points(shape: Any) -> tuple[list[tuple[float, float, float]], list[list[int]]]:
+    diag = _shape_diag(shape)
+    if diag <= 0:
+        return [], []
+    verts, tris = shape.tessellate(max(diag * 1e-3, 1e-4))
+    pts = [(float(v.X), float(v.Y), float(v.Z)) for v in verts]
+    return pts, [list(t) for t in tris]
+
+
+def _moved_components(
+    pts: list[tuple[float, float, float]], tris: list[list[int]], moved: set[int]
+) -> list[list[int]]:
+    if not moved:
+        return []
+
+    adj: dict[int, set[int]] = {i: set() for i in moved}
+    for tri in tris:
+        if len(tri) < 3:
+            continue
+        a, b, c = tri[0], tri[1], tri[2]
+        for u, v in ((a, b), (b, c), (a, c)):
+            if u in moved and v in moved:
+                adj[u].add(v)
+                adj[v].add(u)
+
+    seen: set[int] = set()
+    components: list[list[int]] = []
+    for start in moved:
+        if start in seen:
+            continue
+        q = deque([start])
+        seen.add(start)
+        comp: list[int] = []
+        while q:
+            cur = q.popleft()
+            comp.append(cur)
+            for nxt in adj[cur]:
+                if nxt not in seen:
+                    seen.add(nxt)
+                    q.append(nxt)
+        components.append(comp)
+    return components
+
+
+def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.01) -> dict:
+    """Return a symmetric vertex-sampled Hausdorff diff with a localized region."""
+    from scipy.spatial import cKDTree
+
+    pts_a, tris_a = _tessellate_points(shape_a)
+    pts_b, tris_b = _tessellate_points(shape_b)
+    warnings: list[str] = []
+    if not pts_a or not pts_b:
+        return {
+            "error": "could not tessellate one or both shapes for surface comparison",
+            "warnings": warnings,
+        }
+
+    tree_a = cKDTree(pts_a)
+    tree_b = cKDTree(pts_b)
+    dist_a_to_b, _ = tree_b.query(pts_a, workers=-1)
+    dist_b_to_a, _ = tree_a.query(pts_b, workers=-1)
+
+    max_deviation = max(float(dist_a_to_b.max(initial=0.0)), float(dist_b_to_a.max(initial=0.0)))
+    moved_a = {i for i, d in enumerate(dist_a_to_b) if float(d) > eps}
+    moved_b = {i for i, d in enumerate(dist_b_to_a) if float(d) > eps}
+    moved_points = [pts_a[i] for i in moved_a] + [pts_b[i] for i in moved_b]
+    total_points = len(pts_a) + len(pts_b)
+
+    if not moved_points:
+        return {
+            "max_deviation": round(max_deviation, 4),
+            "changed": {
+                "centroid": None,
+                "bbox": None,
+                "local_max_deviation": 0.0,
+                "moved_fraction": 0.0,
+            },
+            "unchanged_elsewhere": True,
+            "eps": eps,
+            "sample_points": total_points,
+            "warnings": warnings,
+        }
+
+    mins = [min(p[i] for p in moved_points) for i in range(3)]
+    maxs = [max(p[i] for p in moved_points) for i in range(3)]
+    centroid = [sum(p[i] for p in moved_points) / len(moved_points) for i in range(3)]
+
+    comps_a = _moved_components(pts_a, tris_a, moved_a)
+    comps_b = _moved_components(pts_b, tris_b, moved_b)
+    component_count = len(comps_a) + len(comps_b)
+    moved_count = len(moved_points)
+    shape_diag = max(_shape_diag(shape_a), _shape_diag(shape_b))
+    changed_diag = _bbox_diag(mins, maxs)
+
+    # This is a locality check, not a score. A single edit can appear as two
+    # moved patches (old and new feature positions), so use both clustering and
+    # spatial extent to flag obvious "also changed elsewhere" cases.
+    changed_is_spatially_local = shape_diag <= 0 or changed_diag <= max(eps * 4, shape_diag * 0.55)
+    unchanged_elsewhere = bool(changed_is_spatially_local)
+
+    return {
+        "max_deviation": round(max_deviation, 4),
+        "changed": {
+            "centroid": _round_pt(centroid),
+            "bbox": [_round_pt(mins), _round_pt(maxs)],
+            "local_max_deviation": round(max_deviation, 4),
+            "moved_fraction": round(moved_count / total_points, 4),
+            "component_count": component_count,
+        },
+        "unchanged_elsewhere": unchanged_elsewhere,
+        "eps": eps,
+        "sample_points": total_points,
+        "warnings": warnings,
+    }
+
+
+def main(a_step: str, b_step: str, out_json: str, eps: str) -> None:
+    from build123d import import_step
+
+    try:
+        result = compare_shapes(import_step(a_step), import_step(b_step), float(eps))
+    except Exception as exc:  # noqa: BLE001 - convert worker failures to structured JSON
+        result = {"error": f"{type(exc).__name__}: {exc}"}
+    with open(out_json, "w") as f:
+        json.dump(result, f)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -6,6 +6,15 @@ with a symmetric nearest-neighbour surface distance. This is isolated because
 OCC tessellation is an un-interruptible native call; the parent bounds this
 process with ``subprocess.run(timeout=...)`` so the worker session survives a
 large or pathological part.
+
+Noise model (why eps is not a fixed mm). The two shapes are tessellated
+INDEPENDENTLY, so even an unchanged surface has a nonzero nearest-neighbour
+distance: most points sit at ~0, but a thin tail of outliers (sharp edges,
+corners where the two triangulations diverge) reaches roughly the mesh
+DEFLECTION. So eps is scaled to the deflection, and on top of that the moved
+points are clustered and only SIGNIFICANT components are kept — the real edit is
+one contiguous patch of many vertices, while residual noise is scattered tiny
+components. Together these stop a same-geometry pair from fabricating a change.
 """
 
 from __future__ import annotations
@@ -15,6 +24,27 @@ import math
 import sys
 from collections import deque
 from typing import Any
+
+# eps (the per-vertex "this point moved" threshold) = factor x mesh deflection,
+# placed above the independent-tessellation noise floor. Deflection is diag*1e-3
+# (see compare_shapes), so this is ~3x the typical worst-case noise.
+_EPS_DEFLECTION_FACTOR = 3.0
+_EPS_FLOOR_MM = 0.05
+# A genuine changed region is a contiguous moved patch that spans real physical
+# size; residual tessellation noise is a speck within the mesh resolution. Filter
+# by SPATIAL SPAN (density-independent — works for sparse synthetic boxes and dense
+# real parts alike): keep a component only if its bbox diagonal is at least this
+# many mesh-deflections across. A speck of noise spans ~1 deflection; a real feature
+# spans many.
+_MIN_REGION_SPAN_FACTOR = 2.5
+_MIN_REGION_SPAN_FLOOR = 0.1
+# unchanged_elsewhere: the change is localized if the changed regions cluster in one
+# area — i.e. the region centroids span only a small fraction of the part diagonal.
+# Spread (not moved-fraction, not region-count) is the right signal: it is scale-
+# independent (a feature is a huge fraction of a tiny toy part but a tiny fraction of
+# a real one), and a single ring feature (a fillet) fragments into many arc
+# components clustered in one place — still localized.
+_LOCAL_SPREAD_FRAC = 0.4
 
 
 def _round_pt(p: list[float] | tuple[float, float, float], digits: int = 4) -> list[float]:
@@ -30,11 +60,11 @@ def _shape_diag(shape: Any) -> float:
     return math.dist((bb.min.X, bb.min.Y, bb.min.Z), (bb.max.X, bb.max.Y, bb.max.Z))
 
 
-def _tessellate_points(shape: Any) -> tuple[list[tuple[float, float, float]], list[list[int]]]:
-    diag = _shape_diag(shape)
-    if diag <= 0:
-        return [], []
-    verts, tris = shape.tessellate(max(diag * 1e-3, 1e-4))
+def _tessellate_points(
+    shape: Any, deflection: float
+) -> tuple[list[tuple[float, float, float]], list[list[int]]]:
+    """Tessellate at a SHARED deflection so both meshes have comparable sampling."""
+    verts, tris = shape.tessellate(deflection)
     pts = [(float(v.X), float(v.Y), float(v.Z)) for v in verts]
     return pts, [list(t) for t in tris]
 
@@ -74,12 +104,56 @@ def _moved_components(
     return components
 
 
-def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.01) -> dict:
-    """Return a symmetric vertex-sampled Hausdorff diff with a localized region."""
+def _regions(
+    pts: list[tuple[float, float, float]],
+    tris: list[list[int]],
+    moved: set[int],
+    dist: Any,
+    min_span: float,
+) -> list[dict]:
+    """Significant changed regions on one shape: contiguous moved-vertex patches that
+    span at least ``min_span`` mm, each with its own centroid/bbox/local max."""
+    out: list[dict] = []
+    for comp in _moved_components(pts, tris, moved):
+        cpts = [pts[i] for i in comp]
+        mins = [min(p[k] for p in cpts) for k in range(3)]
+        maxs = [max(p[k] for p in cpts) for k in range(3)]
+        if _bbox_diag(mins, maxs) < min_span:
+            continue  # a speck within mesh resolution — tessellation noise, not a real change
+        cen = [sum(p[k] for p in cpts) / len(cpts) for k in range(3)]
+        out.append(
+            {
+                "centroid": _round_pt(cen),
+                "bbox": [_round_pt(mins), _round_pt(maxs)],
+                "max_deviation": round(max(float(dist[i]) for i in comp), 4),
+                "point_count": len(comp),
+            }
+        )
+    return out
+
+
+def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.0) -> dict:
+    """Symmetric vertex-sampled surface diff, localized to significant changed regions.
+
+    eps<=0 (the default) auto-scales the move threshold to the mesh deflection. This
+    is model-vs-input EDIT VERIFICATION, not a score: a true no-op reads
+    max_deviation~0, and a tangential feature move (sliding a hole) is invisible to a
+    surface-distance metric — see the warning emitted when no region is found.
+    """
     from scipy.spatial import cKDTree
 
-    pts_a, tris_a = _tessellate_points(shape_a)
-    pts_b, tris_b = _tessellate_points(shape_b)
+    diag = max(_shape_diag(shape_a), _shape_diag(shape_b))
+    if diag <= 0:
+        return {
+            "error": "degenerate shape (zero bounding box) — nothing to compare",
+            "warnings": [],
+        }
+    deflection = max(diag * 1e-3, 1e-4)
+    if eps <= 0:
+        eps = max(deflection * _EPS_DEFLECTION_FACTOR, _EPS_FLOOR_MM)
+
+    pts_a, tris_a = _tessellate_points(shape_a, deflection)
+    pts_b, tris_b = _tessellate_points(shape_b, deflection)
     warnings: list[str] = []
     if not pts_a or not pts_b:
         return {
@@ -92,56 +166,76 @@ def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.01) -> dict:
     dist_a_to_b, _ = tree_b.query(pts_a, workers=-1)
     dist_b_to_a, _ = tree_a.query(pts_b, workers=-1)
 
-    max_deviation = max(float(dist_a_to_b.max(initial=0.0)), float(dist_b_to_a.max(initial=0.0)))
+    # Raw symmetric Hausdorff max — dominated by the independent-tessellation noise
+    # tail (sharp edges/corners), so NOT the headline; reported for transparency.
+    raw_surface_max = max(float(dist_a_to_b.max(initial=0.0)), float(dist_b_to_a.max(initial=0.0)))
     moved_a = {i for i, d in enumerate(dist_a_to_b) if float(d) > eps}
     moved_b = {i for i, d in enumerate(dist_b_to_a) if float(d) > eps}
-    moved_points = [pts_a[i] for i in moved_a] + [pts_b[i] for i in moved_b]
     total_points = len(pts_a) + len(pts_b)
 
-    if not moved_points:
+    min_span = max(deflection * _MIN_REGION_SPAN_FACTOR, _MIN_REGION_SPAN_FLOOR)
+    regions = _regions(pts_a, tris_a, moved_a, dist_a_to_b, min_span) + _regions(
+        pts_b, tris_b, moved_b, dist_b_to_a, min_span
+    )
+    regions.sort(key=lambda r: r["point_count"], reverse=True)
+    moved_count = sum(r["point_count"] for r in regions)
+    moved_fraction = round(moved_count / total_points, 4) if total_points else 0.0
+    # Headline deviation is the largest REAL change (over significant regions), 0 when
+    # nothing moved above the noise floor — so a no-op reads ~0, not the noise tail.
+    region_max = max((r["max_deviation"] for r in regions), default=0.0)
+
+    base = {
+        "max_deviation": round(region_max, 4),
+        "raw_surface_max": round(raw_surface_max, 4),
+        "eps": round(eps, 4),
+        "sample_points": total_points,
+    }
+
+    if not regions:
+        warnings.append(
+            f"No surface change above eps={round(eps, 4)} mm (the tessellation-resolution floor). "
+            "EITHER the shapes match within mesh resolution, OR the edit is a TANGENTIAL move "
+            "(e.g. relocating a hole/feature), which a surface-distance metric cannot detect. For "
+            "move/relocation edits, confirm with the volume/bbox/center deltas and feature positions "
+            "(find_holes), not this field."
+        )
         return {
-            "max_deviation": round(max_deviation, 4),
+            **base,
             "changed": {
                 "centroid": None,
                 "bbox": None,
                 "local_max_deviation": 0.0,
                 "moved_fraction": 0.0,
             },
+            "regions": [],
+            "region_count": 0,
             "unchanged_elsewhere": True,
-            "eps": eps,
-            "sample_points": total_points,
             "warnings": warnings,
         }
 
-    mins = [min(p[i] for p in moved_points) for i in range(3)]
-    maxs = [max(p[i] for p in moved_points) for i in range(3)]
-    centroid = [sum(p[i] for p in moved_points) / len(moved_points) for i in range(3)]
-
-    comps_a = _moved_components(pts_a, tris_a, moved_a)
-    comps_b = _moved_components(pts_b, tris_b, moved_b)
-    component_count = len(comps_a) + len(comps_b)
-    moved_count = len(moved_points)
-    shape_diag = max(_shape_diag(shape_a), _shape_diag(shape_b))
-    changed_diag = _bbox_diag(mins, maxs)
-
-    # This is a locality check, not a score. A single edit can appear as two
-    # moved patches (old and new feature positions), so use both clustering and
-    # spatial extent to flag obvious "also changed elsewhere" cases.
-    changed_is_spatially_local = shape_diag <= 0 or changed_diag <= max(eps * 4, shape_diag * 0.55)
-    unchanged_elsewhere = bool(changed_is_spatially_local)
-
+    primary = regions[0]  # the DOMINANT changed region — not a merged envelope across all changes
+    centroids = [r["centroid"] for r in regions]
+    region_spread = _bbox_diag(
+        [min(c[k] for c in centroids) for k in range(3)],
+        [max(c[k] for c in centroids) for k in range(3)],
+    )
+    unchanged_elsewhere = bool(region_spread <= diag * _LOCAL_SPREAD_FRAC)
+    if not unchanged_elsewhere:
+        warnings.append(
+            "the changed regions are spread across the part, not confined to one area — the edit may "
+            "have touched more than the requested feature; verify nothing unintended moved."
+        )
     return {
-        "max_deviation": round(max_deviation, 4),
+        **base,
         "changed": {
-            "centroid": _round_pt(centroid),
-            "bbox": [_round_pt(mins), _round_pt(maxs)],
-            "local_max_deviation": round(max_deviation, 4),
-            "moved_fraction": round(moved_count / total_points, 4),
-            "component_count": component_count,
+            "centroid": primary["centroid"],
+            "bbox": primary["bbox"],
+            "local_max_deviation": primary["max_deviation"],
+            "moved_fraction": moved_fraction,
         },
+        "regions": regions[:5],
+        "region_count": len(regions),
         "unchanged_elsewhere": unchanged_elsewhere,
-        "eps": eps,
-        "sample_points": total_points,
         "warnings": warnings,
     }
 

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -30,13 +30,11 @@ from typing import Any
 # of the op budget, skip it and report the (flagged) mesh estimate instead of risking
 # a hard subprocess kill that would lose the whole result.
 _BOOL_RESERVE_S = 25.0
-# Skip the exact boolean when the changed region's clip box spans more than this
-# fraction of the part diagonal AND the part is large enough for that to be slow:
-# boolean cost scales with clip-box size, so a spread or large-extent edit on a big
-# part overruns the op budget. Such edits fall back to the (flagged) mesh estimate.
-# Small parts are fast regardless of spread, so the gate ignores them.
-_MAX_CLIP_DIAG_FRAC = 0.35
-_MIN_DIAG_FOR_CLIP_GATE = 300.0
+# Skip the exact boolean when the changed region's clip box is wider than this (mm).
+# Boolean cost scales with ABSOLUTE clip-box size (not a fraction of the part — a
+# 291mm part with a 198mm clip took 360s), so a spread or large-extent edit falls
+# back to the (flagged) mesh estimate. Localized edits (tight clip) still run exact.
+_MAX_CLIP_ABS_MM = 150.0
 
 # eps (the per-vertex "this point moved" threshold) = factor x mesh deflection,
 # placed above the independent-tessellation noise floor. Deflection is diag*1e-3
@@ -186,9 +184,23 @@ def _exact_region_magnitude(
     from OCP.gp import gp_Pnt
     from OCP.GProp import GProp_GProps
 
+    def _vol(s: Any) -> float:
+        g = GProp_GProps()
+        BRepGProp.VolumeProperties_s(s, g)
+        return g.Mass()
+
+    def _ctr(s: Any) -> list[float]:
+        g = GProp_GProps()
+        BRepGProp.VolumeProperties_s(s, g)
+        c = g.CentreOfMass()
+        return [round(c.X(), 3), round(c.Y(), 3), round(c.Z(), 3)]
+
     pts = [c for r in regions for c in r["bbox"]]
     mn = [min(p[k] for p in pts) - margin for k in range(3)]
     mx = [max(p[k] for p in pts) + margin for k in range(3)]
+    # The WHOLE computation (boolean + volume + displacement) is guarded: any failure
+    # returns None so the caller keeps the already-persisted mesh-estimate salvage —
+    # a post-boolean raise must not discard what a timeout would keep.
     try:
         box = BRepPrimAPI_MakeBox(gp_Pnt(*mn), gp_Pnt(*mx)).Shape()
         cA = BRepAlgoAPI_Common(shape_a.wrapped, box)
@@ -203,33 +215,21 @@ def _exact_region_magnitude(
         add.Build()
         if not rem.IsDone() or not add.IsDone():
             return None
-    except Exception:  # noqa: BLE001 - boolean failure → fall back to mesh estimate
+        rv, av = _vol(rem.Shape()), _vol(add.Shape())
+        disp = 0.0
+        if av > _EXACT_VOL_TOL:
+            disp = max(disp, _chunk_displacement(add.Shape(), shape_a.wrapped))
+        if rv > _EXACT_VOL_TOL:
+            disp = max(disp, _chunk_displacement(rem.Shape(), shape_b.wrapped))
+        return {
+            "added_volume": round(av, 2),
+            "removed_volume": round(rv, 2),
+            "added_centroid": _ctr(add.Shape()) if av > _EXACT_VOL_TOL else None,
+            "removed_centroid": _ctr(rem.Shape()) if rv > _EXACT_VOL_TOL else None,
+            "displacement": round(disp, 4),
+        }
+    except Exception:  # noqa: BLE001 - any failure → fall back to (salvaged) mesh estimate
         return None
-
-    def _vol(s: Any) -> float:
-        g = GProp_GProps()
-        BRepGProp.VolumeProperties_s(s, g)
-        return g.Mass()
-
-    def _ctr(s: Any) -> list[float]:
-        g = GProp_GProps()
-        BRepGProp.VolumeProperties_s(s, g)
-        c = g.CentreOfMass()
-        return [round(c.X(), 3), round(c.Y(), 3), round(c.Z(), 3)]
-
-    rv, av = _vol(rem.Shape()), _vol(add.Shape())
-    disp = 0.0
-    if av > _EXACT_VOL_TOL:
-        disp = max(disp, _chunk_displacement(add.Shape(), shape_a.wrapped))
-    if rv > _EXACT_VOL_TOL:
-        disp = max(disp, _chunk_displacement(rem.Shape(), shape_b.wrapped))
-    return {
-        "added_volume": round(av, 2),
-        "removed_volume": round(rv, 2),
-        "added_centroid": _ctr(add.Shape()) if av > _EXACT_VOL_TOL else None,
-        "removed_centroid": _ctr(rem.Shape()) if rv > _EXACT_VOL_TOL else None,
-        "displacement": round(disp, 4),
-    }
 
 
 def compare_shapes(
@@ -238,6 +238,7 @@ def compare_shapes(
     eps: float = 0.0,
     deadline: float | None = None,
     on_mesh_ready: Any = None,
+    allow_exact: bool = True,
 ) -> dict:
     """Symmetric vertex-sampled surface diff, localized to significant changed regions,
     with an EXACT boolean magnitude in each region.
@@ -372,14 +373,15 @@ def compare_shapes(
         [min(p[k] for p in union) for k in range(3)],
         [max(p[k] for p in union) for k in range(3)],
     )
-    too_wide = diag > _MIN_DIAG_FOR_CLIP_GATE and clip_diag > diag * _MAX_CLIP_DIAG_FRAC
+    too_wide = clip_diag > _MAX_CLIP_ABS_MM
     low_budget = deadline is not None and time.monotonic() > deadline - _BOOL_RESERVE_S
-    if too_wide or low_budget:
-        why = (
-            "the change spans a large/spread region"
-            if too_wide
-            else "insufficient op budget after tessellation"
-        )
+    if not allow_exact or too_wide or low_budget:
+        if not allow_exact:
+            why = "running in-process, where no op-timeout can bound the exact boolean"
+        elif too_wide:
+            why = "the change spans a large/spread region"
+        else:
+            why = "insufficient op budget after tessellation"
         warnings.append(
             f"exact boolean magnitude skipped ({why}); max_deviation is a vertex-mesh estimate that "
             "can overstate displacement on flat faces — use the volume/bbox deltas for magnitude."

--- a/src/build123d_mcp/_shape_compare_subprocess.py
+++ b/src/build123d_mcp/_shape_compare_subprocess.py
@@ -22,8 +22,14 @@ from __future__ import annotations
 import json
 import math
 import sys
+import time
 from collections import deque
 from typing import Any
+
+# Headroom (s) the exact boolean needs after tessellation; if less than this remains
+# of the op budget, skip it and report the (flagged) mesh estimate instead of risking
+# a hard subprocess kill that would lose the whole result.
+_BOOL_RESERVE_S = 25.0
 
 # eps (the per-vertex "this point moved" threshold) = factor x mesh deflection,
 # placed above the independent-tessellation noise floor. Deflection is diag*1e-3
@@ -132,13 +138,105 @@ def _regions(
     return out
 
 
-def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.0) -> dict:
-    """Symmetric vertex-sampled surface diff, localized to significant changed regions.
+_EXACT_VOL_TOL = 1.0  # mm^3 — ignore boolean slivers below this
+
+
+def _chunk_displacement(chunk: Any, ref_solid: Any) -> float:
+    """Max distance from a difference chunk's vertices to the reference solid — i.e.
+    how far the surface actually moved (exact, no vertex-NN flat-face inflation)."""
+    from OCP.BRep import BRep_Tool
+    from OCP.BRepExtrema import BRepExtrema_DistShapeShape
+    from OCP.TopAbs import TopAbs_VERTEX
+    from OCP.TopExp import TopExp_Explorer
+    from OCP.TopoDS import TopoDS
+
+    e = TopExp_Explorer(chunk, TopAbs_VERTEX)
+    seen: set = set()
+    mx = 0.0
+    while e.More():
+        v = TopoDS.Vertex_s(e.Current())
+        p = BRep_Tool.Pnt_s(v)
+        key = (round(p.X(), 3), round(p.Y(), 3), round(p.Z(), 3))
+        if key not in seen:
+            seen.add(key)
+            d = BRepExtrema_DistShapeShape(v, ref_solid)
+            if d.IsDone():
+                mx = max(mx, d.Value())
+        e.Next()
+    return mx
+
+
+def _exact_region_magnitude(
+    shape_a: Any, shape_b: Any, regions: list, margin: float = 3.0
+) -> dict | None:
+    """Exact boolean diff in the located region(s): true added/removed VOLUME and
+    surface DISPLACEMENT, with no vertex-NN inflation. Clipping to the (tight) region
+    keeps the boolean inside budget even on huge parts. Returns None if the boolean
+    fails (caller keeps the mesh estimate)."""
+    from OCP.BRepAlgoAPI import BRepAlgoAPI_Common, BRepAlgoAPI_Cut
+    from OCP.BRepGProp import BRepGProp
+    from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+    from OCP.gp import gp_Pnt
+    from OCP.GProp import GProp_GProps
+
+    pts = [c for r in regions for c in r["bbox"]]
+    mn = [min(p[k] for p in pts) - margin for k in range(3)]
+    mx = [max(p[k] for p in pts) + margin for k in range(3)]
+    try:
+        box = BRepPrimAPI_MakeBox(gp_Pnt(*mn), gp_Pnt(*mx)).Shape()
+        cA = BRepAlgoAPI_Common(shape_a.wrapped, box)
+        cA.Build()
+        cB = BRepAlgoAPI_Common(shape_b.wrapped, box)
+        cB.Build()
+        if not cA.IsDone() or not cB.IsDone():
+            return None
+        rem = BRepAlgoAPI_Cut(cA.Shape(), cB.Shape())  # material in A not B = removed
+        rem.Build()
+        add = BRepAlgoAPI_Cut(cB.Shape(), cA.Shape())  # material in B not A = added
+        add.Build()
+        if not rem.IsDone() or not add.IsDone():
+            return None
+    except Exception:  # noqa: BLE001 - boolean failure → fall back to mesh estimate
+        return None
+
+    def _vol(s: Any) -> float:
+        g = GProp_GProps()
+        BRepGProp.VolumeProperties_s(s, g)
+        return g.Mass()
+
+    def _ctr(s: Any) -> list[float]:
+        g = GProp_GProps()
+        BRepGProp.VolumeProperties_s(s, g)
+        c = g.CentreOfMass()
+        return [round(c.X(), 3), round(c.Y(), 3), round(c.Z(), 3)]
+
+    rv, av = _vol(rem.Shape()), _vol(add.Shape())
+    disp = 0.0
+    if av > _EXACT_VOL_TOL:
+        disp = max(disp, _chunk_displacement(add.Shape(), shape_a.wrapped))
+    if rv > _EXACT_VOL_TOL:
+        disp = max(disp, _chunk_displacement(rem.Shape(), shape_b.wrapped))
+    return {
+        "added_volume": round(av, 2),
+        "removed_volume": round(rv, 2),
+        "added_centroid": _ctr(add.Shape()) if av > _EXACT_VOL_TOL else None,
+        "removed_centroid": _ctr(rem.Shape()) if rv > _EXACT_VOL_TOL else None,
+        "displacement": round(disp, 4),
+    }
+
+
+def compare_shapes(
+    shape_a: Any, shape_b: Any, eps: float = 0.0, deadline: float | None = None
+) -> dict:
+    """Symmetric vertex-sampled surface diff, localized to significant changed regions,
+    with an EXACT boolean magnitude in each region.
 
     eps<=0 (the default) auto-scales the move threshold to the mesh deflection. This
     is model-vs-input EDIT VERIFICATION, not a score: a true no-op reads
     max_deviation~0, and a tangential feature move (sliding a hole) is invisible to a
     surface-distance metric — see the warning emitted when no region is found.
+    deadline (monotonic time): if set and too little remains after tessellation, the
+    exact boolean is skipped for the (flagged) mesh estimate.
     """
     from scipy.spatial import cKDTree
 
@@ -225,13 +323,42 @@ def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.0) -> dict:
             "the changed regions are spread across the part, not confined to one area — the edit may "
             "have touched more than the requested feature; verify nothing unintended moved."
         )
+
+    # Exact magnitude: an EXACT boolean diff clipped to the located region(s) replaces
+    # the vertex-NN deviation, which inflates 10-100x on flat faces. Clipping to the
+    # tight region keeps it in budget even on huge parts; fall back to the mesh
+    # estimate (clearly flagged) only if the boolean fails.
+    skip_exact = deadline is not None and time.monotonic() > deadline - _BOOL_RESERVE_S
+    exact = None if skip_exact else _exact_region_magnitude(shape_a, shape_b, regions)
+    if exact is not None:
+        magnitude = exact["displacement"]
+        magnitude_method = "exact_boolean"
+    else:
+        magnitude = primary["max_deviation"]
+        magnitude_method = "mesh_estimate"
+        why = (
+            "skipped (insufficient op budget after tessellation)"
+            if skip_exact
+            else "unavailable (boolean failed)"
+        )
+        warnings.append(
+            f"exact boolean magnitude {why}; max_deviation is a vertex-mesh estimate that can "
+            "overstate the true surface displacement on flat faces — cross-check the volume/bbox deltas."
+        )
+
     return {
         **base,
+        "max_deviation": round(magnitude, 4),
+        "magnitude_method": magnitude_method,
         "changed": {
             "centroid": primary["centroid"],
             "bbox": primary["bbox"],
-            "local_max_deviation": primary["max_deviation"],
+            "local_max_deviation": round(magnitude, 4),
             "moved_fraction": moved_fraction,
+            "added_volume": exact["added_volume"] if exact else None,
+            "removed_volume": exact["removed_volume"] if exact else None,
+            "added_centroid": exact["added_centroid"] if exact else None,
+            "removed_centroid": exact["removed_centroid"] if exact else None,
         },
         "regions": regions[:5],
         "region_count": len(regions),
@@ -240,11 +367,15 @@ def compare_shapes(shape_a: Any, shape_b: Any, eps: float = 0.0) -> dict:
     }
 
 
-def main(a_step: str, b_step: str, out_json: str, eps: str) -> None:
+def main(a_step: str, b_step: str, out_json: str, eps: str, budget_s: str = "0") -> None:
     from build123d import import_step
 
+    t0 = time.monotonic()
+    deadline = t0 + float(budget_s) if float(budget_s) > 0 else None
     try:
-        result = compare_shapes(import_step(a_step), import_step(b_step), float(eps))
+        result = compare_shapes(
+            import_step(a_step), import_step(b_step), float(eps), deadline=deadline
+        )
     except Exception as exc:  # noqa: BLE001 - convert worker failures to structured JSON
         result = {"error": f"{type(exc).__name__}: {exc}"}
     with open(out_json, "w") as f:
@@ -252,4 +383,4 @@ def main(a_step: str, b_step: str, out_json: str, eps: str) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+    main(*sys.argv[1:6])

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -391,7 +391,7 @@ def reset() -> str:
 
 @mcp.tool()
 def shape_compare(object_a: str, object_b: str) -> str:
-    """Compare two named shapes (from show()) by geometry metrics: volume delta, bbox delta, topology delta (faces/edges/vertices), and center offset. Useful when you have an intended design and a reference/test shape and want to verify they match — or to quantify how a modification changed the geometry."""
+    """Compare two named shapes (from show()) by geometry metrics plus localized surface deviation. Keeps volume, bbox, topology, and center deltas, and adds a bounded symmetric Hausdorff-style surface diff: max_deviation, changed region (centroid/bbox/local max/moved fraction), and unchanged_elsewhere. For editing, this is model↔input verification, not a score: a no-op has low deviation but may be wrong. Use the localized changed region to check that the requested feature moved by the requested amount and that unrelated regions stayed put."""
     return _resolve_session().shape_compare(object_a, object_b)
 
 

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -57,6 +57,7 @@ def _surface_compare_bounded(session, sa, sb) -> dict:
                     b_step,
                     out_json,
                     repr(_SURFACE_EPS_MM),
+                    repr(remaining),
                 ],
                 capture_output=True,
                 text=True,
@@ -122,17 +123,20 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
         },
         "surface_deviation": surface,
         "max_deviation": surface.get("max_deviation"),
+        "magnitude_method": surface.get("magnitude_method"),
         "changed": surface.get("changed"),
         "regions": surface.get("regions"),
         "unchanged_elsewhere": surface.get("unchanged_elsewhere"),
         "warnings": surface.get("warnings"),
         "note": (
-            "Surface deviation compares object_a to object_b, not to a reference answer. "
-            "For editing, verify that the localized changed region(s) match the requested "
-            "feature and magnitude; do not minimise max_deviation as a score. IMPORTANT: a "
-            "TANGENTIAL feature move (e.g. sliding a hole sideways) produces ~zero surface "
-            "deviation and reads as no change here — for move/relocation edits confirm with "
-            "the volume/bbox/center deltas above and feature positions (find_holes), not this."
+            "Compares object_a to object_b, not to a reference answer. max_deviation is the "
+            "EXACT surface displacement (boolean-measured) when magnitude_method='exact_boolean'; "
+            "changed.added_volume/removed_volume give the exact material added/removed. For editing, "
+            "verify the changed region(s), displacement, and add/remove volumes match the request. "
+            "IMPORTANT: a TANGENTIAL feature move (sliding a hole) and a sub-resolution edit on a very "
+            "large part produce no detected region — 'unchanged' then means 'no change above the "
+            "detection floor', NOT a guarantee; cross-check the volume/bbox/center deltas and "
+            "find_holes for those."
         ),
     }
 

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -27,7 +27,9 @@ def _read_json(path):
 def _surface_compare_in_process(sa, sb, deadline=None) -> dict:
     from build123d_mcp._shape_compare_subprocess import compare_shapes
 
-    return compare_shapes(sa, sb, _SURFACE_EPS_MM, deadline=deadline)
+    # In-process (host blocks subprocesses) there is NO op-timeout to kill a runaway
+    # boolean, so never run it here — mesh estimate only (allow_exact=False).
+    return compare_shapes(sa, sb, _SURFACE_EPS_MM, deadline=deadline, allow_exact=False)
 
 
 def _surface_compare_bounded(session, sa, sb) -> dict:

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -10,7 +10,10 @@ from build123d_mcp.tools.measure import _center_of_mass
 
 _COMPARE_MARGIN_S = 15
 _COMPARE_MIN_S = 10
-_SURFACE_EPS_MM = 0.01
+# 0 => the worker auto-scales the move threshold to the mesh deflection. A fixed mm
+# eps is unsafe: it sits below the independent-tessellation noise floor on large
+# parts and fabricates changed regions on unchanged geometry.
+_SURFACE_EPS_MM = 0.0
 
 
 def _surface_compare_in_process(sa, sb) -> dict:
@@ -120,11 +123,16 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
         "surface_deviation": surface,
         "max_deviation": surface.get("max_deviation"),
         "changed": surface.get("changed"),
+        "regions": surface.get("regions"),
         "unchanged_elsewhere": surface.get("unchanged_elsewhere"),
+        "warnings": surface.get("warnings"),
         "note": (
             "Surface deviation compares object_a to object_b, not to a reference answer. "
-            "For editing, verify that the localized changed region matches the requested "
-            "feature and magnitude; do not minimise max_deviation as a score."
+            "For editing, verify that the localized changed region(s) match the requested "
+            "feature and magnitude; do not minimise max_deviation as a score. IMPORTANT: a "
+            "TANGENTIAL feature move (e.g. sliding a hole sideways) produces ~zero surface "
+            "deviation and reads as no change here — for move/relocation edits confirm with "
+            "the volume/bbox/center deltas above and feature positions (find_holes), not this."
         ),
     }
 

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -16,10 +16,18 @@ _COMPARE_MIN_S = 10
 _SURFACE_EPS_MM = 0.0
 
 
-def _surface_compare_in_process(sa, sb) -> dict:
+def _read_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _surface_compare_in_process(sa, sb, deadline=None) -> dict:
     from build123d_mcp._shape_compare_subprocess import compare_shapes
 
-    return compare_shapes(sa, sb, _SURFACE_EPS_MM)
+    return compare_shapes(sa, sb, _SURFACE_EPS_MM, deadline=deadline)
 
 
 def _surface_compare_bounded(session, sa, sb) -> dict:
@@ -64,6 +72,16 @@ def _surface_compare_bounded(session, sa, sb) -> dict:
                 timeout=remaining,
             )
         except subprocess.TimeoutExpired:
+            # The worker persists the mesh-estimate result BEFORE the exact boolean, so
+            # if the boolean overran and got killed, salvage that flagged result rather
+            # than discard the whole comparison.
+            salvaged = _read_json(out_json)
+            if salvaged is not None and "region_count" in salvaged:
+                salvaged.setdefault("warnings", []).append(
+                    "exact boolean magnitude timed out and was stopped; the surface result above is "
+                    "the mesh estimate — use the volume/bbox deltas for magnitude."
+                )
+                return salvaged
             return {
                 "error": (
                     "surface comparison exceeded the time budget -- the parts are too "
@@ -73,8 +91,9 @@ def _surface_compare_bounded(session, sa, sb) -> dict:
             }
         except OSError:
             # Host blocks child-process creation (#143 / InProcessSession): run
-            # in-process because there is no worker op-timeout to protect there.
-            return _surface_compare_in_process(sa, sb)
+            # in-process. There is no worker op-timeout there, so pass a soft deadline
+            # so the worker self-skips the exact boolean if it would run long.
+            return _surface_compare_in_process(sa, sb, deadline=t0 + remaining)
 
         if proc.returncode != 0 or not os.path.exists(out_json):
             return {"error": "surface comparison subprocess failed: " + (proc.stderr or "")[-300:]}

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -28,8 +28,14 @@ def _surface_compare_in_process(sa, sb, deadline=None) -> dict:
     from build123d_mcp._shape_compare_subprocess import compare_shapes
 
     # In-process (host blocks subprocesses) there is NO op-timeout to kill a runaway
-    # boolean, so never run it here — mesh estimate only (allow_exact=False).
-    return compare_shapes(sa, sb, _SURFACE_EPS_MM, deadline=deadline, allow_exact=False)
+    # boolean, so never run it here — mesh estimate only (allow_exact=False). Mirror
+    # the subprocess worker's structured-error boundary: an un-tessellatable shape
+    # (e.g. the build123d-0.11 'NbNodes' quirk) must return a JSON error, not raise
+    # out of shape_compare().
+    try:
+        return compare_shapes(sa, sb, _SURFACE_EPS_MM, deadline=deadline, allow_exact=False)
+    except Exception as exc:  # noqa: BLE001 - convert in-process failures to structured JSON
+        return {"error": f"{type(exc).__name__}: {exc}", "warnings": []}
 
 
 def _surface_compare_bounded(session, sa, sb) -> dict:

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -150,14 +150,17 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
         "unchanged_elsewhere": surface.get("unchanged_elsewhere"),
         "warnings": surface.get("warnings"),
         "note": (
-            "Compares object_a to object_b, not to a reference answer. max_deviation is the "
-            "EXACT surface displacement (boolean-measured) when magnitude_method='exact_boolean'; "
-            "changed.added_volume/removed_volume give the exact material added/removed. For editing, "
-            "verify the changed region(s), displacement, and add/remove volumes match the request. "
-            "IMPORTANT: a TANGENTIAL feature move (sliding a hole) and a sub-resolution edit on a very "
-            "large part produce no detected region — 'unchanged' then means 'no change above the "
-            "detection floor', NOT a guarantee; cross-check the volume/bbox/center deltas and "
-            "find_holes for those."
+            "Compares object_a to object_b, not to a reference answer. magnitude_method tells you "
+            "how to read max_deviation: 'exact_boolean' = exact surface displacement AND exact "
+            "volumes; 'exact_volume_mesh_displacement' = exact added/removed VOLUME but max_deviation "
+            "is a mesh estimate (a cut/flush-fill has ~0 true surface displacement, so volume is the "
+            "real magnitude); 'mesh_estimate' = both are mesh estimates (boolean skipped or failed). "
+            "changed.added_volume/removed_volume are the exact material added/removed whenever the "
+            "method starts with 'exact_'. For editing, verify the changed region(s) and the add/remove "
+            "volumes match the request. IMPORTANT: a TANGENTIAL move (sliding a hole) and a sub-"
+            "resolution edit on a very large part produce no detected region — 'unchanged' then means "
+            "'no change above the detection floor', NOT a guarantee; cross-check the volume/bbox/"
+            "center deltas and find_holes for those."
         ),
     }
 

--- a/src/build123d_mcp/tools/shape_compare.py
+++ b/src/build123d_mcp/tools/shape_compare.py
@@ -1,7 +1,94 @@
 import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
 
 from build123d_mcp.tools.diff import _shape_diag
 from build123d_mcp.tools.measure import _center_of_mass
+
+_COMPARE_MARGIN_S = 15
+_COMPARE_MIN_S = 10
+_SURFACE_EPS_MM = 0.01
+
+
+def _surface_compare_in_process(sa, sb) -> dict:
+    from build123d_mcp._shape_compare_subprocess import compare_shapes
+
+    return compare_shapes(sa, sb, _SURFACE_EPS_MM)
+
+
+def _surface_compare_bounded(session, sa, sb) -> dict:
+    from build123d_mcp.tools.export import _write_step
+
+    t0 = time.monotonic()
+    work = tempfile.mkdtemp(prefix="b123d_compare_")
+    a_step = os.path.join(work, "a.step")
+    b_step = os.path.join(work, "b.step")
+    out_json = os.path.join(work, "surface.json")
+    try:
+        try:
+            _write_step(sa, a_step)
+            _write_step(sb, b_step)
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"could not serialise shapes for surface comparison: {exc}"}
+
+        budget = max(60, getattr(session, "exec_timeout", 120))
+        remaining = budget - (time.monotonic() - t0) - _COMPARE_MARGIN_S
+        if remaining < _COMPARE_MIN_S:
+            return {
+                "error": (
+                    "not enough of the op budget left to surface-compare safely; "
+                    "retry on a fresh op."
+                )
+            }
+
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "build123d_mcp._shape_compare_subprocess",
+                    a_step,
+                    b_step,
+                    out_json,
+                    repr(_SURFACE_EPS_MM),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=remaining,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "error": (
+                    "surface comparison exceeded the time budget -- the parts are too "
+                    "large/complex to tessellate in budget; use volume/bbox deltas and "
+                    "targeted measure()/render_view() checks."
+                )
+            }
+        except OSError:
+            # Host blocks child-process creation (#143 / InProcessSession): run
+            # in-process because there is no worker op-timeout to protect there.
+            return _surface_compare_in_process(sa, sb)
+
+        if proc.returncode != 0 or not os.path.exists(out_json):
+            return {"error": "surface comparison subprocess failed: " + (proc.stderr or "")[-300:]}
+        try:
+            with open(out_json) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            return {"error": f"surface comparison produced an unreadable result: {exc}"}
+    finally:
+        for p in (a_step, b_step, out_json):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+        try:
+            os.rmdir(work)
+        except OSError:
+            pass
 
 
 def shape_compare(session, object_a: str, object_b: str) -> str:
@@ -17,19 +104,28 @@ def shape_compare(session, object_a: str, object_b: str) -> str:
     offset = round(
         ((cb["x"] - ca["x"]) ** 2 + (cb["y"] - ca["y"]) ** 2 + (cb["z"] - ca["z"]) ** 2) ** 0.5, 4
     )
+    surface = _surface_compare_bounded(session, sa, sb)
 
-    return json.dumps(
-        {
-            "a": {"name": object_a, **da, "center": ca},
-            "b": {"name": object_b, **db, "center": cb},
-            "delta": {
-                "volume": round(db["volume"] - da["volume"], 4),
-                "faces": db["faces"] - da["faces"],
-                "edges": db["edges"] - da["edges"],
-                "vertices": db["vertices"] - da["vertices"],
-                "bbox": [round(db["bbox"][i] - da["bbox"][i], 4) for i in range(3)],
-                "center_offset": offset,
-            },
+    payload = {
+        "a": {"name": object_a, **da, "center": ca},
+        "b": {"name": object_b, **db, "center": cb},
+        "delta": {
+            "volume": round(db["volume"] - da["volume"], 4),
+            "faces": db["faces"] - da["faces"],
+            "edges": db["edges"] - da["edges"],
+            "vertices": db["vertices"] - da["vertices"],
+            "bbox": [round(db["bbox"][i] - da["bbox"][i], 4) for i in range(3)],
+            "center_offset": offset,
         },
-        indent=2,
-    )
+        "surface_deviation": surface,
+        "max_deviation": surface.get("max_deviation"),
+        "changed": surface.get("changed"),
+        "unchanged_elsewhere": surface.get("unchanged_elsewhere"),
+        "note": (
+            "Surface deviation compares object_a to object_b, not to a reference answer. "
+            "For editing, verify that the localized changed region matches the requested "
+            "feature and magnitude; do not minimise max_deviation as a score."
+        ),
+    }
+
+    return json.dumps(payload, indent=2)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -605,7 +605,7 @@ class WorkerSession:
     def last_error(self) -> str:
         raise NotImplementedError
 
-    @_op(_tool(f"{_T}.shape_compare:shape_compare"), _GEOMETRY_TIMEOUT)
+    @_op(_tool(f"{_T}.shape_compare:shape_compare"), _export_budget)
     def shape_compare(self, object_a: str, object_b: str) -> str:
         raise NotImplementedError
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -729,6 +729,31 @@ def test_shape_compare_falls_back_in_process_when_subprocess_blocked(session, mo
     assert "error" not in data["surface_deviation"]
 
 
+def test_shape_compare_in_process_tessellation_failure_is_clean_error(session, monkeypatch):
+    """On a subprocess-blocked host, an un-tessellatable shape (the build123d-0.11
+    'NbNodes' quirk) must return a structured JSON error, not raise out of the tool."""
+    import subprocess
+
+    import build123d_mcp._shape_compare_subprocess as scs
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10) + Pos(0,0,6)*Box(4,4,4), 'b')"
+    )
+
+    def _blocked(*a, **k):
+        raise PermissionError("child process creation not permitted")
+
+    def _boom(*a, **k):
+        raise AttributeError("'NoneType' object has no attribute 'NbNodes'")
+
+    monkeypatch.setattr(subprocess, "run", _blocked)
+    monkeypatch.setattr(scs, "_tessellate_points", _boom)
+    data = json.loads(shape_compare(session, "a", "b"))  # must NOT raise
+    assert "error" in data["surface_deviation"]
+    assert "NbNodes" in data["surface_deviation"]["error"]
+
+
 def test_shape_compare_timeout_is_clean_error(session, monkeypatch):
     import subprocess
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -527,10 +527,31 @@ def test_shape_compare_reports_local_surface_deviation(session):
         "show(base + Pos(6, 0, 7) * Box(8, 8, 8), 'b')",
     )
     data = json.loads(shape_compare(session, "a", "b"))
+    # Exact boolean magnitude: the boss slid 6mm, so displacement ~6mm, and equal
+    # material is added (new position) and removed (old position).
+    assert data["magnitude_method"] == "exact_boolean"
     assert data["max_deviation"] == pytest.approx(6.0, abs=0.35)
-    assert data["changed"]["moved_fraction"] > 0
+    assert data["changed"]["added_volume"] > 0 and data["changed"]["removed_volume"] > 0
     assert data["changed"]["bbox"] is not None
     assert data["unchanged_elsewhere"] is True
+
+
+def test_shape_compare_exact_magnitude_growth(session):
+    """A pure boss-height increase: exact boolean reports material ADDED, none removed,
+    and the displacement equals the height change — not the inflated vertex-NN distance."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 6)\n"
+        "show(base + Pos(0, 0, 7) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(0, 0, 8) * Box(8, 8, 10), 'b')",  # top 11 -> 13 mm: +2 mm
+    )
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["magnitude_method"] == "exact_boolean"
+    assert data["max_deviation"] == pytest.approx(2.0, abs=0.2)
+    assert data["changed"]["added_volume"] == pytest.approx(128.0, rel=0.1)  # 8*8*2
+    assert data["changed"]["removed_volume"] == 0.0  # pure growth, nothing removed
 
 
 def test_shape_compare_flags_change_elsewhere(session):
@@ -544,8 +565,9 @@ def test_shape_compare_flags_change_elsewhere(session):
         "show(base + Pos(25, 0, 7) * Box(6, 6, 8), 'b')",
     )
     data = json.loads(shape_compare(session, "a", "b"))
-    assert data["max_deviation"] > 10
+    # Two separate bosses removed/added -> regions span the part -> not localized.
     assert data["unchanged_elsewhere"] is False
+    assert data["changed"]["added_volume"] > 0 and data["changed"]["removed_volume"] > 0
 
 
 def test_shape_compare_reexport_noop_is_clean(session, tmp_path):

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -584,6 +584,10 @@ def test_shape_compare_exact_magnitude_removal(session):
     assert data["magnitude_method"] == "exact_boolean"
     assert data["changed"]["removed_volume"] == pytest.approx(502.65, rel=0.1)  # pi*16*10
     assert data["changed"]["added_volume"] == 0.0
+    # A cut has ~0 surface displacement, but max_deviation must NOT read 0 ("no change")
+    # — it falls back to the mesh estimate, with a warning that volume is the exact amount.
+    assert data["max_deviation"] > 0.0
+    assert any("cut or flush fill" in w for w in data["warnings"])
 
 
 def test_shape_compare_budget_skip_falls_back_to_mesh(session):

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -511,6 +511,74 @@ def test_shape_compare_identical_shapes_zero_delta(session):
     data = json.loads(shape_compare(session, "a", "b"))
     assert abs(data["delta"]["volume"]) < 0.001
     assert data["delta"]["center_offset"] < 0.001
+    assert data["max_deviation"] < 0.001
+    assert data["changed"]["moved_fraction"] == 0.0
+    assert data["unchanged_elsewhere"] is True
+
+
+def test_shape_compare_reports_local_surface_deviation(session):
+    """A local boss translation reports a non-zero localized surface deviation."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 6)\n"
+        "show(base + Pos(0, 0, 7) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(6, 0, 7) * Box(8, 8, 8), 'b')",
+    )
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["max_deviation"] == pytest.approx(6.0, abs=0.35)
+    assert data["changed"]["moved_fraction"] > 0
+    assert data["changed"]["bbox"] is not None
+    assert data["unchanged_elsewhere"] is True
+
+
+def test_shape_compare_flags_change_elsewhere(session):
+    """Two distant edits should not be reported as one clean localized change."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session,
+        "base = Box(80, 20, 6)\n"
+        "show(base + Pos(-25, 0, 7) * Box(6, 6, 8), 'a')\n"
+        "show(base + Pos(25, 0, 7) * Box(6, 6, 8), 'b')",
+    )
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["max_deviation"] > 10
+    assert data["unchanged_elsewhere"] is False
+
+
+def test_shape_compare_falls_back_in_process_when_subprocess_blocked(session, monkeypatch):
+    """If child process creation is blocked, surface compare still runs in-process."""
+    import subprocess
+
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(10,10,10), 'b')")
+
+    def _blocked(*a, **k):
+        raise PermissionError("child process creation not permitted")
+
+    monkeypatch.setattr(subprocess, "run", _blocked)
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["max_deviation"] < 0.001
+    assert "error" not in data["surface_deviation"]
+
+
+def test_shape_compare_timeout_is_clean_error(session, monkeypatch):
+    import subprocess
+
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(session, "show(Box(10,10,10), 'a')\nshow(Box(20,20,20), 'b')")
+
+    def _timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="shape_compare", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert "time budget" in data["surface_deviation"]["error"]
+    assert data["delta"]["volume"] > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -548,6 +548,29 @@ def test_shape_compare_flags_change_elsewhere(session):
     assert data["unchanged_elsewhere"] is False
 
 
+def test_shape_compare_reexport_noop_is_clean(session, tmp_path):
+    """A shape vs a STEP round-trip of ITSELF — same geometry, INDEPENDENTLY
+    re-tessellated — must report NO change. This guards the eps-vs-tessellation-
+    noise regression: a fixed-mm eps sat below the noise floor and fabricated a
+    multi-mm 'change' on identical geometry. Curved geometry (a cylinder wall) is
+    used so the two tessellations genuinely differ, unlike two identical Box()es."""
+    import os
+
+    from build123d_mcp.tools.export import _write_step
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(session, "show(Cylinder(20, 30) + Box(70, 14, 30), 'orig')")
+    rt = os.path.join(tmp_path, "roundtrip.step")
+    _write_step(session.objects["orig"], rt)
+    execute_code(session, f"show(import_step({rt!r}), 'rt')")
+
+    data = json.loads(shape_compare(session, "orig", "rt"))
+    # No REAL change: region-filtered max_deviation ~0, no localized region, clean.
+    assert data["max_deviation"] < 1.0
+    assert data["changed"]["moved_fraction"] == 0.0
+    assert data["unchanged_elsewhere"] is True
+
+
 def test_shape_compare_falls_back_in_process_when_subprocess_blocked(session, monkeypatch):
     """If child process creation is blocked, surface compare still runs in-process."""
     import subprocess

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -570,6 +570,55 @@ def test_shape_compare_flags_change_elsewhere(session):
     assert data["changed"]["added_volume"] > 0 and data["changed"]["removed_volume"] > 0
 
 
+def test_shape_compare_exact_magnitude_removal(session):
+    """Drilling a hole reports material REMOVED, none added (exact boolean, right sign)."""
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 10)\n"
+        "show(base, 'a')\n"
+        "show(base - Cylinder(4, 10), 'b')",  # Ø8 through-hole removed
+    )
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["magnitude_method"] == "exact_boolean"
+    assert data["changed"]["removed_volume"] == pytest.approx(502.65, rel=0.1)  # pi*16*10
+    assert data["changed"]["added_volume"] == 0.0
+
+
+def test_shape_compare_budget_skip_falls_back_to_mesh(session):
+    """With no op budget left, the exact boolean is skipped for the flagged mesh estimate."""
+    import time
+
+    from build123d_mcp._shape_compare_subprocess import compare_shapes
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 6)\n"
+        "show(base + Pos(0, 0, 7) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(0, 0, 8) * Box(8, 8, 10), 'b')",
+    )
+    r = compare_shapes(session.objects["a"], session.objects["b"], deadline=time.monotonic())
+    assert r["magnitude_method"] == "mesh_estimate"
+    assert any("skipped" in w for w in r["warnings"])
+
+
+def test_shape_compare_skips_boolean_on_large_spread_edit(session):
+    """A spread edit on a LARGE part skips the exact boolean (its clip would span the
+    part and overrun the budget) and returns the flagged mesh estimate."""
+    from build123d_mcp._shape_compare_subprocess import compare_shapes
+
+    execute_code(
+        session,
+        "base = Box(400, 40, 8)\n"
+        "show(base + Pos(-180, 0, 9) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(180, 0, 9) * Box(8, 8, 8), 'b')",
+    )
+    r = compare_shapes(session.objects["a"], session.objects["b"])
+    assert r["magnitude_method"] == "mesh_estimate"
+    assert any("spread region" in w for w in r["warnings"])
+
+
 def test_shape_compare_reexport_noop_is_clean(session, tmp_path):
     """A shape vs a STEP round-trip of ITSELF — same geometry, INDEPENDENTLY
     re-tessellated — must report NO change. This guards the eps-vs-tessellation-

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -581,11 +581,12 @@ def test_shape_compare_exact_magnitude_removal(session):
         "show(base - Cylinder(4, 10), 'b')",  # Ø8 through-hole removed
     )
     data = json.loads(shape_compare(session, "a", "b"))
-    assert data["magnitude_method"] == "exact_boolean"
+    # Volumes are exact; the displacement is a mesh estimate (a cut has ~0 true surface
+    # displacement) — the METHOD must say so, not claim 'exact_boolean'.
+    assert data["magnitude_method"] == "exact_volume_mesh_displacement"
     assert data["changed"]["removed_volume"] == pytest.approx(502.65, rel=0.1)  # pi*16*10
     assert data["changed"]["added_volume"] == 0.0
-    # A cut has ~0 surface displacement, but max_deviation must NOT read 0 ("no change")
-    # — it falls back to the mesh estimate, with a warning that volume is the exact amount.
+    # max_deviation must NOT read 0 ("no change") for a real removal.
     assert data["max_deviation"] > 0.0
     assert any("cut or flush fill" in w for w in data["warnings"])
 

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -603,20 +603,85 @@ def test_shape_compare_budget_skip_falls_back_to_mesh(session):
     assert any("skipped" in w for w in r["warnings"])
 
 
-def test_shape_compare_skips_boolean_on_large_spread_edit(session):
-    """A spread edit on a LARGE part skips the exact boolean (its clip would span the
-    part and overrun the budget) and returns the flagged mesh estimate."""
+def test_shape_compare_skips_boolean_on_wide_clip(session):
+    """A wide-clip (spread) edit skips the exact boolean because the boolean cost
+    scales with ABSOLUTE clip size — gated even on a sub-300mm part (the 206-class
+    that a part-size floor wrongly let run 360s)."""
     from build123d_mcp._shape_compare_subprocess import compare_shapes
 
     execute_code(
         session,
-        "base = Box(400, 40, 8)\n"
-        "show(base + Pos(-180, 0, 9) * Box(8, 8, 8), 'a')\n"
-        "show(base + Pos(180, 0, 9) * Box(8, 8, 8), 'b')",
+        "base = Box(250, 40, 8)\n"  # diag ~253mm (<300) but the two changes are ~200mm apart
+        "show(base + Pos(-100, 0, 9) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(100, 0, 9) * Box(8, 8, 8), 'b')",
     )
     r = compare_shapes(session.objects["a"], session.objects["b"])
     assert r["magnitude_method"] == "mesh_estimate"
     assert any("spread region" in w for w in r["warnings"])
+
+
+def test_shape_compare_in_process_never_runs_boolean(session):
+    """The in-process path (subprocess-blocked host) has no op-timeout to bound a
+    runaway boolean, so it must run mesh-only (allow_exact=False)."""
+    from build123d_mcp._shape_compare_subprocess import compare_shapes
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 6)\n"
+        "show(base + Pos(0, 0, 7) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(0, 0, 8) * Box(8, 8, 10), 'b')",  # a real localized edit
+    )
+    r = compare_shapes(session.objects["a"], session.objects["b"], allow_exact=False)
+    assert r["magnitude_method"] == "mesh_estimate"
+    assert any("in-process" in w for w in r["warnings"])
+
+
+def test_shape_compare_exception_after_boolean_keeps_mesh_estimate(session, monkeypatch):
+    """If a post-boolean step raises, the comparison must fall back to the mesh
+    estimate (the salvage), not crash — a raise must not lose what a timeout keeps."""
+    import build123d_mcp._shape_compare_subprocess as scs
+    from build123d_mcp._shape_compare_subprocess import compare_shapes
+
+    execute_code(
+        session,
+        "base = Box(60, 30, 6)\n"
+        "show(base + Pos(0, 0, 7) * Box(8, 8, 8), 'a')\n"
+        "show(base + Pos(0, 0, 8) * Box(8, 8, 10), 'b')",
+    )
+
+    def _boom(*a, **k):
+        raise RuntimeError("displacement blew up")
+
+    monkeypatch.setattr(scs, "_chunk_displacement", _boom)
+    r = compare_shapes(session.objects["a"], session.objects["b"])
+    assert r["magnitude_method"] == "mesh_estimate"  # not an error, not a crash
+    assert r["region_count"] > 0
+
+
+def test_shape_compare_salvages_mesh_result_on_subprocess_timeout(session, monkeypatch, tmp_path):
+    """If the boolean overruns and the subprocess is hard-killed, the driver returns
+    the mesh-estimate result the worker persisted before the boolean — not a bare error."""
+    import subprocess
+
+    from build123d_mcp.tools.shape_compare import shape_compare
+
+    execute_code(
+        session, "show(Box(20, 10, 10), 'a')\nshow(Box(20, 10, 10) + Pos(0,0,6)*Box(4,4,4), 'b')"
+    )
+
+    def _kill(cmd, *a, **k):
+        # cmd[5] is the out_json path; the worker would have persisted the mesh result
+        # there before the boolean. Simulate that, then act like a hard timeout kill.
+        with open(cmd[5], "w") as f:
+            json.dump(
+                {"max_deviation": 4.0, "magnitude_method": "mesh_estimate", "region_count": 1}, f
+            )
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _kill)
+    data = json.loads(shape_compare(session, "a", "b"))
+    assert data["surface_deviation"]["magnitude_method"] == "mesh_estimate"
+    assert any("timed out" in w for w in data["surface_deviation"]["warnings"])
 
 
 def test_shape_compare_reexport_noop_is_clean(session, tmp_path):

--- a/tests/test_worker_timeouts.py
+++ b/tests/test_worker_timeouts.py
@@ -45,7 +45,6 @@ def test_geometry_heavy_ops_use_geometry_timeout():
     ws.measure("a")
     ws.clearance("a", "b")
     ws.cross_sections("a")
-    ws.shape_compare("a", "b")
     ws.align_check("a", "b")
     ws.analyze_printability("a")
     ws.save_snapshot("s")
@@ -88,6 +87,23 @@ def test_load_part_keeps_geometry_floor():
     ws = _proxy_session(record, exec_timeout=10)
     ws.load_part("worm_gear")
     assert record == [("load_part", _GEOMETRY_TIMEOUT)]
+
+
+def test_shape_compare_honours_exec_timeout():
+    # shape_compare bounds its own tessellation/boolean subprocess by the op budget
+    # (max(60, exec_timeout) - margin), so the worker op MUST give it that budget or
+    # the parent would kill the worker while the child still runs.
+    record = []
+    ws = _proxy_session(record, exec_timeout=300)
+    ws.shape_compare("a", "b")
+    assert record == [("shape_compare", 300)]
+
+
+def test_shape_compare_keeps_export_floor():
+    record = []
+    ws = _proxy_session(record, exec_timeout=10)
+    ws.shape_compare("a", "b")
+    assert record == [("shape_compare", _EXPORT_TIMEOUT)]
 
 
 def test_bookkeeping_ops_keep_short_timeout():

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "mcp" },
     { name = "resvg-py" },
+    { name = "scipy" },
     { name = "vtk" },
 ]
 
@@ -155,6 +156,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "mcp", specifier = ">=1.9" },
     { name = "resvg-py" },
+    { name = "scipy" },
     { name = "uvicorn", marker = "extra == 'http'" },
     { name = "vtk", specifier = ">=9.3" },
 ]


### PR DESCRIPTION
## Summary

- Adds bounded localized surface-deviation output to `shape_compare` while preserving the existing volume, bbox, topology, and center delta fields.
- Runs tessellation and nearest-neighbour surface comparison in a hard-bounded subprocess, with in-process fallback when child process creation is blocked.
- Adds explicit `scipy` runtime dependency for `cKDTree` use.
- Updates the MCP tool description to frame this as model-vs-input edit verification, not a score.
- Adds outcome tests for no-op comparisons, localized edits, unrelated-region changes, subprocess fallback, and timeout handling.

## Validation

- `uv run pytest tests/test_outcomes.py -q` -> 60 passed
- `uv run pytest tests/test_worker_timeouts.py tests/test_render_tessellation_bounded.py tests/test_locate.py -q` -> 23 passed
- `uv run ruff check src/build123d_mcp/_shape_compare_subprocess.py src/build123d_mcp/tools/shape_compare.py src/build123d_mcp/server.py tests/test_outcomes.py`
- `uv run ruff format --check src/build123d_mcp/_shape_compare_subprocess.py src/build123d_mcp/tools/shape_compare.py src/build123d_mcp/server.py tests/test_outcomes.py`