### PR TITLE
docs: expand HTTP transport README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,36 @@ install_skill(target="agents-md", skill="drawing")    # engineering drawings fro
 
 ### HTTP transport (advanced)
 
-By default the server runs over **stdio** — one isolated session per client process. With `--transport http` it serves streamable-HTTP for web/embedded deployments.
+By default the server runs over **stdio** — one isolated session per client process. With `--transport http` it serves [Streamable HTTP](https://modelcontextprotocol.io/docs/concepts/transports) (via uvicorn/ASGI) for web/embedded deployments (a shared server, a Docker container, or a cloud instance):
+
+```bash
+uv tool run --python 3.12 build123d-mcp --transport http --host 0.0.0.0 --port 8000
+```
+
+Clients connect to `http://<host>:8000/mcp`.
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--transport http` | `BUILD123D_TRANSPORT=http` | `stdio` | Enable HTTP mode |
+| `--host ADDR` | `BUILD123D_HOST` | `127.0.0.1` | Bind address (`0.0.0.0` to expose externally) |
+| `--port N` | `BUILD123D_PORT` | `8000` | Listen port |
+
+**Claude Code with HTTP:**
+
+```json
+{
+  "mcpServers": {
+    "build123d-mcp": {
+      "type": "http",
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
 
 > ⚠️ **HTTP mode uses one shared CAD session for every request** unless your host installs middleware that sets a per-request `WorkerSession` on the `_session_var` contextvar (see `http_app()`). Do **not** expose HTTP mode to more than one user without that middleware — they would all read and mutate the same session state.
+
+> **Security note.** The server has no built-in authentication. When binding to `0.0.0.0`, place it behind a reverse proxy with auth (e.g. nginx + mTLS, or a VPN).
 
 ---
 


### PR DESCRIPTION
## What

Expands the **HTTP transport (advanced)** section of the README into one self-contained reference, merging the docs already on `main` with an in-progress local draft.

## Why

The shipped section (#293) carried the critical shared-session safety warning but lacked the practical run details; the local draft had those details but predated — and would have clobbered — the safety warning. This keeps both.

## Changes

Kept from `main`:
- stdio-vs-HTTP intro
- ⚠️ shared-session warning (`_session_var` / per-request `WorkerSession` middleware)

Added from the draft:
- `--transport http --host 0.0.0.0 --port 8000` run command + `http://<host>:8000/mcp` endpoint
- flag / env-var / default options table
- Claude Code HTTP client config JSON
- no-auth / reverse-proxy security note for binding to `0.0.0.0`

Docs-only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)