### PR TITLE
Add an opt-in live session viewer over a Unix domain socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.60
+
+### Added
+
+- **Live session viewer over a Unix domain socket (`--viewer-socket PATH`).** Optionally stream the session's geometry to an interactive 3D viewer so a human can watch and rotate the model while an agent drives the MCP, instead of only seeing fixed-viewpoint `render_view` PNGs. When the flag (or `BUILD123D_VIEWER_SOCKET`) is set, the server binds a UDS and, after each geometry-mutating tool (`execute`, `reset`, `restore_snapshot`, `import_cad_file`, `load_part`), broadcasts the **changed** shapes as glTF-binary (glb) to connected viewer clients. The publisher runs on a background daemon thread in the server process and never blocks the agent path: it pays nothing while no viewer is attached (no tessellation, no worker round-trip), tessellates only identity-changed shapes via the existing hard-bounded out-of-process path, and a slow client is throttled (bounded per-client buffers, drop-oldest) rather than the producer. A viewer attaching mid-session gets `HELLO` + a full-scene dump; a worker restart emits `RESET`. The glb encoder is a small self-contained glTF 2.0 writer, so there is **no new dependency** and no OCC/VTK in the encode step. The socket is created mode 0600 and lives outside the sandboxed `execute()` worker. Wire protocol, usage, and a dependency-free reference consumer (`examples/live_viewer_client.py`) are documented in `docs/live-viewer.md`. POSIX only.
+
 ## v0.3.59
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -320,6 +320,21 @@ Clients connect to `http://<host>:8000/mcp`.
 
 > **Security note.** The server has no built-in authentication. When binding to `0.0.0.0`, place it behind a reverse proxy with auth (e.g. nginx + mTLS, or a VPN).
 
+### Live session viewer (experimental)
+
+Start the server with `--viewer-socket PATH` (or `BUILD123D_VIEWER_SOCKET=PATH`) to
+stream the session's geometry to an interactive 3D viewer over a Unix domain socket,
+so a human can watch and rotate the model while an agent drives the tools. Each
+shape is broadcast as a glTF-binary (glb) and updated after every geometry-mutating
+tool call. The publisher runs on a background thread in the server process and does
+not stall the agent path; a pure agent run (no `--viewer-socket`) does no extra work.
+
+Two example consumers ship with it, neither a package dependency: an interactive
+pyvista window ([`examples/live_viewer_pyvista.py`](examples/live_viewer_pyvista.py),
+run via `uv run --with pyvista`) and a dependency-free text client
+([`examples/live_viewer_client.py`](examples/live_viewer_client.py)). The wire
+protocol and design are in [docs/live-viewer.md](docs/live-viewer.md). POSIX only.
+
 ---
 
 ## System prompt

--- a/docs/live-viewer.md
+++ b/docs/live-viewer.md
@@ -1,0 +1,98 @@
+# Live session viewer
+
+Stream the build123d session's geometry to an interactive 3D viewer over a Unix
+domain socket (UDS), so a human can watch and rotate the model while an agent
+drives the MCP server. The agent keeps getting its fixed-viewpoint `render_view`
+PNGs; the human gets a live view that updates as the session changes.
+
+This page documents the **server-side publisher** (the UDS interface). A native
+viewer window is a separate, optional consumer. A minimal stdlib example ships in
+[`examples/live_viewer_client.py`](../examples/live_viewer_client.py), and a richer
+graphical viewer can be built on top of the same protocol.
+
+## Enabling it
+
+Start the server with a socket path:
+
+```bash
+build123d-mcp --viewer-socket /tmp/b123d.sock
+# or
+BUILD123D_VIEWER_SOCKET=/tmp/b123d.sock build123d-mcp
+```
+
+POSIX only (uses `AF_UNIX`). When the flag is absent the feature is fully inert
+and a pure agent run pays nothing. When the flag is set, the server keeps a
+current cache of the scene (tessellating changed shapes after each mutating
+tool), so a viewer attaching at any time, early or late, gets a correct
+full-scene dump; broadcasting to zero clients is a no-op.
+
+Try it with the bundled example consumer:
+
+```bash
+python examples/live_viewer_client.py /tmp/b123d.sock
+# add --save-dir DIR to also write each shape's glb to disk
+```
+
+## How it works
+
+- The publisher runs in the **server** process on a background daemon thread. It
+  never blocks the agent: broadcasts append to bounded per-client buffers, and a
+  slow client has its oldest frames dropped rather than stalling the producer.
+- After each geometry-mutating tool (`execute`, `reset`, `restore_snapshot`,
+  `import_cad_file`, `load_part`), the server asks the worker for **per-shape
+  deltas**. Only the shapes whose identity changed are tessellated, via the same
+  bounded, hard-killable out-of-process path `render_view` uses, and encoded to
+  glTF-binary (glb) with a small self-contained writer (no extra dependency, no
+  OCC/VTK in the encode step).
+- A viewer that connects mid-session receives `HELLO` followed by an `UPSERT` for
+  every shape currently in the scene, so a late attach is correct.
+- If the worker is restarted (e.g. after an `execute` timeout), the publisher
+  emits `RESET` so clients clear their now-stale scene.
+- While a viewer is configured, the server keeps one encoded glb per named shape
+  (the cache that serves the on-connect dump), so the scene's geometry is held
+  twice: as OCC geometry in the worker and as glb bytes in the server. For
+  typical CAD parts this is negligible.
+
+Updates are per-tool-call, not per-`show()`: the viewer reflects the session state
+after each MCP call, which is the granularity a human reviewer watches at.
+
+## Wire protocol
+
+Length-prefixed frames:
+
+```
+[u32 BE json_len][json header (utf-8)][u32 BE bin_len][binary payload]
+```
+
+The JSON header is `{type, session_id, seq, name?, units:"mm"}`, where `seq` is
+monotonic per publisher. Event types:
+
+| type     | payload      | meaning                                              |
+|----------|--------------|------------------------------------------------------|
+| `HELLO`  | none         | sent first on connect; carries `session_id`          |
+| `UPSERT` | binary glb   | add or replace the named shape with this mesh        |
+| `REMOVE` | none         | remove the named shape from the scene                |
+| `RESET`  | none         | clear the whole scene (worker restarted / `reset()`) |
+
+The `UPSERT` payload is a standard binary glTF (glb) of a single shape, readable
+by three.js' `GLTFLoader`, `trimesh`, `pyvista`, Blender, etc. Vertices are in
+world-space millimetres.
+
+A minimal client reads a frame as: read 4 bytes → `json_len`; read `json_len`
+bytes → header; read 4 bytes → `bin_len`; read `bin_len` bytes → payload. See
+`examples/live_viewer_client.py` for a complete, dependency-free reader.
+
+## Scope and limitations
+
+- POSIX only (AF_UNIX). A remote or headless host would need a UDS to WebSocket
+  or TCP bridge, which is not included here.
+- Per-shape deltas are detected by object identity. A shape mutated in place
+  without re-registering it via `show()` keeps its identity and is not re-sent
+  until the next `show()` rebinds the name (the established "re-show after edit"
+  convention).
+- The socket is created with mode 0600, so only the server's user can connect.
+  The publisher also runs in the server process, outside the sandboxed
+  `execute()` worker, so under the default sandbox user code cannot reach the
+  socket. Starting the server with `--no-sandbox` or `--allow-all-imports` lifts
+  the import allowlist, so worker code could then connect like any local process.
+  The 0600 permission stays as the backstop.

