### PR TITLE
docs: surface the #366 composable primitives in the agent-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 ## Tools
 
 **Core**
-- `execute` — run build123d Python code in a persistent session; use `show(shape, name)` to register named parts
+- `execute` — run build123d Python code in a persistent session; use `show(shape, name)` to register named parts. The analysis functions (`measure`, `clearance`, `cross_sections`, `find_holes`, `find_bosses`, `find_countersinks`, `find_hole_patterns`, `align_check`) are also callable *in code* and return real Python objects — `measure(part)["volume"]`, `[h for h in find_holes(part) if h.location[0] < 5]` — so results compose without copying numbers between tool calls
 - `reset` — clear session back to empty state (namespace, shapes, snapshots)
 
 **Geometry inspection**

--- a/llms.md
+++ b/llms.md
@@ -28,6 +28,8 @@ If you see "Import of 'X' is not allowed" or "Call to 'Y' is not allowed", the u
 
 All tool calls share a single Python namespace. Variables and shapes you create with `execute` persist across subsequent calls. Use this to build geometry step by step, checking your work after each step.
 
+**Analysis composes in code.** `measure`, `clearance`, `cross_sections`, `find_holes`, `find_bosses`, `find_countersinks`, `find_hole_patterns`, and `align_check` are callable *inside* `execute` and return real Python objects (dicts / recogniser records), so you compute over results — `measure(part)["volume"]`, `[h for h in find_holes(part) if h.location[0] < 5]`, `clearance(a, b)["clearance"]` — instead of reading numbers out of one JSON tool result and re-typing them into the next call. They take a shape (default: `current_shape`); the standalone MCP tools of the same name remain for one-shot queries.
+
 ### Multi-object sessions
 
 Use `show(shape, name)` inside `execute` to register named objects. Calling `show()` also sets `current_shape`, so subsequent `measure()`/`export()`/`render_view()` calls work immediately without an explicit `result` assignment. All tools that accept `object_name` operate on a named object instead of the implicit `current_shape`. This is essential for assemblies where you need to inspect, measure, or export individual parts.

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -659,6 +659,11 @@ BUILD123D-MCP WORKFLOW GUIDE
    After building or modifying geometry, verify with measure() before calling render_view.
    Numbers are unambiguous; renders can look correct even when the geometry is wrong.
    Recommended order: execute → measure → render_view (if you need to see it).
+   Compose in code: measure/clearance/cross_sections/find_holes/find_bosses/
+   find_countersinks/find_hole_patterns/align_check are callable INSIDE execute() and
+   return real objects — measure(part)["volume"], [h for h in find_holes(part) if
+   h.location[0] < 5] — so filter/compute in code instead of copying numbers out of a
+   JSON tool result. The standalone tools remain for one-shot queries.
 
 3. VERIFY BOOLEAN OPERATIONS WITH TOPOLOGY
    After any cut, union, or intersection, call measure() and check topology.faces.

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -82,6 +82,15 @@ Finish by running `design_audit()` (Step 6) to prove the parameters are robust.
 
 `measure()` is the source of truth; renders confirm appearance, not geometry.
 
+**Compose in code, don't copy numbers.** The analysis functions are callable *inside*
+`execute()` and return real Python objects, so filter and compute in code instead of
+reading a number out of one tool result and re-typing it into the next call:
+`measure(part)["volume"]`, `[h for h in find_holes(part) if h.location[0] < 5]`,
+`clearance(a, b)["clearance"]`, `align_check(a, b)["delta"]`. Also available:
+`cross_sections`, `find_bosses`, `find_countersinks`, `find_hole_patterns`. They take a
+shape (default: current shape); `measure`/`clearance`/`cross_sections` stay bounded on
+large shapes. The standalone MCP tools remain for one-shot queries.
+
 - **After every boolean (`-`, `+`, `&`) call `measure()`** and check
   `topology.faces` changed. Unchanged face/edge counts mean the boolean
   silently failed.


### PR DESCRIPTION
Pre-release doc audit for v0.3.68 turned up one real gap: #366's composable analysis primitives (`measure`/`clearance`/`cross_sections`/`find_holes`/`find_bosses`/`find_countersinks`/`find_hole_patterns`/`align_check`, callable *in* `execute()` code) were documented **only** in the `execute()` tool docstring. Since the whole value of #366 is agents *learning to compose in code* (filter/compute over results instead of copying numbers between tool calls), leaving it untaught in the workflow docs would blunt the feature.

Surfaced it in the four places agents actually read the workflow:
- **modeling SKILL** — Step 3 ("Compose in code, don't copy numbers")
- **`workflow_hints`** — the MEASURE section (returned at session start)
- **llms.md** — the persistent-session section
- **README** — the `execute` entry

Additive, no behaviour change. Lint clean; `test_install_skill` (32) and the primitive tests pass; the only test reference to `workflow_hints` is its tool-name, so the content additions break nothing.

Everything else shipped in v0.3.68 was already documented (#367 README config section; #368 client-side, no doc; #359/#360/#362 covered in the prior release's docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)