### PR TITLE
fix: name-preserving STEP fallback via Compound-wrap retry (#327)

### DIFF
--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -95,19 +95,40 @@ def _write_step(shape, abs_path: str) -> None:
 
     build123d's ``export_step`` goes through ``STEPCAFControl_Writer`` (the CAF
     writer that carries colours/layers/names). On build123d 0.11.0 that path
-    raises ``RuntimeError: Failed to write STEP file`` on many imported-STEP-
-    derived solids that 0.10.0 wrote fine — observed on ~38% of editing-fixture
-    runs, where the agent imports a STEP and exports the (valid) edited solid.
-    The basic ``STEPControl_Writer`` writes the same geometry without trouble, so
-    fall back to it: a CAD scorer / downstream tool needs the geometry, not the
-    CAF labels/colours the basic writer drops. Geometry round-trips identically.
+    raises ``RuntimeError: Failed to write STEP file`` on a solid that came
+    straight from ``import_step`` (gumyr/build123d#1356) — observed on ~38% of
+    editing-fixture runs, where the agent imports a STEP and exports the (valid)
+    edited solid. Two fallbacks, best first:
+
+    1. **Wrap in a ``Compound`` and retry ``export_step``.** The same solid
+       writes through the CAF path once wrapped, so body names/colours survive.
+    2. **Raw ``STEPControl_Writer``.** Writes the geometry but drops CAF
+       names/colours.
+
+    Geometry round-trips identically in all three; a CAD scorer needs the
+    geometry, and the wrap retry additionally keeps the CAF metadata when it can.
     """
     from build123d import export_step
 
     try:
         export_step(shape, abs_path)
         return
-    except Exception:  # noqa: BLE001 - any high-level-writer failure → raw fallback
+    except Exception:  # noqa: BLE001 - high-level-writer failure → try the wrap retry
+        pass
+
+    # Wrap-and-retry (gumyr/build123d#1356). Constructing a Compound reparents its
+    # children, so save/restore ``shape.parent`` to keep the fallback free of side
+    # effects on the caller's shape (which may be the live session object).
+    try:
+        from build123d import Compound
+
+        _saved_parent = shape.parent
+        try:
+            export_step(Compound(children=[shape]), abs_path)
+            return
+        finally:
+            shape.parent = _saved_parent
+    except Exception:  # noqa: BLE001 - still failing → raw geometry-only fallback
         pass
 
     from OCP.IFSelect import IFSelect_ReturnStatus
@@ -117,8 +138,8 @@ def _write_step(shape, abs_path: str) -> None:
     writer.Transfer(shape.wrapped, STEPControl_AsIs)
     if writer.Write(abs_path) != IFSelect_ReturnStatus.IFSelect_RetDone:
         raise RuntimeError(
-            "Failed to write STEP file (build123d export_step and the raw "
-            "STEPControl_Writer fallback both failed)"
+            "Failed to write STEP file (build123d export_step, the Compound-wrap "
+            "retry, and the raw STEPControl_Writer fallback all failed)"
         )
 
 

--- a/tests/test_export_step.py
+++ b/tests/test_export_step.py
@@ -3,9 +3,11 @@
 build123d 0.11.0's high-level ``export_step`` (the ``STEPCAFControl_Writer`` path)
 raises ``RuntimeError: Failed to write STEP file`` on many imported-STEP-derived
 solids that 0.10.0 wrote fine — it hit ~38% of editing-fixture benchmark runs.
-``_write_step`` falls back to the basic ``STEPControl_Writer``, which writes the
-same geometry. These tests pin the happy path and the fallback (forced by making
-the high-level writer raise, so it's exercised on any build123d version).
+``_write_step`` first retries through a ``Compound`` wrapper (which keeps the CAF
+path working, so names/colours survive), then falls back to the basic
+``STEPControl_Writer`` (geometry only). These tests pin the happy path, the
+forced fallback (high-level writer made to raise, so it runs on any version), and
+the real reimported-solid regression.
 """
 
 import pytest
@@ -94,5 +96,30 @@ def test_export_step_raises_clearly_when_both_writers_fail(session, tmp_path, mo
             return IFSelect_ReturnStatus.IFSelect_RetFail
 
     monkeypatch.setattr("OCP.STEPControl.STEPControl_Writer", _Dead)
-    with pytest.raises(RuntimeError, match="both failed"):
+    with pytest.raises(RuntimeError, match="all failed"):
         export_file(session, "out", "step", object_name="part")
+
+
+def test_write_step_handles_reimported_solid(tmp_path):
+    """gumyr/build123d#1356: on build123d 0.11 ``export_step`` raises on a solid
+    that came straight from ``import_step``; ``_write_step`` must still write a
+    valid STEP (via the Compound-wrap retry) and must NOT mutate the caller's
+    shape. Cross-version: on 0.10 the primary path already works. No monkeypatch
+    — this exercises the real regression where the installed version has it.
+    """
+    from build123d import Box, export_step, import_step
+
+    from build123d_mcp.tools.export import _write_step
+
+    seed = tmp_path / "seed.step"
+    export_step(Box(10, 10, 10), str(seed))
+    s = import_step(str(seed))
+    parent_before = s.parent
+
+    out = tmp_path / "out.step"
+    _write_step(s, str(out))  # must not raise on either build123d version
+
+    assert s.parent is parent_before  # the fallback must not reparent the shape
+    back = import_step(str(out))
+    assert len(back.solids()) == 1
+    assert back.volume == pytest.approx(1000.0, rel=1e-3)


### PR DESCRIPTION
Closes #327.

## Problem

build123d 0.11.0 regresses `export_step` (the `STEPCAFControl_Writer` path) on a solid taken straight from `import_step` — [gumyr/build123d#1356](https://github.com/gumyr/build123d/issues/1356), confirmed a regression with OCCT held constant (works on 0.10.0, same `cadquery-ocp` 7.8.1.1). It hit ~38% of editing-fixture runs. `_write_step` previously fell straight back to the basic `STEPControl_Writer`, which writes the geometry but **silently drops CAF body names/colours**.

## Fix

Insert a middle rung in the fallback ladder:

```
export_step(shape)                       # primary
  ↓ fails
export_step(Compound(children=[shape]))  # NEW — recovers the CAF path, keeps names
  ↓ fails
raw STEPControl_Writer                   # last resort, geometry only
```

The same solid writes through the CAF path once wrapped, so body names survive. Constructing a `Compound` reparents its children, so the shape's `.parent` is saved/restored to keep the fallback side-effect-free on the live session object.

## Scope / impact

- **Benchmark-neutral.** Geometry round-trips identically through all three writers, and CADGenBench scores geometry, not body names. This is a correctness fix for named multi-body exports, not a scoring change.
- The name-preservation gain is specific to the 0.11 wrap path; on 0.10 a bare reimported solid loses its name on the primary path regardless (build123d behaviour).

## Verification

- New `test_write_step_handles_reimported_solid` exercises the **real** regression (no monkeypatch): wrap path on 0.11, primary on 0.10, asserts valid geometry round-trip **and** no parent mutation.
- Export tests pass on **both build123d 0.10.0 and 0.11.0** (5/5 each).
- Full suite: **818 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)