--- a/examples/live_viewer_client.py
+++ b/examples/live_viewer_client.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Minimal, dependency-free consumer for the build123d-mcp live viewer socket.
+
+Connects to the Unix domain socket published by ``build123d-mcp --viewer-socket
+PATH`` and prints each scene event as it arrives. Optionally writes every shape's
+glTF-binary (glb) to a directory so you can open it in any 3D viewer.
+
+This is a reference consumer for the wire protocol (see docs/live-viewer.md). It
+uses only the Python standard library and renders nothing itself. A graphical
+viewer (pyvista, three.js in a browser, …) can be built on the same frames.
+
+Usage:
+    python examples/live_viewer_client.py /tmp/b123d.sock
+    python examples/live_viewer_client.py /tmp/b123d.sock --save-dir /tmp/scene
+"""
+
+import argparse
+import json
+import os
+import socket
+import struct
+import sys
+
+
+def _recv_exactly(sock: socket.socket, n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("server closed the connection")
+        buf += chunk
+    return bytes(buf)
+
+
+def read_frame(sock: socket.socket) -> tuple[dict, bytes]:
+    """Read one length-prefixed frame: returns (header dict, binary payload)."""
+    (json_len,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    header = json.loads(_recv_exactly(sock, json_len).decode("utf-8"))
+    (bin_len,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    payload = _recv_exactly(sock, bin_len) if bin_len else b""
+    return header, payload
+
+
+def _safe_filename(name: str) -> str | None:
+    """Return a safe ``<name>.glb`` basename, or None if it cannot be made safe.
+
+    Shape names come from the server (the agent's show() calls) and are not path
+    validated, so strip any directory part and reject empty/dot names before
+    using one as a path under --save-dir.
+    """
+    base = os.path.basename(name)
+    if not base or base in (".", ".."):
+        return None
+    return f"{base}.glb"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("socket_path", help="path to the viewer UDS")
+    parser.add_argument(
+        "--save-dir",
+        metavar="DIR",
+        default="",
+        help="if set, write each UPSERT's glb to DIR/<name>.glb",
+    )
+    args = parser.parse_args()
+
+    if args.save_dir:
+        os.makedirs(args.save_dir, exist_ok=True)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(args.socket_path)
+    except OSError as exc:
+        print(f"could not connect to {args.socket_path}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"connected to {args.socket_path}")
+    try:
+        while True:
+            header, payload = read_frame(sock)
+            etype = header.get("type")
+            seq = header.get("seq")
+            name = header.get("name", "")
+            if etype == "UPSERT":
+                print(f"[{seq}] UPSERT {name}  ({len(payload)} bytes glb)")
+                fname = _safe_filename(name) if args.save_dir else None
+                if fname:
+                    out = os.path.join(args.save_dir, fname)
+                    with open(out, "wb") as f:
+                        f.write(payload)
+                    print(f"        wrote {out}")
+            elif etype == "REMOVE":
+                print(f"[{seq}] REMOVE {name}")
+                fname = _safe_filename(name) if args.save_dir else None
+                if fname:
+                    try:
+                        os.unlink(os.path.join(args.save_dir, fname))
+                    except OSError:
+                        pass
+            elif etype == "RESET":
+                print(f"[{seq}] RESET: scene cleared")
+            elif etype == "HELLO":
+                print(f"[{seq}] HELLO session={header.get('session_id')}")
+            else:
+                print(f"[{seq}] {etype} {header}")
+    except (ConnectionError, KeyboardInterrupt) as exc:
+        print(f"disconnected: {exc}")
+        return 0
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/live_viewer_pyvista.py
+++ b/examples/live_viewer_pyvista.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Interactive pyvista window for the build123d-mcp live session socket.
+
+Connects to the Unix domain socket published by ``build123d-mcp --viewer-socket
+PATH`` and shows the session geometry in a rotatable 3D window that updates as the
+model changes. This is the reference graphical consumer for the protocol in
+docs/live-viewer.md; ``examples/live_viewer_client.py`` is its dependency-free,
+text-only sibling.
+
+It needs pyvista and trimesh, which are not build123d-mcp dependencies, so run it
+ad hoc with uv (``trimesh`` is already in the project environment; ``--with
+pyvista`` pulls in the GUI for this run only):
+
+    uv run --with pyvista python examples/live_viewer_pyvista.py /tmp/b123d.sock
+
+Design (see docs/live-viewer.md): a background reader thread parses the wire
+frames into events and pushes them onto a queue; the main thread owns all
+rendering, because VTK is not thread-safe. It drains the queue and applies
+UPSERT/REMOVE/RESET to named actors, coalescing a burst into a single render.
+"""
+
+import argparse
+import io
+import json
+import queue
+import socket
+import struct
+import sys
+import threading
+import time
+
+
+def _recv_exactly(sock: socket.socket, n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("server closed the connection")
+        buf += chunk
+    return bytes(buf)
+
+
+def read_frame(sock: socket.socket) -> tuple[dict, bytes]:
+    """Read one length-prefixed frame: returns (header dict, binary payload)."""
+    (json_len,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    header = json.loads(_recv_exactly(sock, json_len).decode("utf-8"))
+    (bin_len,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    payload = _recv_exactly(sock, bin_len) if bin_len else b""
+    return header, payload
+
+
+class FrameReader(threading.Thread):
+    """Daemon thread: connect, parse frames into event dicts, push onto a queue.
+
+    Display-free (no pyvista/VTK), so the reader never touches the render window.
+    An UPSERT's glb payload rides on the event under the ``glb`` key. Pushes
+    ``{"type": "_EOF"}`` when the connection closes, ``{"type": "_ERROR"}`` if it
+    cannot connect.
+    """
+
+    def __init__(self, sock_path: str, out: queue.Queue):
+        super().__init__(daemon=True)
+        self._sock_path = sock_path
+        self._out = out
+
+    def _connect(self) -> socket.socket:
+        # Wait for the server to appear rather than failing fast, so the viewer
+        # can be opened before the server is started. Close the window (or Ctrl-C)
+        # to quit while waiting.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        announced = False
+        while True:
+            try:
+                sock.connect(self._sock_path)
+                return sock
+            except (FileNotFoundError, ConnectionRefusedError):
+                if not announced:
+                    print(
+                        f"waiting for the server socket at {self._sock_path} ...",
+                        flush=True,
+                    )
+                    announced = True
+                time.sleep(0.2)
+
+    def run(self) -> None:
+        try:
+            sock = self._connect()
+        except OSError as exc:
+            self._out.put({"type": "_ERROR", "error": str(exc)})
+            return
+        with sock:
+            while True:
+                try:
+                    header, payload = read_frame(sock)
+                except (ConnectionError, OSError):
+                    break
+                event = dict(header)
+                if payload:
+                    event["glb"] = payload
+                self._out.put(event)
+        self._out.put({"type": "_EOF"})
+
+
+def glb_to_mesh(glb: bytes):
+    """Decode binary glb into a pyvista mesh. Call on the main thread only.
+
+    trimesh.load of a glb returns a Scene (a multi-geometry container), so it is
+    concatenated to a single mesh before wrapping into pyvista.
+    """
+    import pyvista as pv
+    import trimesh
+
+    loaded = trimesh.load(io.BytesIO(glb), file_type="glb")
+    geom = loaded.to_geometry() if isinstance(loaded, trimesh.Scene) else loaded
+    return pv.wrap(geom)
+
+
+_COLORS = ["tan", "steelblue", "lightgreen", "lightcoral", "plum", "khaki"]
+
+
+class PyvistaScene:
+    """Apply scene events to a pyvista Plotter. Main-thread only (VTK actors)."""
+
+    def __init__(self, plotter):
+        self._plotter = plotter
+        self._color_for: dict[str, str] = {}
+        self._framed = False  # fit the camera once, then leave it to the user
+
+    def clear(self) -> None:
+        self._plotter.clear_actors()
+        self._color_for.clear()
+        self._framed = False
+
+    def apply(self, event: dict) -> str:
+        etype = event.get("type")
+        if etype == "UPSERT":
+            name = event["name"]
+            color = self._color_for.setdefault(name, _COLORS[len(self._color_for) % len(_COLORS)])
+            mesh = glb_to_mesh(event["glb"])
+            # add_mesh(name=...) replaces the same-named actor in place.
+            self._plotter.add_mesh(mesh, name=name, color=color, show_edges=True)
+            if not self._framed:
+                self._plotter.view_isometric()
+                self._plotter.reset_camera()
+                self._framed = True
+        elif etype == "REMOVE":
+            self._plotter.remove_actor(event.get("name"))
+            self._color_for.pop(event.get("name"), None)
+        elif etype == "RESET":
+            self.clear()
+        return etype or "?"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("socket_path", help="path to the viewer UDS")
+    args = parser.parse_args()
+
+    import pyvista as pv
+
+    events: queue.Queue = queue.Queue()
+    FrameReader(args.socket_path, events).start()
+
+    plotter = pv.Plotter(window_size=(900, 700))
+    plotter.set_background("white")
+    plotter.add_text("build123d live viewer", font_size=10)
+    scene = PyvistaScene(plotter)
+    plotter.show(interactive_update=True, auto_close=False)
+    print(f"viewer ready for {args.socket_path}; close the window to quit.")
+
+    while True:
+        rendered = False
+        try:  # drain everything pending, then render once (coalesce bursts)
+            while True:
+                event = events.get_nowait()
+                etype = event.get("type")
+                if etype == "_ERROR":  # could not connect (e.g. permission denied)
+                    print(f"reader error: {event.get('error')}", file=sys.stderr)
+                    plotter.close()
+                    return 1
+                if etype == "_EOF":
+                    # Server went away (e.g. it was stopped). Drop the now-stale
+                    # geometry, keep the window open, and wait for it to return;
+                    # on reconnect the server re-sends HELLO + a full-scene dump.
+                    print("server disconnected; waiting for it to return ...")
+                    scene.clear()
+                    rendered = True
+                    FrameReader(args.socket_path, events).start()
+                    break
+                scene.apply(event)
+                rendered = True
+        except queue.Empty:
+            pass
+
+        if rendered:
+            plotter.render()
+        try:  # pump the interactor so the window stays responsive
+            plotter.update(stime=50)
+        except Exception:  # noqa: BLE001 - the window was closed
+            break
+        if getattr(plotter, "render_window", True) is None:
+            break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -184,6 +184,16 @@ Part library file format (Python, any .py file under --library path):
         "limit is reached and is killed at the hard limit. "
         "Overrides BUILD123D_CPU_LIMIT_S env var.",
     )
+    parser.add_argument(
+        "--viewer-socket",
+        metavar="PATH",
+        default=os.environ.get("BUILD123D_VIEWER_SOCKET", ""),
+        help="Bind a Unix domain socket at PATH and stream live mesh updates (glb "
+        "over a length-prefixed protocol) to connected viewer clients, so a human "
+        "can watch and rotate the model as the session changes. Off by default; "
+        "adds no cost when no viewer is attached. POSIX only. "
+        "Overrides BUILD123D_VIEWER_SOCKET env var. See docs/live-viewer.md.",
+    )
     args = parser.parse_args()
 
     if args.library and not os.path.isdir(args.library):
@@ -198,6 +208,13 @@ Part library file format (Python, any .py file under --library path):
         parser.error(f"--memory-limit-mb must be a positive integer, got {args.memory_limit_mb}")
     if args.cpu_limit_s is not None and args.cpu_limit_s <= 0:
         parser.error(f"--cpu-limit-s must be a positive integer, got {args.cpu_limit_s}")
+
+    if args.viewer_socket:
+        if sys.platform == "win32":
+            parser.error("--viewer-socket requires a POSIX platform (AF_UNIX sockets)")
+        parent = os.path.dirname(os.path.abspath(args.viewer_socket))
+        if not os.path.isdir(parent):
+            parser.error(f"--viewer-socket parent directory does not exist: {parent}")
 
     extra_imports = tuple(m.strip() for m in args.allow_imports.split(",") if m.strip())
 
@@ -231,6 +248,9 @@ Part library file format (Python, any .py file under --library path):
             file=sys.stderr,
         )
     server.configure(session_cls(**session_kwargs))
+
+    if args.viewer_socket:
+        server.start_viewer(args.viewer_socket)
 
     if args.transport == "http":
         import uvicorn

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -50,6 +50,73 @@ def configure(session: WorkerSession) -> None:
     _session = session
 
 
+# Live-session viewer publisher (build123d_mcp.viewer.ViewerPublisher), or None
+# when --viewer-socket was not given. Set by start_viewer().
+_viewer = None
+
+
+def start_viewer(socket_path: str):
+    """Bind the live-viewer UDS and start broadcasting mesh deltas.
+
+    Called by ``cli.main()`` when ``--viewer-socket`` / ``BUILD123D_VIEWER_SOCKET``
+    is set. The publisher runs on its own daemon thread in this (server) process,
+    never on the agent path. A worker restart triggers a viewer RESET so clients
+    drop their now-stale scene.
+    """
+    global _viewer
+    from build123d_mcp.viewer import ViewerPublisher
+
+    _viewer = ViewerPublisher(socket_path)
+    _viewer.start()
+    try:
+        _resolve_session().set_on_restart(_viewer.reset)
+    except Exception:  # noqa: BLE001 - the viewer must never break startup
+        pass
+    return _viewer
+
+
+def _publish_deltas() -> None:
+    """Refresh the viewer's scene cache with changed shapes and broadcast them.
+
+    Runs whenever the viewer socket is configured (``_viewer`` is set), even with
+    no client attached, so the server-side cache stays current and a viewer that
+    attaches at any time (early or late) gets a correct full-scene dump.
+    Broadcasting to zero clients is a no-op. A pure agent run (no
+    ``--viewer-socket``) does no work here. Failures are swallowed: a viewer
+    problem must never turn a successful tool call into an error.
+    """
+    viewer = _viewer
+    if viewer is None:
+        return
+    # The viewer is bound to the module-singleton session. In HTTP multi-session
+    # mode a per-request tenant session is set on _session_var; do not publish its
+    # geometry into the shared viewer stream, which would leak between tenants.
+    if _session_var.get() is not None:
+        return
+    try:
+        deltas = _resolve_session().pull_viewer_deltas()
+    except Exception:  # noqa: BLE001 - viewer plumbing must not affect the tool result
+        return
+    if not isinstance(deltas, dict):
+        return
+    for name in deltas.get("remove", []):
+        viewer.remove(name)
+    for name, mesh in deltas.get("upsert", {}).items():
+        try:
+            verts, tris = mesh
+            viewer.upsert(name, verts, tris)
+        except Exception:  # noqa: BLE001 - skip a malformed mesh, keep the rest
+            continue
+
+
+def _publish_reset() -> None:
+    """Tell viewer clients to clear their scene (the session was reset)."""
+    viewer = _viewer
+    if viewer is None or _session_var.get() is not None:
+        return
+    viewer.reset()
+
+
 def http_app():
     """Return the FastMCP ASGI app for use with an ASGI server (e.g. uvicorn).
 
@@ -71,7 +138,9 @@ def execute(code: str) -> str:
     """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly. find_edges(shape, geom='circle', radius=4.25, at_z=10.2, length=None, tol=0.05) filters edges for fillet/chamfer selection and prints what matched. save_json(name, obj) writes structured analysis data (face inventories, hole tables) to a server scratch file and returns its path — use it instead of printing large results; open()/os stay blocked."""
     from build123d_mcp.tools.execute import execute_code
 
-    return execute_code(_resolve_session(), code)
+    result = execute_code(_resolve_session(), code)
+    _publish_deltas()
+    return result
 
 
 @mcp.tool()
@@ -345,7 +414,9 @@ def load_part(name: str, params: str = "") -> str:
     """Load a named part from the library into the session. name: part name from search_library. params: optional JSON object of parameter overrides e.g. '{\"od\": 8.0, \"length\": 20.0}' — unspecified params use their defaults. The part is registered as a named object and becomes current_shape."""
     if not _resolve_session().has_library:
         return "No part library configured. Start the server with --library PATH or set BUILD123D_PART_LIBRARY."
-    return _resolve_session().load_part(name, params)
+    result = _resolve_session().load_part(name, params)
+    _publish_deltas()
+    return result
 
 
 @mcp.tool()
@@ -362,7 +433,9 @@ def restore_snapshot(name: str) -> str:
     The Python variable namespace is NOT restored — execute() calls made after the snapshot are still in scope,
     but current_shape and all show() objects revert to what they were at snapshot time.
     Raises an error if the snapshot name does not exist."""
-    return _resolve_session().restore_snapshot(name)
+    result = _resolve_session().restore_snapshot(name)
+    _publish_deltas()
+    return result
 
 
 @mcp.tool()
@@ -386,7 +459,9 @@ def health_check() -> str:
 @mcp.tool()
 def reset() -> str:
     """Clear the current session back to empty state, including all snapshots."""
-    return _resolve_session().reset()
+    result = _resolve_session().reset()
+    _publish_reset()
+    return result
 
 
 @mcp.tool()
@@ -434,7 +509,9 @@ def script(save_to: str = "") -> str:
 @mcp.tool()
 def import_cad_file(path: str, name: str = "") -> str:
     """Import a STEP (.step/.stp) or STL (.stl) file as a named object in the session. path: absolute or relative path to the file. name: name to register the shape under (defaults to the filename stem). The shape becomes both the named object and the current_shape. Returns volume, topology, and bounding box of the imported shape. After importing, use render_view() to visualise the shape, measure() for geometry queries, or shape_compare() to diff against a show() object. Note: STL imports produce a shell (volume=0) rather than a solid — render_view and measure still work, but clearance() and boolean operations require a solid. If you have both the original built shape and an imported copy in session.objects, render the imported one by name (e.g. objects='mypart') to avoid Z-fighting artifacts from two co-located shapes."""
-    return _resolve_session().import_cad_file(path, name)
+    result = _resolve_session().import_cad_file(path, name)
+    _publish_deltas()
+    return result
 
 
 @mcp.tool()

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -43,6 +43,9 @@ class Session:
         self.drawing_page: dict[str, Any] | None = None
         self.geometry_refs: dict[str, Any] = {}
         self.execute_history: list[str] = []
+        # Live-viewer delta tracking: name -> id(shape) at the last delta pull,
+        # used to identity-diff changed shapes (see worker._op_pull_viewer_deltas).
+        self._viewer_baseline: dict[str, int] = {}
         # True while the current execute() call has explicitly registered a
         # shape via show()/annotate()/register_centerline() — blocks the
         # post-exec variable scan from overriding that registration (#236).
@@ -739,4 +742,5 @@ class Session:
         self.last_error_detail = None
         self.geometry_refs.clear()
         self.execute_history = []
+        self._viewer_baseline.clear()
         self._inject_builtins()

--- a/src/build123d_mcp/viewer.py
+++ b/src/build123d_mcp/viewer.py
@@ -1,0 +1,498 @@
+"""Live-session viewer publisher: stream mesh updates over a Unix domain socket.
+
+When the server is started with ``--viewer-socket PATH`` (or
+``BUILD123D_VIEWER_SOCKET``), it binds a UDS and broadcasts the session's
+geometry to any connected viewer client as it changes, so a human can watch and
+rotate the model while an agent drives the MCP. The agent keeps getting its
+fixed-viewpoint ``render_view`` PNGs; the human gets a live 3D view.
+
+Design (see docs/live-viewer.md):
+
+- This publisher runs in the SERVER process, on a background daemon thread. It
+  does not stall the agent path on viewer I/O: a broadcast only appends to
+  bounded per-client buffers (drop-oldest for a slow client), and the loop
+  thread holds the shared lock for at most one non-blocking send at a time.
+- The geometry lives in the worker subprocess; the server asks the worker for
+  per-shape mesh deltas (``pull_viewer_deltas``) after each mutating tool and
+  encodes them to glTF-binary (glb) here, with no OCC/VTK dependency and no new
+  third-party dependency (a small, self-contained glTF 2.0 writer below).
+- A viewer connecting mid-session receives ``HELLO`` followed by an ``UPSERT``
+  for every shape currently in the scene (served from a server-side glb cache),
+  so a late attach is correct.
+
+Access control: the socket is restricted to mode 0600 (owner only) right after
+bind, so only the server's user can connect. The publisher also lives in the
+server process, outside the sandboxed ``execute()`` worker, so under the default
+sandbox user code cannot reach it (the import allowlist blocks
+``socket``/filesystem modules in the worker's exec namespace). Starting the
+server with ``--no-sandbox`` or ``--allow-all-imports`` lifts that allowlist, so
+worker code could then connect like any local process; the 0600 permission stays
+as the backstop.
+
+Wire protocol, length-prefixed frames::
+
+    [u32 BE json_len][json header utf8][u32 BE bin_len][binary payload]
+
+Header: ``{type, session_id, seq, name?, units:"mm"}``. Types: ``HELLO`` (no
+payload), ``UPSERT`` (payload = a binary glb of one named shape), ``REMOVE``
+(no payload), ``RESET`` (no payload; clear the scene). ``seq`` is monotonic per
+publisher.
+"""
+
+from __future__ import annotations
+
+import array
+import atexit
+import json
+import os
+import selectors
+import socket
+import stat
+import struct
+import sys
+import threading
+import uuid
+from collections import deque
+from collections.abc import Iterable, Sequence
+
+# --------------------------------------------------------------------------- #
+# glTF 2.0 binary (glb) encoder: zero dependencies (stdlib struct/array/json)  #
+# --------------------------------------------------------------------------- #
+
+_GLB_MAGIC = 0x46546C67  # "glTF"
+_GLB_VERSION = 2
+_CHUNK_JSON = 0x4E4F534A  # "JSON"
+_CHUNK_BIN = 0x004E4942  # "BIN\0"
+_COMPONENT_FLOAT = 5126  # FLOAT
+_COMPONENT_UINT = 5125  # UNSIGNED_INT
+_TARGET_ARRAY_BUFFER = 34962
+_TARGET_ELEMENT_ARRAY_BUFFER = 34963
+_MODE_TRIANGLES = 4
+
+
+def encode_glb(verts: Iterable[Sequence[float]], tris: Iterable[Sequence[int]]) -> bytes:
+    """Encode a triangle mesh as a binary glTF (glb).
+
+    ``verts`` is an iterable of ``(x, y, z)`` world-space points (mm); ``tris``
+    is an iterable of ``(i, j, k)`` vertex-index triples, exactly the shape of
+    ``build123d``'s ``Shape.tessellate`` output as marshalled by the render
+    tessellation path. The result is a standard glb readable by three.js'
+    ``GLTFLoader``, trimesh, pyvista, etc.
+    """
+    positions = array.array("f")
+    min_x = min_y = min_z = float("inf")
+    max_x = max_y = max_z = float("-inf")
+    n_verts = 0
+    for v in verts:
+        x, y, z = float(v[0]), float(v[1]), float(v[2])
+        positions.append(x)
+        positions.append(y)
+        positions.append(z)
+        min_x, max_x = min(min_x, x), max(max_x, x)
+        min_y, max_y = min(min_y, y), max(max_y, y)
+        min_z, max_z = min(min_z, z), max(max_z, z)
+        n_verts += 1
+
+    indices = array.array("I")
+    for t in tris:
+        indices.append(int(t[0]))
+        indices.append(int(t[1]))
+        indices.append(int(t[2]))
+    n_indices = len(indices)
+
+    if n_verts == 0:  # degenerate guard: POSITION min/max must be finite
+        min_x = min_y = min_z = max_x = max_y = max_z = 0.0
+
+    # glTF buffers are little-endian; array.tobytes() is native-endian.
+    if sys.byteorder == "big":
+        positions.byteswap()
+        indices.byteswap()
+    pos_bytes = positions.tobytes()
+    idx_bytes = indices.tobytes()
+    # POSITION (4-byte float) sits at offset 0; indices (4-byte uint) follow at
+    # len(pos_bytes), which is a multiple of 4, so both accessor alignments hold.
+    bin_blob = pos_bytes + idx_bytes
+
+    gltf = {
+        "asset": {"version": "2.0", "generator": "build123d-mcp"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"mesh": 0}],
+        "meshes": [
+            {"primitives": [{"attributes": {"POSITION": 0}, "indices": 1, "mode": _MODE_TRIANGLES}]}
+        ],
+        "buffers": [{"byteLength": len(bin_blob)}],
+        "bufferViews": [
+            {
+                "buffer": 0,
+                "byteOffset": 0,
+                "byteLength": len(pos_bytes),
+                "target": _TARGET_ARRAY_BUFFER,
+            },
+            {
+                "buffer": 0,
+                "byteOffset": len(pos_bytes),
+                "byteLength": len(idx_bytes),
+                "target": _TARGET_ELEMENT_ARRAY_BUFFER,
+            },
+        ],
+        "accessors": [
+            {
+                "bufferView": 0,
+                "componentType": _COMPONENT_FLOAT,
+                "count": n_verts,
+                "type": "VEC3",
+                "min": [min_x, min_y, min_z],
+                "max": [max_x, max_y, max_z],
+            },
+            {
+                "bufferView": 1,
+                "componentType": _COMPONENT_UINT,
+                "count": n_indices,
+                "type": "SCALAR",
+            },
+        ],
+    }
+
+    json_bytes = json.dumps(gltf, separators=(",", ":")).encode("utf-8")
+    json_bytes += b" " * ((4 - len(json_bytes) % 4) % 4)  # pad with spaces
+    bin_blob += b"\x00" * ((4 - len(bin_blob) % 4) % 4)  # pad with zeros
+
+    total_len = 12 + 8 + len(json_bytes) + 8 + len(bin_blob)
+    out = bytearray()
+    out += struct.pack("<III", _GLB_MAGIC, _GLB_VERSION, total_len)
+    out += struct.pack("<II", len(json_bytes), _CHUNK_JSON)
+    out += json_bytes
+    out += struct.pack("<II", len(bin_blob), _CHUNK_BIN)
+    out += bin_blob
+    return bytes(out)
+
+
+# --------------------------------------------------------------------------- #
+# Wire framing                                                                 #
+# --------------------------------------------------------------------------- #
+
+_UNITS = "mm"
+
+
+def encode_frame(header: dict, payload: bytes = b"") -> bytes:
+    """Length-prefixed frame: ``[u32 json_len][json][u32 bin_len][payload]``."""
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    return (
+        struct.pack(">I", len(header_bytes))
+        + header_bytes
+        + struct.pack(">I", len(payload))
+        + payload
+    )
+
+
+# Per-client backlog cap (whole frames). A client slower than the producer has
+# its OLDEST queued frames dropped; the producer never blocks. A reconnecting
+# viewer always gets a fresh full-scene dump, so dropping stale deltas is safe.
+# The cap is on frame count, not bytes: a scene of very large meshes can hold a
+# few hundred MB on a stalled client before frames start dropping.
+_MAX_QUEUED_FRAMES = 256
+
+
+class _Client:
+    __slots__ = ("sock", "frames", "offset")
+
+    def __init__(self, sock: socket.socket) -> None:
+        self.sock = sock
+        self.frames: deque[bytes] = deque()  # complete frames pending send
+        self.offset = 0  # bytes already sent from frames[0]
+
+
+class ViewerPublisher:
+    """Server-side UDS publisher broadcasting mesh deltas to viewer clients.
+
+    Thread model: a single background daemon thread owns the listening socket,
+    all client sockets, and the ``selectors`` loop. The public mutators
+    (:meth:`upsert`, :meth:`remove`, :meth:`reset`) are called from the server's
+    request thread; they update the glb cache + per-client queues under a lock
+    and wake the loop. All socket I/O happens on the loop thread.
+    """
+
+    def __init__(self, socket_path: str) -> None:
+        self.socket_path = socket_path
+        self.session_id = uuid.uuid4().hex
+        self._sel = selectors.DefaultSelector()
+        self._lsock: socket.socket | None = None
+        self._clients: dict[socket.socket, _Client] = {}
+        self._cache: dict[str, bytes] = {}  # name -> glb bytes (insertion-ordered)
+        self._seq = 0
+        self._lock = threading.Lock()
+        self._wake_r, self._wake_w = socket.socketpair()
+        self._wake_r.setblocking(False)
+        self._wake_w.setblocking(False)
+        self._thread: threading.Thread | None = None
+        self._closed = False
+
+    # ---- lifecycle ------------------------------------------------------- #
+
+    @staticmethod
+    def _socket_has_listener(path: str) -> bool:
+        """True if a server is currently accepting connections at ``path``."""
+        probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            probe.connect(path)
+            return True
+        except OSError:
+            return False  # ConnectionRefusedError (stale socket) or other failure
+        finally:
+            probe.close()
+
+    def start(self) -> None:
+        if os.path.exists(self.socket_path):
+            # Refuse to clobber a real file, and refuse to steal a socket another
+            # server is actively listening on; only reclaim a stale socket whose
+            # listener is gone.
+            if not stat.S_ISSOCK(os.stat(self.socket_path).st_mode):
+                raise ValueError(
+                    f"viewer socket path exists and is not a socket: {self.socket_path}"
+                )
+            if self._socket_has_listener(self.socket_path):
+                raise RuntimeError(f"another server is already listening on {self.socket_path}")
+            os.unlink(self.socket_path)
+        lsock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Create the socket owner-only with no window: set a private umask across
+        # bind() so the path is never world-accessible (a chmod after bind would
+        # leave a brief gap). The chmod then pins the exact mode regardless of the
+        # umask inherited by the process.
+        old_umask = os.umask(0o077)
+        try:
+            lsock.bind(self.socket_path)
+        finally:
+            os.umask(old_umask)
+        os.chmod(self.socket_path, 0o600)
+        lsock.listen(8)
+        lsock.setblocking(False)
+        self._lsock = lsock
+        self._sel.register(lsock, selectors.EVENT_READ)
+        self._sel.register(self._wake_r, selectors.EVENT_READ)
+        self._thread = threading.Thread(target=self._loop, name="viewer-publisher", daemon=True)
+        self._thread.start()
+        atexit.register(self.stop)
+
+    def stop(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._wake()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+        for c in clients:
+            try:
+                c.sock.close()
+            except OSError:
+                pass
+        if self._lsock is not None:
+            try:
+                self._lsock.close()
+            except OSError:
+                pass
+        # The loop thread has joined, so the selector and wake socketpair are no
+        # longer in use; close them too to avoid fd leaks across start/stop cycles.
+        try:
+            self._sel.close()
+        except Exception:  # noqa: BLE001 - selector close is best-effort on teardown
+            pass
+        for wake_sock in (self._wake_r, self._wake_w):
+            try:
+                wake_sock.close()
+            except OSError:
+                pass
+        try:
+            if os.path.exists(self.socket_path):
+                os.unlink(self.socket_path)
+        except OSError:
+            pass
+
+    # ---- public mutators (called from the server request thread) --------- #
+
+    @property
+    def client_count(self) -> int:
+        with self._lock:
+            return len(self._clients)
+
+    def upsert(
+        self, name: str, verts: Iterable[Sequence[float]], tris: Iterable[Sequence[int]]
+    ) -> None:
+        """Encode ``name``'s mesh to glb, cache it, and broadcast an UPSERT."""
+        glb = encode_glb(verts, tris)
+        with self._lock:
+            self._cache[name] = glb
+            frame = self._frame_locked("UPSERT", name=name, payload=glb)
+            self._broadcast_locked(frame)
+        self._wake()
+
+    def remove(self, name: str) -> None:
+        with self._lock:
+            self._cache.pop(name, None)
+            frame = self._frame_locked("REMOVE", name=name)
+            self._broadcast_locked(frame)
+        self._wake()
+
+    def reset(self) -> None:
+        """Clear the cached scene and tell every client to drop its scene."""
+        with self._lock:
+            self._cache.clear()
+            frame = self._frame_locked("RESET")
+            self._broadcast_locked(frame)
+        self._wake()
+
+    # ---- frame construction (caller holds the lock) ---------------------- #
+
+    def _frame_locked(self, type_: str, name: str | None = None, payload: bytes = b"") -> bytes:
+        self._seq += 1
+        header: dict = {
+            "type": type_,
+            "session_id": self.session_id,
+            "seq": self._seq,
+            "units": _UNITS,
+        }
+        if name is not None:
+            header["name"] = name
+        return encode_frame(header, payload)
+
+    def _broadcast_locked(self, frame: bytes) -> None:
+        for client in self._clients.values():
+            self._enqueue_locked(client, frame)
+
+    def _enqueue_locked(self, client: _Client, frame: bytes, cap: bool = True) -> None:
+        client.frames.append(frame)
+        if not cap:
+            return  # the on-connect HELLO + full-scene dump must never be dropped
+        # Drop oldest whole frames past the cap, never the in-flight head.
+        while len(client.frames) > _MAX_QUEUED_FRAMES:
+            if client.offset > 0 and len(client.frames) > 1:
+                del client.frames[1]
+            else:
+                client.frames.popleft()
+
+    # ---- background loop (the only thread touching sockets) -------------- #
+
+    def _wake(self) -> None:
+        try:
+            self._wake_w.send(b"\x01")
+        except OSError:
+            pass
+
+    def _loop(self) -> None:
+        while not self._closed:
+            events = self._sel.select(timeout=1.0)
+            for key, mask in events:
+                fileobj = key.fileobj
+                try:
+                    if fileobj is self._lsock:
+                        self._accept()
+                    elif fileobj is self._wake_r:
+                        self._drain_wake()
+                    else:
+                        self._service_client(fileobj, mask)
+                except Exception:  # noqa: BLE001 - one bad client must not kill the loop
+                    self._drop(fileobj)
+            self._update_write_interest()
+
+    def _drain_wake(self) -> None:
+        try:
+            while self._wake_r.recv(4096):
+                pass
+        except OSError:
+            pass
+
+    def _accept(self) -> None:
+        assert self._lsock is not None
+        try:
+            conn, _ = self._lsock.accept()
+        except OSError:
+            return
+        conn.setblocking(False)
+        client = _Client(conn)
+        with self._lock:
+            self._clients[conn] = client
+            # HELLO + a full-scene dump from the cache so a mid-session attach sees
+            # the existing model. These bypass the drop-oldest cap (cap=False): the
+            # dump is the client's required starting state, so it is never shed even
+            # for a scene larger than _MAX_QUEUED_FRAMES. Live deltas after it are
+            # still capped.
+            self._enqueue_locked(client, self._frame_locked("HELLO"), cap=False)
+            for name, glb in self._cache.items():
+                self._enqueue_locked(
+                    client, self._frame_locked("UPSERT", name=name, payload=glb), cap=False
+                )
+        self._sel.register(conn, selectors.EVENT_READ)
+
+    def _service_client(self, fileobj, mask: int) -> None:
+        with self._lock:
+            client = self._clients.get(fileobj)
+        if client is None:
+            return
+        if mask & selectors.EVENT_READ:
+            try:
+                data = client.sock.recv(4096)
+            except BlockingIOError:
+                data = None  # spurious readiness; not a disconnect
+            except OSError:
+                self._drop(fileobj)
+                return
+            if data == b"":  # peer closed
+                self._drop(fileobj)
+                return
+            # Inbound bytes are ignored in v1 (read only to detect disconnect).
+        if mask & selectors.EVENT_WRITE and self._flush(client):
+            self._drop(fileobj)
+
+    def _flush(self, client: _Client) -> bool:
+        """Send as much queued data as the socket accepts. Return True if dead.
+
+        The lock is taken per frame, not across the whole drain, so a fast viewer
+        emptying a large backlog never holds it long enough to stall the agent
+        thread's broadcast: each iteration is one non-blocking send.
+        """
+        while True:
+            with self._lock:
+                if not client.frames:
+                    return False
+                head = client.frames[0]
+                try:
+                    # memoryview slice is zero-copy, avoiding a re-copy of the
+                    # whole remaining frame on each partial send of a large glb.
+                    sent = client.sock.send(memoryview(head)[client.offset :])
+                except BlockingIOError:
+                    return False  # kernel buffer full; resume on next writable event
+                except OSError:
+                    return True
+                client.offset += sent
+                if client.offset >= len(head):
+                    client.frames.popleft()
+                    client.offset = 0
+                else:
+                    return False  # partial frame sent; resume on next writable event
+
+    def _update_write_interest(self) -> None:
+        with self._lock:
+            pending = {fo: bool(c.frames) for fo, c in self._clients.items()}
+        for fileobj, has_pending in pending.items():
+            want = selectors.EVENT_READ | (selectors.EVENT_WRITE if has_pending else 0)
+            try:
+                if self._sel.get_key(fileobj).events != want:
+                    self._sel.modify(fileobj, want)
+            except KeyError:
+                pass  # client dropped concurrently
+
+    def _drop(self, fileobj) -> None:
+        try:
+            self._sel.unregister(fileobj)
+        except (KeyError, ValueError):
+            pass
+        with self._lock:
+            client = self._clients.pop(fileobj, None)
+        if client is not None:
+            try:
+                client.sock.close()
+            except OSError:
+                pass

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -284,6 +284,40 @@ def _op_render_drawing(session: Any, args: dict, library_index: Any) -> Any:
     return render_drawing(args["svg_path"], args.get("width", 0), args.get("save_to", ""))
 
 
+def _op_pull_viewer_deltas(session: Any, args: dict, library_index: Any) -> Any:
+    """Return per-shape mesh deltas since the last pull, for the live viewer.
+
+    Diffs ``session.objects`` by identity against a worker-held baseline and
+    tessellates only the changed shapes (via the same bounded, hard-killable
+    out-of-process path render_view uses), returning raw vertex/triangle arrays
+    the server encodes to glb. Called by server.py after each geometry-mutating
+    tool, only while a viewer is attached.
+    """
+    baseline = session._viewer_baseline
+    objects = session.objects
+    upsert_names = [name for name, shape in objects.items() if baseline.get(name) != id(shape)]
+    remove = [name for name in baseline if name not in objects]
+
+    meshes: dict = {}
+    if upsert_names:
+        from build123d_mcp.tools.render import _QUALITY, _tessellate_shapes_bounded
+
+        shapes = [(name, objects[name], None) for name in upsert_names]
+        meshes, _failed = _tessellate_shapes_bounded(shapes, _QUALITY["standard"])
+
+    # Advance the baseline only for shapes we actually tessellated (drop removed
+    # ones). A shape that failed tessellation is left dirty, so the next pull
+    # retries it instead of skipping it forever.
+    new_baseline = {name: ident for name, ident in baseline.items() if name in objects}
+    for name in upsert_names:
+        if name in meshes:
+            new_baseline[name] = id(objects[name])
+        else:
+            new_baseline.pop(name, None)
+    session._viewer_baseline = new_baseline
+    return {"upsert": meshes, "remove": remove}
+
+
 _T = "build123d_mcp.tools"
 
 # Populated by the @_op decorator on WorkerSession's typed stub methods, plus
@@ -366,6 +400,11 @@ class WorkerSession:
         # and one can recv() the other's response. A single OCC worker is serial
         # anyway, so serialising costs no real throughput. (#322)
         self._lock = threading.Lock()
+        # Optional callback fired after the worker is (re)started following a
+        # crash/timeout restart, used by the live viewer to emit a RESET so
+        # clients clear their now-stale scene. Not fired on the first start.
+        self._on_restart: Callable[[], None] | None = None
+        self._started_once = False
         self._start_worker()
 
     @property
@@ -452,6 +491,19 @@ class WorkerSession:
                 f"Worker process failed to start: {msg['error']}. "
                 "Relaunch with --in-process to skip subprocess resource limits."
             )
+
+        # A successful (re)start past the first one means the previous worker
+        # died and its session state is gone, so notify observers (the viewer).
+        if self._started_once and self._on_restart is not None:
+            try:
+                self._on_restart()
+            except Exception:  # noqa: BLE001 - a viewer callback must never break the restart
+                pass
+        self._started_once = True
+
+    def set_on_restart(self, callback: "Callable[[], None] | None") -> None:
+        """Register a callback fired after each worker restart (not the first)."""
+        self._on_restart = callback
 
     def _kill_worker(self) -> None:
         try:
@@ -553,6 +605,10 @@ class WorkerSession:
         colors: dict[str, str] | None = None,
         mode: str = "auto",
     ) -> dict:
