### PR TITLE
fix: serialise WorkerSession IPC so concurrent requests can't mispair (#322)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,20 @@ tools/export.py    — STEP/STL export; path traversal blocked
 - **Snapshots** save `current_shape` + `objects` only — the Python namespace is NOT restored on `restore_snapshot()`.
 - **`reset()`** clears everything: namespace, shapes, objects, snapshots.
 
+## Concurrency model
+
+- **A `WorkerSession` is single-threaded over its pipe.** `_call()` holds
+  `self._lock` across `send → poll → recv`, so concurrent callers serialise.
+  This matters under HTTP transport, where one shared `WorkerSession` fields
+  concurrent requests — without the lock, replies mispair. **Subclasses
+  override `_do_call`, not `_call`**, so they inherit the guard (e.g.
+  `InProcessSession`). See `docs/adr/0001-worker-ipc-concurrency.md` (#322).
+- **HTTP mode shares one CAD session by default.** The lock makes the sharing
+  *safe*, not *isolated* — concurrent clients still see one namespace.
+  Per-tenant isolation is an embedder concern via the `_session_var` contextvar
+  hook in `server.py`; the CLI does not ship multi-session middleware, and
+  building it is a deliberate non-goal until a real hosting requirement exists.
+
 ## Security model
 
 Three layers, all must pass before user code runs:

--- a/docs/adr/0001-worker-ipc-concurrency.md
+++ b/docs/adr/0001-worker-ipc-concurrency.md
@@ -1,0 +1,64 @@
+# ADR 0001 — WorkerSession IPC is serialised; multi-tenant isolation is the embedder's job
+
+- **Status:** Accepted
+- **Date:** 2026-06-28
+- **Issue:** #322 (concurrency bug); context from #268/#272 (HTTP transport)
+
+## Context
+
+`server.py` resolves every tool call to a `WorkerSession` (`worker.py`), a
+parent-side proxy that talks to a persistent worker subprocess (see
+[ADR 0002](0002-worker-subprocess-crash-containment.md)) over a single
+`multiprocessing.Pipe`. The session is *stateful by design*: the namespace,
+named objects, and snapshots accumulate across calls — that persistence is the
+product's core value.
+
+Two facts collide under the HTTP transport (`--transport http`, added in
+#268/#272):
+
+1. **One shared session.** With no per-request middleware installed (the
+   default), `server._resolve_session()` returns a single module-level
+   `WorkerSession` for *all* requests. The `_session_var` contextvar exists as
+   an extension hook, but the shipped CLI does not wire per-request sessions.
+2. **Concurrent execution.** The streamable-HTTP ASGI app fields requests
+   concurrently, and FastMCP runs the sync tool closures off the event loop.
+   So two requests can be inside `WorkerSession._call()` at the same time.
+
+`_call()` did `send -> poll -> recv` on the pipe with **no lock**. That pair is
+not atomic, so two concurrent callers could interleave and one could `recv()`
+the *other's* response — wrong result to the wrong caller, or a desynced IPC
+stream. This needs only one client issuing parallel/pipelined calls (or two
+tabs / two `curl`s); it is not a multi-tenant-only problem. The `--in-process`
+fallback shares one `Session`/OCC kernel across threads and has the same
+hazard.
+
+## Decision
+
+Two separate concerns, two separate answers:
+
+1. **IPC concurrency safety — fix now.** Serialise the request/reply critical
+   section with a `threading.Lock` held across `send -> poll -> recv -> restart`.
+   Subclasses override `_do_call`, not `_call`, so `InProcessSession` inherits
+   the same guard over its shared `Session`. A single OCC worker is serial
+   anyway, so serialising costs no real throughput.
+
+2. **Multi-tenant data isolation — do *not* build speculatively.** The shared
+   session-per-process model is intended for single-user web/embedded
+   deployments and is documented as such (README "HTTP transport"; the CLI
+   prints a single-shared-session warning). True multi-tenancy is a real
+   feature — stateful MCP sessions, a per-session worker subprocess with
+   lifecycle/eviction, and per-tenant resource caps — and a per-tenant OCC
+   subprocess is memory-heavy. It is left to embedders via the `_session_var`
+   hook until a concrete hosting requirement exists.
+
+## Consequences
+
+- Concurrent calls against one `WorkerSession` are now correct (serialised),
+  not subtly corruptible. Covered by `tests/test_worker_concurrency.py`.
+- Throughput is unchanged in practice (the worker was already serial).
+- HTTP mode remains single-CAD-session: concurrent clients still *share* state
+  (one namespace). That is by design — the lock makes the sharing safe, it does
+  not make sessions independent. Multi-user isolation still requires embedder
+  middleware on `_session_var`.
+- If multi-tenant CLI hosting becomes a goal, it is a new, larger piece of work
+  (session lifecycle + per-session worker pool + eviction), tracked separately.

--- a/docs/adr/0002-worker-subprocess-crash-containment.md
+++ b/docs/adr/0002-worker-subprocess-crash-containment.md
@@ -1,0 +1,68 @@
+# ADR 0002 — Geometry runs in a spawned worker subprocess for native-crash containment
+
+- **Status:** Accepted (retrospective — records the #21 design, reinforced by closing #137)
+- **Date:** 2026-06-28
+- **Issues:** #21 (persistent worker), #137 (opt-in ephemeral subprocess — rejected), #143 (`--in-process` fallback)
+
+## Context
+
+`execute()` runs model/LLM-authored code. The security sandbox has three
+layers (AST allowlist, restricted builtins, exec timeout) — but all three guard
+only *Python-level* behaviour. A native **OpenCASCADE (OCCT) segfault or hard
+abort cannot be caught**: no Python `try/except` or signal handler reliably
+recovers from a native crash. Run in-process, such a fault takes down the whole
+MCP server — and with it the persistent session (namespace, named objects,
+snapshots) that is the product's core value.
+
+OCC also runs its own native threads (TBB), which makes `fork()` unsafe:
+forking a process with live OCC/TBB threads can deadlock or corrupt state in the
+child.
+
+## Decision
+
+All geometry/OCC work runs in a **persistent worker subprocess**, created with
+the `multiprocessing` **spawn** context. The parent process (`WorkerSession` in
+`worker.py`) never imports or touches OCC; it proxies each operation to the
+worker over a `Pipe`. On either a worker crash or an operation timeout, the
+parent **SIGKILLs the worker and starts a fresh one**.
+
+Alternatives considered and rejected:
+
+- **In-process `exec()`** — simplest, but no native-crash containment. The
+  whole reason this ADR exists.
+- **Fork-per-call** — the original design (replaced in #21). Unsafe with live
+  OCC/TBB threads, and pays process-setup cost on every call.
+- **Opt-in ephemeral per-call subprocess** (proposed in #137) — an
+  `isolated=True` / `try` tool that spins up a fresh process per call.
+  Rejected: crash containment should be the **default for every call**, not an
+  opt-in path a caller must remember to use. The persistent-worker design
+  already contains crashes for *all* operations, so #137 was closed as
+  superseded.
+
+## Consequences
+
+- **Native crashes are contained by default.** An OCCT segfault kills the
+  worker, not the server; the parent detects the dead worker and restarts it.
+- **A SIGKILL destroys all session state.** This is the central tradeoff: every
+  worker restart — whether from a crash or a mere op-timeout — loses the
+  namespace, named objects, and snapshots. That single fact is the forcing
+  function behind a family of follow-ups:
+  - per-op timeout budgets so a slow-but-valid op doesn't needlessly nuke the
+    session (#214), and clear "state was lost" messaging on every restart path
+    (#215);
+  - pushing un-interruptible native calls **out of process, hard-bounded below
+    the op-timeout**, so a heavy render / mesh-check / defect-scan can't trip
+    the SIGKILL — render (#308), export mesh gate (#294/#295),
+    `locate_gate_defects` (#310);
+  - the general policy that no un-interruptible native call should run unbounded
+    in the worker (#307), and the cold-large-part short-timeout bug (#296).
+- **Spawn, not fork** — safe with OCC/TBB threads; the per-process startup cost
+  (re-importing OCC) is paid once and amortised because the worker is
+  persistent, not per-call.
+- **`--in-process` fallback** (#143) exists for MCP hosts that block
+  subprocess creation (e.g. some sandboxed Windows hosts). It runs OCC in the
+  server process and **explicitly trades away** crash containment and operation
+  timeouts — a documented degraded mode.
+- The shared worker pipe must be accessed serially — see
+  [ADR 0001](0001-worker-ipc-concurrency.md), which adds the lock this
+  architecture depends on under concurrent (HTTP) callers.

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -22,6 +22,7 @@ containment and no operation timeouts.
 import functools
 import inspect
 import multiprocessing
+import threading
 from collections.abc import Callable
 from typing import Any, NamedTuple, TypeVar, cast
 
@@ -358,6 +359,13 @@ class WorkerSession:
         self._no_sandbox = no_sandbox
         self._conn: Any = None
         self._proc: Any = None
+        # Serialises the request/reply critical section (send -> poll -> recv)
+        # over the single worker Pipe. Under HTTP transport one WorkerSession is
+        # shared across concurrent requests (FastMCP runs sync tools off the
+        # event loop); without this lock two threads can interleave on the pipe
+        # and one can recv() the other's response. A single OCC worker is serial
+        # anyway, so serialising costs no real throughput. (#322)
+        self._lock = threading.Lock()
         self._start_worker()
 
     @property
@@ -453,6 +461,13 @@ class WorkerSession:
             pass
 
     def _call(self, op: str, args: dict, timeout: int) -> Any:
+        # Serialise the IPC critical section so concurrent callers (HTTP shared
+        # session, pipelined clients) can't interleave on the pipe. Subclasses
+        # override _do_call, not _call, so they inherit this guard. (#322)
+        with self._lock:
+            return self._do_call(op, args, timeout)
+
+    def _do_call(self, op: str, args: dict, timeout: int) -> Any:
         if not self._proc.is_alive():
             self._start_worker()
             raise RuntimeError(
@@ -735,11 +750,13 @@ class InProcessSession(WorkerSession):
         # no process here, so always dispatch the real reset.
         return self._call("reset", {}, _SHORT_TIMEOUT)
 
-    def _call(self, op: str, args: dict, timeout: int) -> Any:
+    def _do_call(self, op: str, args: dict, timeout: int) -> Any:
         # Same error contract as the worker path: tool exceptions surface as
         # RuntimeError("TypeName: message"), mirroring worker_main's error
         # envelope. (Session.execute() handles ExecutionTimeout internally
         # and returns an error string, so no special-casing is needed here.)
+        # Inherits the base _call's lock, so concurrent requests can't run the
+        # one shared Session/OCC kernel re-entrantly. (#322)
         try:
             return _dispatch(self._session, op, args, self._library_index)
         except Exception as exc:

--- a/tests/test_worker_concurrency.py
+++ b/tests/test_worker_concurrency.py
@@ -1,0 +1,55 @@
+"""WorkerSession IPC must be concurrency-safe (issue #322).
+
+Under HTTP transport one WorkerSession is shared across concurrent requests
+(FastMCP runs sync tool closures off the event loop). The request/reply pair
+over the single worker Pipe (send -> poll -> recv) is not atomic, so without a
+lock two threads can interleave and one can recv() the other's response —
+returning the wrong result to the wrong caller. A threading.Lock in _call()
+serialises the critical section.
+
+This test fires many concurrent read-only measure() calls against one shared
+WorkerSession, each for a different named box with a distinct volume. measure()
+does not mutate session state, so the only way a call can return another box's
+measurement is a mispaired pipe reply. Without the lock this race is flaky;
+with it, deterministic.
+"""
+
+import concurrent.futures
+
+import pytest
+
+from build123d_mcp.worker import WorkerSession
+
+_N = 16
+
+
+@pytest.fixture
+def ws():
+    s = WorkerSession(exec_timeout=30)
+    # Box(i, 1, 1) has volume i, so every named object measures distinctly.
+    setup = "from build123d import *\n" + "".join(
+        f"show(Box({i}, 1, 1), 'b{i}')\n" for i in range(1, _N + 1)
+    )
+    s.execute(setup)
+    try:
+        yield s
+    finally:
+        s._kill_worker()
+
+
+def test_concurrent_calls_do_not_mispair_responses(ws):
+    names = [f"b{i}" for i in range(1, _N + 1)]
+    reference = {name: ws.measure(name) for name in names}
+    assert len(set(reference.values())) == _N, "objects must measure distinctly"
+
+    # Each name appears several times so threads genuinely contend on the pipe.
+    work = names * 4
+
+    def call(name):
+        return name, ws.measure(name)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as ex:
+        results = list(ex.map(call, work))
+
+    for name, got in results:
+        assert got == reference[name], f"response mispaired for {name}"

--- a/tests/test_worker_timeouts.py
+++ b/tests/test_worker_timeouts.py
@@ -10,6 +10,7 @@ These tests stub the pipe/process layer — no worker subprocess is spawned.
 """
 
 import inspect
+import threading
 
 import pytest
 
@@ -152,6 +153,7 @@ def _stubbed_session(conn, alive=True):
     ws._conn = conn
     ws._proc = _StubProc(alive=alive)
     ws._exec_timeout = 120
+    ws._lock = threading.Lock()
     ws._kill_worker = lambda: None
     ws._start_worker = lambda: None
     return ws


### PR DESCRIPTION
Closes #322.

## Problem

`WorkerSession._call()` did `send → poll → recv` over the single worker `Pipe` with **no lock**. Under HTTP transport one `WorkerSession` is shared across concurrent requests (FastMCP runs sync tool closures off the event loop), so two threads could interleave on the pipe and one could `recv()` the **other's** response — wrong result to the wrong caller, or a desynced IPC stream. Needs only one client issuing parallel/pipelined calls; not a multi-tenant-only problem. `InProcessSession` (the `--in-process` fallback) shared one `Session`/OCC kernel across threads with the same hazard.

## Fix

- Hold a `threading.Lock` across the request/reply critical section in `_call()`. Subclasses override `_do_call`, not `_call`, so `InProcessSession` inherits the guard. A single OCC worker is serial anyway, so no real throughput cost.
- **Out of scope:** multi-tenant data isolation — a deliberate embedder extension point via the `_session_var` contextvar, not this bug.

## Tests

- `tests/test_worker_concurrency.py` — fires 64 concurrent read-only `measure()` calls on distinct-volume boxes through one shared session and asserts every reply pairs with its own request (flaky without the lock, deterministic with it).
- `tests/test_worker_timeouts.py` — the `__new__`-based stubs now supply `_lock`.
- Full suite green: **817 passed**.

## Docs

- `docs/adr/0001-worker-ipc-concurrency.md` — the lock decision + why multi-tenancy is left to embedders.
- `docs/adr/0002-worker-subprocess-crash-containment.md` — retrospective ADR for the worker-subprocess crash-containment architecture this sits on (records #21, why #137's opt-in design was rejected, and the session-loss tradeoff).
- `CLAUDE.md` — new "Concurrency model" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)