### PR TITLE
test: tools never return null/empty — the cold-start 'null' is a stream-parsing artifact (#344)

### DIFF
--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -368,3 +368,28 @@ def test_empty_worker_reports_missing_state():
             s.measure("a")
     finally:
         s._kill_worker()
+
+
+def test_tools_never_deliver_null_or_empty(seeded_ws):
+    """Invariant: a successful tool call always returns a non-empty string, never
+    None/"".
+
+    A bare `null` in a run stream is only ever the streaming `status=in_progress`
+    placeholder (which precedes every `status=completed` event) — never a tool's
+    actual return. This pins that build123d-mcp is not the source of a null
+    delivered to the model (field-report-#2 clarification). Covers in-worker and
+    subprocess-backed tools.
+    """
+    spec = json.dumps({"solid": {"count": 1, "valid": True}})
+    results = {
+        "measure": seeded_ws.measure("a"),
+        "validate": seeded_ws.validate("a"),
+        "locate_gate_defects": seeded_ws.locate_gate_defects("a"),  # subprocess-backed
+        "shape_compare": seeded_ws.shape_compare("a", "b"),  # subprocess-backed
+        "verify_spec": seeded_ws.verify_spec(spec=spec, object_name="a"),
+        "design_audit": seeded_ws.design_audit(),  # subprocess-backed
+        "session_state": seeded_ws.session_state(),
+        "script": seeded_ws.script(),
+    }
+    for name, r in results.items():
+        assert isinstance(r, str) and r.strip(), f"{name} returned null/empty: {r!r}"


### PR DESCRIPTION
Investigation of field report #2 (cold-start `null` on first subprocess-tool call) against the **actual run transcripts** on the pipeline machine: **there is no null bug.**

## Evidence
Every MCP tool call streams two events — `status=in_progress` (result: `null`, a placeholder) then `status=completed` (the real result). Counting only `completed`:
- `design_audit` (`v0360-xhigh-smoke15-p1da`, 13 fixtures): **0 null** — every call completed with a real report.
- `locate_gate_defects` (`v0359-xhigh-full`): **89 completed calls, 0 null.**

The `null` the reports saw is the `in_progress` placeholder; the model receives the `completed` result (the runs succeeded). So it's an **analysis/stream-parsing artifact**, not a runtime bug. (Field report #1's *classification* findings were real and are already fixed in #342; only the *null* claims were the misread.)

## This PR
Adds `test_tools_never_deliver_null_or_empty`: asserts every successful tool call (in-worker + subprocess-backed: measure/validate/locate/shape_compare/verify_spec/design_audit/session_state/script) returns a **non-empty string** — pinning that build123d-mcp is never the source of a bare null delivered to the model. Test-only; no behavior change.

Supersedes the abandoned #345 (which "fixed" the phantom null). Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)