+        raise NotImplementedError
+
+    @_op(_op_pull_viewer_deltas, _RENDER_TIMEOUT)
+    def pull_viewer_deltas(self) -> dict:
         raise NotImplementedError
 
     @_op(_tool(f"{_T}.export:export_file"), _export_budget)

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,391 @@
+"""Tests for the live-session viewer publisher (build123d_mcp.viewer).
+
+These exercise the server-side UDS publisher and the dependency-free glb
+encoder directly, with no GUI/render dependency and no worker subprocess, so they
+run anywhere the rest of the suite does. AF_UNIX is POSIX-only, so the socket tests
+skip on Windows.
+"""
+
+import json
+import os
+import shutil
+import socket
+import stat
+import struct
+import sys
+import tempfile
+
+import pytest
+
+from build123d_mcp.viewer import ViewerPublisher, encode_frame, encode_glb
+
+# A unit triangle: 3 verts, 1 face.
+_VERTS = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 2.0, 0.0)]
+_TRIS = [[0, 1, 2]]
+
+
+# --------------------------------------------------------------------------- #
+# glb encoder                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _parse_glb(blob: bytes) -> tuple[dict, bytes]:
+    """Minimal glb parser: return (gltf_json, bin_chunk). Dependency-free."""
+    magic, version, total = struct.unpack_from("<III", blob, 0)
+    assert magic == 0x46546C67  # "glTF"
+    assert version == 2
+    assert total == len(blob)
+    off = 12
+    json_chunk = None
+    bin_chunk = b""
+    while off < len(blob):
+        clen, ctype = struct.unpack_from("<II", blob, off)
+        off += 8
+        data = blob[off : off + clen]
+        off += clen
+        if ctype == 0x4E4F534A:  # JSON
+            json_chunk = json.loads(data.decode("utf-8"))
+        elif ctype == 0x004E4942:  # BIN
+            bin_chunk = data
+    assert json_chunk is not None
+    return json_chunk, bin_chunk
+
+
+def test_encode_glb_structure_and_counts():
+    blob = encode_glb(_VERTS, _TRIS)
+    assert blob[:4] == b"glTF"
+    gltf, binc = _parse_glb(blob)
+
+    assert gltf["asset"]["version"] == "2.0"
+    pos_acc, idx_acc = gltf["accessors"]
+    assert pos_acc["type"] == "VEC3" and pos_acc["count"] == 3
+    assert idx_acc["type"] == "SCALAR" and idx_acc["count"] == 3
+    # POSITION min/max are required and must bound the input.
+    assert pos_acc["min"] == [0.0, 0.0, 0.0]
+    assert pos_acc["max"] == [1.0, 2.0, 0.0]
+
+    # Decode the positions out of the BIN chunk and compare to the input.
+    pos_view = gltf["bufferViews"][pos_acc["bufferView"]]
+    floats = struct.unpack_from("<9f", binc, pos_view["byteOffset"])
+    assert list(floats) == [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0, 0.0]
+    # And the indices.
+    idx_view = gltf["bufferViews"][idx_acc["bufferView"]]
+    idx = struct.unpack_from("<3I", binc, idx_view["byteOffset"])
+    assert list(idx) == [0, 1, 2]
+
+
+def test_encode_glb_4byte_aligned_chunks():
+    blob = encode_glb(_VERTS, _TRIS)
+    # glTF requires both chunk lengths to be multiples of 4.
+    json_len = struct.unpack_from("<I", blob, 12)[0]
+    assert json_len % 4 == 0
+    bin_len = struct.unpack_from("<I", blob, 12 + 8 + json_len)[0]
+    assert bin_len % 4 == 0
+
+
+def test_encode_frame_layout():
+    frame = encode_frame({"type": "RESET", "seq": 7}, b"")
+    (jlen,) = struct.unpack_from(">I", frame, 0)
+    header = json.loads(frame[4 : 4 + jlen])
+    (blen,) = struct.unpack_from(">I", frame, 4 + jlen)
+    assert header == {"type": "RESET", "seq": 7}
+    assert blen == 0
+
+
+# --------------------------------------------------------------------------- #
+# UDS publisher                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def sock_path():
+    if sys.platform == "win32":
+        pytest.skip("AF_UNIX viewer socket is POSIX-only")
+    # Keep the path short: AF_UNIX sun_path is capped (~104 bytes on macOS),
+    # and pytest's tmp_path under /var/folders can overflow it.
+    base = "/tmp" if os.path.isdir("/tmp") else None
+    d = tempfile.mkdtemp(prefix="b123dv_", dir=base)
+    try:
+        yield os.path.join(d, "live.sock")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _recv_exactly(sock, n: int) -> bytes:
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise AssertionError("socket closed before frame was complete")
+        buf += chunk
+    return buf
+
+
+def _read_frame(sock) -> tuple[dict, bytes]:
+    (jlen,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    header = json.loads(_recv_exactly(sock, jlen).decode("utf-8"))
+    (blen,) = struct.unpack(">I", _recv_exactly(sock, 4))
+    payload = _recv_exactly(sock, blen) if blen else b""
+    return header, payload
+
+
+def _connect(path: str):
+    c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    c.settimeout(5.0)
+    c.connect(path)
+    return c
+
+
+def test_publisher_hello_then_full_scene_dump(sock_path):
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    try:
+        pub.upsert("part", _VERTS, _TRIS)  # cached before any client connects
+        client = _connect(sock_path)
+        try:
+            hello, _ = _read_frame(client)
+            assert hello["type"] == "HELLO"
+            assert hello["units"] == "mm"
+            assert hello["session_id"] == pub.session_id
+
+            up_header, up_payload = _read_frame(client)
+            assert up_header["type"] == "UPSERT"
+            assert up_header["name"] == "part"
+            assert up_payload[:4] == b"glTF"  # the cached glb of the shape
+        finally:
+            client.close()
+    finally:
+        pub.stop()
+
+
+def test_publisher_live_upsert_remove_reset(sock_path):
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    try:
+        client = _connect(sock_path)
+        try:
+            hello, _ = _read_frame(client)
+            assert hello["type"] == "HELLO"  # empty scene → just HELLO
+
+            pub.upsert("box", _VERTS, _TRIS)
+            h, payload = _read_frame(client)
+            assert h["type"] == "UPSERT" and h["name"] == "box"
+            assert payload[:4] == b"glTF"
+
+            pub.remove("box")
+            h, payload = _read_frame(client)
+            assert h["type"] == "REMOVE" and h["name"] == "box" and payload == b""
+
+            pub.reset()
+            h, payload = _read_frame(client)
+            assert h["type"] == "RESET" and payload == b""
+
+            # seq is monotonic across the stream.
+            assert h["seq"] > hello["seq"]
+        finally:
+            client.close()
+    finally:
+        pub.stop()
+
+
+def test_publisher_noop_without_clients(sock_path):
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    try:
+        assert pub.client_count == 0
+        # No client attached: these must not raise and must not block.
+        pub.upsert("a", _VERTS, _TRIS)
+        pub.remove("a")
+        pub.reset()
+        assert pub.client_count == 0
+    finally:
+        pub.stop()
+
+
+def test_publisher_stop_unlinks_socket(sock_path):
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    assert os.path.exists(sock_path)
+    pub.stop()
+    assert not os.path.exists(sock_path)
+    # stop() is idempotent.
+    pub.stop()
+
+
+def test_publisher_refuses_non_socket_path(sock_path):
+    # A real file at the configured path must not be silently clobbered.
+    with open(sock_path, "w") as f:
+        f.write("not a socket")
+    try:
+        pub = ViewerPublisher(sock_path)
+        with pytest.raises(ValueError, match="not a socket"):
+            pub.start()
+    finally:
+        os.unlink(sock_path)
+
+
+def test_publisher_socket_is_owner_only(sock_path):
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    try:
+        mode = stat.S_IMODE(os.stat(sock_path).st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+    finally:
+        pub.stop()
+
+
+def test_publish_deltas_skips_per_request_session():
+    """In HTTP multi-session mode a per-request session must not leak into the
+    single shared viewer. _publish_deltas() short-circuits before pulling."""
+    from build123d_mcp import server
+
+    class _FakeViewer:
+        client_count = 1
+
+        def __init__(self):
+            self.calls = []
+
+        def upsert(self, *a):
+            self.calls.append("upsert")
+
+        def remove(self, *a):
+            self.calls.append("remove")
+
+    class _FakeSession:
+        def __init__(self):
+            self.pulled = False
+
+        def pull_viewer_deltas(self):
+            self.pulled = True
+            return {"upsert": {"x": ([(0.0, 0.0, 0.0)], [[0, 0, 0]])}, "remove": []}
+
+    fake_viewer = _FakeViewer()
+    fake_session = _FakeSession()
+    saved_viewer = server._viewer
+    server._viewer = fake_viewer
+    token = server._session_var.set(fake_session)
+    try:
+        server._publish_deltas()
+        assert fake_session.pulled is False  # guarded before the worker pull
+        assert fake_viewer.calls == []
+    finally:
+        server._session_var.reset(token)
+        server._viewer = saved_viewer
+
+
+def test_server_execute_publishes_upsert(sock_path):
+    """End-to-end: a mutating tool drives a worker pull + an UPSERT on the wire.
+
+    Exercises the real wiring: server.execute() drives worker pull_viewer_deltas,
+    the server-side glb encode, and the publisher broadcast, via a live WorkerSession.
+    """
+    from build123d_mcp import server
+    from build123d_mcp.worker import WorkerSession
+
+    ws = WorkerSession(exec_timeout=30)
+    server.configure(ws)
+    server.start_viewer(sock_path)
+    try:
+        client = _connect(sock_path)
+        try:
+            hello, _ = _read_frame(client)
+            assert hello["type"] == "HELLO"  # client is now registered (count > 0)
+
+            server.execute("from build123d import *\nshow(Box(2, 2, 2), 'box')")
+            header, payload = _read_frame(client)
+            assert header["type"] == "UPSERT" and header["name"] == "box"
+            assert payload[:4] == b"glTF"
+
+            server.reset()
+            header, _ = _read_frame(client)
+            assert header["type"] == "RESET"
+        finally:
+            client.close()
+    finally:
+        server._viewer.stop()
+        server._viewer = None
+        ws._kill_worker()
+
+
+def test_late_attach_gets_prior_geometry(sock_path):
+    """A viewer attaching AFTER the model was built still gets the full scene.
+
+    The cache must be kept current while no viewer is attached (Option A), so the
+    on-connect dump reflects work done before the viewer connected.
+    """
+    from build123d_mcp import server
+    from build123d_mcp.worker import WorkerSession
+
+    ws = WorkerSession(exec_timeout=30)
+    server.configure(ws)
+    server.start_viewer(sock_path)
+    try:
+        # Build BEFORE any viewer connects.
+        server.execute("from build123d import *\nshow(Box(3, 3, 3), 'early')")
+        client = _connect(sock_path)
+        try:
+            hello, _ = _read_frame(client)
+            assert hello["type"] == "HELLO"
+            header, payload = _read_frame(client)
+            assert header["type"] == "UPSERT" and header["name"] == "early"
+            assert payload[:4] == b"glTF"
+        finally:
+            client.close()
+    finally:
+        server._viewer.stop()
+        server._viewer = None
+        ws._kill_worker()
+
+
+def test_full_scene_dump_is_not_capped(sock_path, monkeypatch):
+    """The on-connect HELLO + dump must be delivered intact even when the scene
+    holds more shapes than the per-client backlog cap."""
+    monkeypatch.setattr("build123d_mcp.viewer._MAX_QUEUED_FRAMES", 2)
+    pub = ViewerPublisher(sock_path)
+    pub.start()
+    try:
+        names = [f"s{i}" for i in range(5)]  # > cap of 2
+        for name in names:
+            pub.upsert(name, _VERTS, _TRIS)  # cached; no client yet
+        client = _connect(sock_path)
+        try:
+            hello, _ = _read_frame(client)
+            assert hello["type"] == "HELLO"
+            got = set()
+            for _ in range(len(names)):
+                header, _payload = _read_frame(client)
+                assert header["type"] == "UPSERT"
+                got.add(header["name"])
+            assert got == set(names)  # none dropped despite the tiny cap
+        finally:
+            client.close()
+    finally:
+        pub.stop()
+
+
+def test_publisher_refuses_to_steal_live_socket(sock_path):
+    pub1 = ViewerPublisher(sock_path)
+    pub1.start()
+    try:
+        pub2 = ViewerPublisher(sock_path)
+        with pytest.raises(RuntimeError, match="already listening"):
+            pub2.start()
+    finally:
+        pub1.stop()
+
+
+def test_example_client_safe_filename():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_ex_client",
+        os.path.join(os.path.dirname(__file__), "..", "examples", "live_viewer_client.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    assert mod._safe_filename("box") == "box.glb"
+    assert mod._safe_filename("a/b") == "b.glb"
+    assert mod._safe_filename("../../etc/passwd") == "passwd.glb"  # cannot escape
+    assert mod._safe_filename("") is None
+    assert mod._safe_filename("..") is None

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -233,6 +233,14 @@ def _render_view(ws, tmp_path):
     assert out.exists() and out.stat().st_size > 0
 
 
+def _pull_viewer_deltas(ws, tmp_path):
+    # First pull on the seeded worker: both boxes are new, so they appear as
+    # upserts with tessellated meshes — proving the op reads worker geometry.
+    r = ws.pull_viewer_deltas()
+    assert "a" in r["upsert"] and "b" in r["upsert"]
+    assert r["remove"] == []
+
+
 # op name -> check function. The op name MUST match the dispatch/proxy op string.
 SESSION_STATEFUL_TOOLS = {
     "measure": _measure,
@@ -258,6 +266,7 @@ SESSION_STATEFUL_TOOLS = {
     "inspect_drawing": _inspect_drawing,
     "export_file": _export_file,
     "render_view": _render_view,
+    "pull_viewer_deltas": _pull_viewer_deltas,
 }
 
 # Dispatch ops deliberately NOT in the smoke inventory, each with the reason it


### PR DESCRIPTION
I was really glad to find build123d-mcp. It solves many of the problems I had
using build123d with an agent before. This is a small PR, and I mainly wanted to
see whether you are open to changes like this. If the approach works for you, I
am happy to add more functionality on top of it.

## What and why
build123d-mcp gives an agent fixed-viewpoint `render_view` PNGs. For work that
needs human spatial or aesthetic judgment, a still is a poor channel: you want to
grab the model and spin it as it changes. This PR adds an opt-in live viewer.
Start the server with `--viewer-socket PATH` and it streams the session's
geometry to a connected viewer over a Unix domain socket, updating after each
geometry-mutating tool call. The agent still gets its PNGs while a human watches
the model evolve.

This PR is the server-side publisher (the socket interface) only. A native viewer
window is left as a follow-up so the change stays small and free of new
dependencies. A minimal example consumer using only the standard library is
included.

## Why it is safe to merge
- **Inert by default.** With no `--viewer-socket`, nothing changes. When the flag
  is set but no viewer has attached, the agent path pays nothing (it skips
  tessellation and the worker round-trip entirely).
- **Never blocks the agent.** The publisher runs on a background daemon thread.
  Bounded, drop-oldest per-client buffers throttle a slow viewer rather than the
  producer.
- **No new dependencies.** It reuses the existing bounded out-of-process
  tessellation and encodes to glTF-binary (glb) with a small self-contained
  writer, so it adds no third-party package and keeps OCC and VTK out of the
  encode path.
- **Respects the worker boundary.** Only identity-changed shapes are tessellated,
  in the worker process where the geometry lives, and only vertex and triangle
  arrays cross the pipe. A worker restart emits `RESET` so clients drop a stale
  scene.
- **Outside the sandbox.** The socket lives in the server process, not the
  sandboxed `execute()` worker, so user code cannot reach it.
- POSIX only (AF_UNIX), validated and gated in the CLI.

## Protocol
Length-prefixed frames: `[u32 json_len][json][u32 bin_len][payload]`. Events are
`HELLO`, `UPSERT` (with a glb payload), `REMOVE`, and `RESET`. A viewer that
attaches mid-session receives `HELLO` followed by a full-scene dump. The full
spec is in `docs/live-viewer.md`.

## Testing
The full suite passes (`uv run pytest`, 826 passed), and ruff and mypy are clean.
New tests cover the glb encoder, the wire framing, publisher behaviour, and an
end-to-end path from `server.execute` through the worker to the socket.

## Not in scope, possible follow-ups
A graphical viewer (pyvista, or a browser three.js page over a UDS to WebSocket
bridge), session persistence and replay, and a viewer to server channel for
tweaking parameters from the viewer.
