### PR TITLE
fix: render_view VTK isolation runs a real subprocess, not dead daemon-fallback (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.66
+
+### Fixed
+
+- **`render_view` no longer destroys the session on a slow macOS VTK render (#357).** The VTK isolation subprocess never actually engaged in production: `_vtk_render_subprocess` short-circuited to an unbounded in-process render whenever `multiprocessing.current_process().daemon` was true — which is *always*, since the worker runs `daemon=True`, and a daemon can't spawn `multiprocessing` children. So every macOS `render_view` ran VTK in-process with no per-call timeout; the only backstop was the 120 s op-watchdog, which SIGKILLs the whole worker and wipes session state (variables, snapshots, named objects) when it fires. VTK now runs in a real `subprocess.run` (a `_vtk_render_subprocess_worker` entry point, mirroring the `_tessellate_subprocess` fix from #308) bounded by its own **`_VTK_BUDGET_S = 60`**; on overrun it raises a clean `RuntimeError` with the session intact. The in-process path is kept only for the genuine degraded-host case (`OSError` on subprocess creation, e.g. InProcessSession), not the daemon check. The op-watchdog `_RENDER_TIMEOUT` is raised 120 → 150 s so tessellation (75 s) + VTK (60 s) + a named 15 s margin stay under it and each stage's own guard always fires first. A budget timeout in either stage now surfaces directly instead of triggering `render_view`'s unbounded SVG (HLR) auto-fallback — after both stages are near their limits, running that fallback in the same op could itself blow the watchdog and defeat the guarantee. This also removes an intermittent `render_view` flake in the test suite (VTK state leaking across in-process renders).
+
 ## v0.3.65
 
 ### Fixed

--- a/src/build123d_mcp/_vtk_render_subprocess_worker.py
+++ b/src/build123d_mcp/_vtk_render_subprocess_worker.py
@@ -1,0 +1,38 @@
+"""Out-of-process VTK render worker for render_view on macOS (see tools/render.py).
+
+Run as ``python -m build123d_mcp._vtk_render_subprocess_worker <in.pkl> <out.png>``.
+``in.pkl`` holds the pickled render inputs (already-tessellated ``shape_data`` plus
+view parameters); the rendered PNG bytes are written to ``out.png``.
+
+Why a separate program (not ``multiprocessing``): the worker runs as a daemon, and
+daemon processes cannot spawn ``multiprocessing`` children — so the only way to
+bound VTK's macOS Cocoa render (which can freeze the window server / hang on first
+offscreen-context creation) is a real subprocess the parent can hard-kill via
+``subprocess.run(timeout=...)``. Mirrors ``_tessellate_subprocess`` (#357/#308).
+"""
+
+import pickle
+import sys
+
+
+def main(in_path: str, out_path: str) -> None:
+    from build123d_mcp.tools.render import _vtk_render_tesselated
+
+    with open(in_path, "rb") as f:
+        args = pickle.load(f)
+
+    png = _vtk_render_tesselated(
+        args["shape_data"],
+        args["direction"],
+        args["clip_plane"],
+        args["clip_at"],
+        args["azimuth"],
+        args["elevation"],
+        args["labels"],
+    )
+    with open(out_path, "wb") as f:
+        f.write(png)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/src/build123d_mcp/tools/render.py
+++ b/src/build123d_mcp/tools/render.py
@@ -80,6 +80,22 @@ _VALID_FORMATS = ("png", "svg", "dxf", "both")
 # OCC BRepMesh is un-interruptible, so this is the only way to bound it; the
 # worker is a daemon, so it must be a real subprocess, not multiprocessing.
 _TESS_BUDGET_S = 75
+# VTK's macOS render, likewise bounded in a real subprocess (#357). The two stages
+# run sequentially, so _TESS_BUDGET_S + _VTK_BUDGET_S + _RENDER_OVERHEAD_MARGIN_S
+# must stay <= WorkerSession._RENDER_TIMEOUT, so an overrun in either fires its own
+# clean guard before the parent's watchdog SIGKILLs the whole session. The margin
+# covers parent-side work (per-shape STEP export, pickle, subprocess spawn, PNG
+# read) that runs outside either budget; test_worker_timeouts pins the inequality.
+_VTK_BUDGET_S = 60
+_RENDER_OVERHEAD_MARGIN_S = 15
+
+
+class _RenderBudgetExceeded(RuntimeError):
+    """A render stage (tessellation or VTK) blew its own subprocess budget. Raised
+    instead of a bare RuntimeError so render_view can surface it directly rather
+    than spending the *remaining* op-budget on the unbounded SVG fallback — which,
+    after both stages are already near their limits, could push the op past the
+    parent watchdog and SIGKILL the session (the very failure the budgets prevent)."""
 
 
 def _resolve_shapes(session, objects: str):
@@ -383,21 +399,6 @@ def _vtk_render_tesselated(
             return f.read()
 
 
-def _vtk_subprocess_worker(
-    conn, shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-):
-    """Module-level worker for multiprocessing.Process (must be top-level to be picklable)."""
-    try:
-        png_bytes = _vtk_render_tesselated(
-            shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-        )
-        conn.send(("ok", png_bytes))
-    except Exception as exc:
-        conn.send(("error", f"{type(exc).__name__}: {exc}"))
-    finally:
-        conn.close()
-
-
 def _tessellate_in_process(shapes, tess) -> tuple[dict, list[str]]:
     """Tessellate in the current process — the fallback for hosts that block
     child-process creation (#143 / InProcessSession), where ``subprocess.run``
@@ -467,7 +468,7 @@ def _tessellate_shapes_bounded(shapes, tess) -> tuple[dict, list[str]]:
                 timeout=_TESS_BUDGET_S,
             )
         except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(
+            raise _RenderBudgetExceeded(
                 f"Rendering exceeded the {_TESS_BUDGET_S}s tessellation budget — this part is too "
                 "complex to render at this quality. Try quality='standard', render fewer objects, "
                 "or inspect it numerically with measure()/cross_sections()."
@@ -535,54 +536,84 @@ def _do_render_png(
 
 
 def _vtk_render_subprocess(
-    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels, timeout=100
+    shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels, timeout=_VTK_BUDGET_S
 ) -> bytes:
-    """Run VTK rendering in an isolated subprocess on macOS.
+    """Render the tessellated shapes with VTK in an isolated subprocess (macOS).
 
-    VTK's Cocoa backend touches the macOS window server on first context
-    creation, which freezes all GUI applications when called from a non-
-    foreground process. Isolating the render in a child process prevents the
-    freeze from locking the MCP server itself, and the timeout+kill ensures
-    the server always recovers even if VTK hangs permanently.
+    VTK's Cocoa backend touches the macOS window server on first context creation,
+    which can freeze GUI apps — and hang — when called from a non-foreground
+    process. Running it in a real ``subprocess.run`` child (a daemon worker cannot
+    spawn ``multiprocessing`` children — the #357 bug, where this whole isolation
+    silently degraded to an unbounded in-process render) both isolates the freeze
+    and hard-bounds the render: on ``timeout`` the child is killed and a clean
+    ``RuntimeError`` is raised, so the worker and its session survive instead of
+    the parent's ``_RENDER_TIMEOUT`` watchdog SIGKILLing the whole session.
 
-    The default timeout must stay below WorkerSession._RENDER_TIMEOUT (120s):
-    if both expire together, the parent wins the race and SIGKILLs the whole
-    worker — destroying session state — instead of this guard returning a
-    clean error with the session intact (issue #216).
+    ``timeout`` (``_VTK_BUDGET_S``) + ``_TESS_BUDGET_S`` must stay under
+    ``WorkerSession._RENDER_TIMEOUT`` so this guard always fires first.
     """
-    import multiprocessing
+    import os
+    import pickle
+    import subprocess
+    import sys
+    import tempfile
 
-    # Daemon processes cannot spawn children (Python restriction). When
-    # render_view is called from inside WorkerSession (which runs as daemon=True),
-    # fall back to running VTK directly in the current process.
-    if multiprocessing.current_process().daemon:
-        return _vtk_render_tesselated(
-            shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
-        )
-
-    parent_conn, child_conn = multiprocessing.Pipe(duplex=False)
-    p = multiprocessing.Process(
-        target=_vtk_subprocess_worker,
-        args=(child_conn, shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels),
-        daemon=True,
-    )
-    p.start()
-    child_conn.close()
-
+    work = tempfile.mkdtemp(prefix="b123d_vtk_")
+    in_pkl = os.path.join(work, "in.pkl")
+    out_png = os.path.join(work, "out.png")
     try:
-        if parent_conn.poll(timeout):
-            try:
-                kind, data = parent_conn.recv()
-            except (EOFError, OSError) as exc:
-                raise RuntimeError(f"VTK render subprocess died unexpectedly: {exc}") from exc
-            if kind == "error":
-                raise RuntimeError(data)
-            return data
-        raise RuntimeError(f"VTK render subprocess timed out after {timeout}s")
+        with open(in_pkl, "wb") as f:
+            pickle.dump(
+                {
+                    "shape_data": shape_data,
+                    "direction": direction,
+                    "clip_plane": clip_plane,
+                    "clip_at": clip_at,
+                    "azimuth": azimuth,
+                    "elevation": elevation,
+                    "labels": labels,
+                },
+                f,
+                protocol=pickle.HIGHEST_PROTOCOL,
+            )
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "build123d_mcp._vtk_render_subprocess_worker",
+                    in_pkl,
+                    out_png,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise _RenderBudgetExceeded(
+                f"VTK rendering exceeded the {timeout}s budget — the offscreen render did not "
+                "complete. Try quality='standard', render fewer objects, or a different direction."
+            ) from exc
+        except OSError:
+            # Host blocks child-process creation (#143 / InProcessSession): no
+            # subprocess, and no worker op-timeout to kill us — render in-process.
+            return _vtk_render_tesselated(
+                shape_data, direction, clip_plane, clip_at, azimuth, elevation, labels
+            )
+        if proc.returncode != 0 or not os.path.exists(out_png):
+            raise RuntimeError("VTK render subprocess failed: " + (proc.stderr or "")[-300:])
+        with open(out_png, "rb") as f:
+            return f.read()
     finally:
-        if p.is_alive():
-            p.kill()
-        p.join(timeout=5)
+        for p in (in_pkl, out_png):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+        try:
+            os.rmdir(work)
+        except OSError:
+            pass
 
 
 def _viewport_origin_for(direction: str, shapes, azimuth: float, elevation: float):
@@ -1158,6 +1189,11 @@ def render_view(
                 result["png_warnings"] = [
                     f"Skipped shapes (tessellation failed): {', '.join(png_failed)}"
                 ]
+        except _RenderBudgetExceeded:
+            # The render already consumed its hard budget; the unbounded SVG (HLR)
+            # fallback below could push the op past the parent watchdog and kill the
+            # session. Surface the clean budget error instead, session intact (#357).
+            raise
         except Exception as exc:
             if format == "png":
                 # Auto-fallback: produce SVG so the AI still gets a visual.

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -148,7 +148,15 @@ def worker_main(
 # 10s on complex parts, and a timeout here kills the worker and destroys all
 # session state — so the budget errs generous (issue #214). _SHORT_TIMEOUT is
 # only for ops that read session bookkeeping without touching geometry kernels.
-_RENDER_TIMEOUT = 120
+# Shared by render_view, render_drawing, health_check, and pull_viewer_deltas.
+# render_view is the binding case: it runs two hard-bounded subprocess stages back
+# to back — tessellation (_TESS_BUDGET_S=75) then VTK (_VTK_BUDGET_S=60) — so this
+# parent watchdog must exceed their sum + margin (150 = 75+60+15) for each stage's
+# own guard to fire first with the session intact; it never SIGKILLs a render on
+# time now, only a genuine hang elsewhere. The other three inherit it as pure slack
+# (render_drawing has no inner subprocess bound; the raster/input-size checks gate
+# it at ingest instead). (#357)
+_RENDER_TIMEOUT = 150
 # The export/geometry floor is shared with the tool side (tools/_budget.py) so a
 # worker-run tool's self-imposed budget provably tracks this parent op budget.
 _EXPORT_TIMEOUT = OP_BUDGET_FLOOR_S

--- a/tests/test_render_tessellation_bounded.py
+++ b/tests/test_render_tessellation_bounded.py
@@ -8,6 +8,7 @@ timeout it returns a clean error and the worker survives.
 """
 
 import subprocess
+import sys
 
 import pytest
 from build123d import Box
@@ -86,3 +87,96 @@ def test_tessellate_bounded_unreadable_pickle_is_clean_error(monkeypatch, tmp_pa
     monkeypatch.setattr(subprocess, "run", _run)
     with pytest.raises(RuntimeError, match="unreadable result"):
         _tessellate_shapes_bounded([("box", Box(10, 10, 10), None)], render._QUALITY["standard"])
+
+
+# --------------------------------------------------------------------------- #
+# VTK render is likewise bounded out-of-process (#357): the daemon worker can't
+# spawn a multiprocessing child, so isolation must go through subprocess.run —
+# the old daemon-check fallback silently ran VTK unbounded in-process, letting a
+# hung render blow the op-timeout and SIGKILL the whole session.
+# --------------------------------------------------------------------------- #
+
+from build123d_mcp.tools.render import _vtk_render_subprocess
+
+
+def _box_shape_data():
+    meshes, _ = _tessellate_shapes_bounded(
+        [("box", Box(10, 10, 10), None)], render._QUALITY["standard"]
+    )
+    return [("box", meshes["box"][0], meshes["box"][1], None)]
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="_vtk_render_subprocess is the macOS-only render path; Linux/Windows render in-process",
+)
+def test_vtk_render_subprocess_returns_png():
+    """A normal render goes through the real subprocess and returns valid PNG bytes."""
+    png = _vtk_render_subprocess(_box_shape_data(), "iso", "", None, 0.0, 0.0, None)
+    assert png[:8] == b"\x89PNG\r\n\x1a\n" and len(png) > 100
+
+
+def test_vtk_render_timeout_is_graceful(monkeypatch):
+    """A VTK render that overruns its budget raises a clean RuntimeError (child
+    killed) — it does NOT hang until the parent SIGKILLs the session."""
+    shape_data = _box_shape_data()  # tessellate for real BEFORE mocking subprocess.run
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="vtk", timeout=render._VTK_BUDGET_S)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+    with pytest.raises(RuntimeError, match="VTK rendering exceeded"):
+        _vtk_render_subprocess(shape_data, "iso", "", None, 0.0, 0.0, None)
+
+
+def test_vtk_render_reports_subprocess_failure(monkeypatch):
+    """A non-zero VTK subprocess exit surfaces a clear error, not a silent blank."""
+    shape_data = _box_shape_data()
+
+    class _Proc:
+        returncode = 1
+        stderr = "boom in the vtk worker"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc())
+    with pytest.raises(RuntimeError, match="VTK render subprocess failed"):
+        _vtk_render_subprocess(shape_data, "iso", "", None, 0.0, 0.0, None)
+
+
+def test_vtk_render_falls_back_in_process_when_subprocess_blocked(monkeypatch):
+    """On a host that blocks child-process creation (#143 / InProcessSession),
+    subprocess.run raises OSError — VTK must fall back to in-process rendering
+    (the genuine degraded-host case), NOT the old always-on daemon fallback."""
+    shape_data = _box_shape_data()
+
+    def _blocked(*args, **kwargs):
+        raise OSError("child processes disabled")
+
+    monkeypatch.setattr(subprocess, "run", _blocked)
+    monkeypatch.setattr(render, "_vtk_render_tesselated", lambda *a, **k: b"IN_PROCESS_PNG")
+    out = _vtk_render_subprocess(shape_data, "iso", "", None, 0.0, 0.0, None)
+    assert out == b"IN_PROCESS_PNG"
+
+
+def test_render_budget_timeout_does_not_trigger_svg_fallback(monkeypatch):
+    """A budget timeout surfaces cleanly — it must NOT run the unbounded SVG (HLR)
+    fallback, which after both stages are near their limits could push the op past
+    the parent watchdog and SIGKILL the session (#357)."""
+    from build123d_mcp.session import Session
+    from build123d_mcp.tools.render import _RenderBudgetExceeded, render_view
+
+    s = Session()
+    s.execute("from build123d import *")
+    s.execute("show(Box(10, 10, 10), 'b')\n")
+
+    def _budget_timeout(*a, **k):
+        raise _RenderBudgetExceeded("VTK rendering exceeded the 60s budget — too complex")
+
+    svg_called = []
+    monkeypatch.setattr(render, "_do_render_png", _budget_timeout)
+    monkeypatch.setattr(
+        render, "_do_render_svg", lambda *a, **k: (svg_called.append(True), b"<svg/>")[1]
+    )
+
+    with pytest.raises(_RenderBudgetExceeded, match="budget"):
+        render_view(s)
+    assert svg_called == []  # the unbounded SVG fallback must not have run

--- a/tests/test_worker_timeouts.py
+++ b/tests/test_worker_timeouts.py
@@ -184,9 +184,19 @@ def test_mid_call_crash_message_reports_session_loss():
 
 
 def test_vtk_subprocess_timeout_below_render_poll():
-    # If the inner guard and the parent's poll expire together, the parent
-    # SIGKILLs the worker and the session dies; the inner guard must win.
-    from build123d_mcp.tools.render import _vtk_render_subprocess
+    # If an inner guard and the parent's poll expire together, the parent SIGKILLs
+    # the worker and the session dies; both inner guards must win. render_view runs
+    # tessellation then VTK sequentially, so their budgets ADD against the parent's
+    # watchdog — the sum (plus margin) must stay under _RENDER_TIMEOUT.
+    from build123d_mcp.tools.render import (
+        _RENDER_OVERHEAD_MARGIN_S,
+        _TESS_BUDGET_S,
+        _VTK_BUDGET_S,
+        _vtk_render_subprocess,
+    )
 
     inner = inspect.signature(_vtk_render_subprocess).parameters["timeout"].default
-    assert inner < _RENDER_TIMEOUT
+    assert inner == _VTK_BUDGET_S
+    # The two stages run sequentially, so their budgets ADD, plus parent-side
+    # overhead — the sum + margin must stay within the parent watchdog.
+    assert _TESS_BUDGET_S + _VTK_BUDGET_S + _RENDER_OVERHEAD_MARGIN_S <= _RENDER_TIMEOUT


### PR DESCRIPTION
Closes #357.

## The bug
`_vtk_render_subprocess`'s isolation **never engaged in production**. It opened with `if multiprocessing.current_process().daemon: return _vtk_render_tesselated(...)` — an unbounded *in-process* render. But the worker runs `daemon=True`, and a daemon can't spawn `multiprocessing` children, so that branch was **always** taken: every macOS `render_view` ran VTK in-process with **no per-call timeout**. The only backstop was the 120 s op-watchdog, which SIGKILLs the whole worker and wipes session state (variables, snapshots, named objects) when it fires — the `render_view` session-kills that survived #308, and an intermittent flake in this very suite.

## The fix
VTK now runs in a real `subprocess.run` via a new `_vtk_render_subprocess_worker` entry point (mirroring `_tessellate_subprocess` / the #308 fix), bounded by its own **`_VTK_BUDGET_S = 60`**; on overrun it raises a clean error, session intact. The in-process path survives only for the genuine `OSError` degraded-host case (InProcessSession/#143), **not** the daemon check. `_RENDER_TIMEOUT` raised 120→150 so `tess(75) + vtk(60) + margin(15)` stay under it and each stage's own guard fires first.

## Hardened by an independent 4-prong adversarial review
All four prongs confirmed the core sound (byte-identical PNG parity, hard-kill + clean-error on every failure path, budget math holds, isolation genuinely engages in a real daemon worker with session survival). Four refinements applied from their findings:
- **Budget timeout no longer triggers the unbounded SVG fallback.** `render_view` fell back to an unbounded HLR-SVG render *in the same op* on any PNG failure — including a budget timeout, when both stages are already near their limits, which could itself blow the watchdog and defeat the guarantee. A new `_RenderBudgetExceeded` surfaces the clean error directly (also fixes the pre-existing tessellation-timeout case).
- **Named `_RENDER_OVERHEAD_MARGIN_S = 15`**; the invariant test now pins `tess + vtk + margin <= _RENDER_TIMEOUT` so the margin can't silently erode on a future budget bump.
- The macOS-only real-render test is **skipped off darwin** (production never uses that path there — avoids a red-CI surprise on Linux/Windows).
- `_RENDER_TIMEOUT`'s shared use across four render ops is documented.

## Trade-off
On macOS each render now spawns a subprocess (~1 s interpreter startup) — the same pattern tessellation already uses; Linux/Windows are unaffected (that path renders in-process).

## Tests
VTK returns-PNG (darwin), timeout/subprocess-failure/OSError-fallback, budget-timeout-skips-SVG-fallback, strengthened budget invariant. **916 passed** (the `render_view` flake is gone); ruff + mypy + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)