### PR TITLE
feat: b123d-repair skill — a validity-gate repair cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`b123d-repair` skill: a validity-gate repair cookbook (`build123d://skill/repair`, `install_skill(skill="repair")`).** Until now the server could *diagnose* an invalid solid (`validate()` reasons, `locate_gate_defects()` coordinates) but offered no guidance on *fixing* one — and field runs show agents burning entire sessions failing to heal a BRepCheck-broken import that a known recipe repairs in minutes. The skill distills field-proven repairs from real defective parts into a defect-class-keyed escalation ladder: diagnose from the gate output first, then `ShapeFix_Shape` → clean-boolean re-computation → `BRepAlgoAPI_Defeaturing` → four-stage sliver-face surgery (ruled-face replace → drop+tolerant-sew → patch+small-sew → thin-box cut), plus the mesh-gate-only variant for unmeshable ~zero-area faces. Every rung states when it applies, when it fails, and what to try next, with the two observed silent-failure traps as mandatory checks (defeaturing filling an internal bore at +14% volume; booleans dropping the invalid solid). Includes the heal-FIRST workflow for editing an invalid import (a valid baseline exists on disk before the edit starts) and an avoidance section for the constructions that create these defects (exactly-coincident faces, tangencies). The `export()` gate-fail message now points at the skill — discovery at the moment of need.
+
 ## v0.3.68
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.69
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 - `repair_hints` — get targeted fix suggestions for a given `execute()` error message
 - `workflow_hints` — guidance on using the tools effectively
 - `script` — assemble a reproducible Python script from the session's executed code blocks
-- `install_skill` — copy a b123d workflow skill (modeling or drawing) into the current project
+- `install_skill` — copy a b123d workflow skill (modeling, drawing, or repair) into the current project
 
 ## Resources
 
@@ -302,6 +302,7 @@ Then install the workflow guidance into `AGENTS.md` so the agent follows the bui
 ```
 install_skill(target="agents-md", skill="modeling")   # 3D modeling from a spec / drawing
 install_skill(target="agents-md", skill="drawing")    # engineering drawings from geometry
+install_skill(target="agents-md", skill="repair")     # heal a solid that fails the validity gate
 ```
 
 (`install_skill` also supports `target="claude"`, `"cursor"`, and `"windsurf"`.)

--- a/llms.md
+++ b/llms.md
@@ -159,7 +159,7 @@ for repeated in-loop use.
 
 **Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `watertight_manifold`, `open_edges`, `nonmanifold_edges`, `mesh_nonmanifold_edges`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task). Watertightness/manifoldness is judged by the edge→face map (not build123d's `is_manifold`, which false-negates on imported solids) plus a bounded tessellated-mesh check that catches self-touching / coincident faces — valid B-reps that a CAD scorer still rejects.
 
-A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off.
+A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off. For an imported or damaged solid that keeps failing, read the `build123d://skill/repair` resource — a defect-class-keyed repair ladder (ShapeFix → boolean re-computation → defeaturing → sliver-face surgery) with export-gate verification at every step.
 
 `validate()` is not the final authority. It is deliberately cheaper than export:
 small parts get the exact mesh stitch, but large or expensive shapes may fall

--- a/src/build123d_mcp/cli.py
+++ b/src/build123d_mcp/cli.py
@@ -27,7 +27,7 @@ def _cmd_install_skill(argv: list) -> None:
         "--skill",
         choices=tuple(SKILLS),
         default="drawing",
-        help="Workflow to install: drawing or modeling (default: drawing)",
+        help=f"Workflow to install: {'/'.join(SKILLS)} (default: drawing)",
     )
     p.add_argument("--force", action="store_true", help="Overwrite existing installation")
     args = p.parse_args(argv)
@@ -50,21 +50,25 @@ def main():
     from importlib.metadata import version
 
     from build123d_mcp import server
+    from build123d_mcp.tools.install_skill import SKILLS
     from build123d_mcp.worker import InProcessSession, WorkerSession
 
     if len(sys.argv) > 1 and sys.argv[1] == "install-skill":
         _cmd_install_skill(sys.argv[2:])
         return
 
+    _skill_list = "/".join(SKILLS)
+    _skill_epilog = f"""\
+Subcommands:
+  install-skill     Copy a b123d workflow skill ({_skill_list}) into .claude/skills/ of the current project
+                    Usage: build123d-mcp install-skill [--skill {_skill_list}] [--force]
+"""
     parser = argparse.ArgumentParser(
         prog="build123d-mcp",
         description="MCP server for interactive 3D CAD via build123d. Communicates over stdio.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""\
-Subcommands:
-  install-skill     Copy a b123d workflow skill (drawing or modeling) into .claude/skills/ of the current project
-                    Usage: build123d-mcp install-skill [--skill drawing|modeling] [--force]
-
+        epilog=_skill_epilog
+        + """
 MCP client configuration example:
   {
     "mcpServers": {

--- a/src/build123d_mcp/security.py
+++ b/src/build123d_mcp/security.py
@@ -107,6 +107,7 @@ OCP_ALLOWLIST = frozenset(
         "OCP.BRepBuilderAPI",
         "OCP.BRepPrimAPI",
         "OCP.BRepFeat",
+        "OCP.BRepFill",
         "OCP.BRepFilletAPI",
         "OCP.BRepOffsetAPI",
         "OCP.BRepSweep",

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -22,8 +22,9 @@ Quick start: execute("from build123d import *"), build in small steps,
 register parts with show(part, "name"), measure() after every boolean,
 export() when done. Read the build123d://quickref resource before writing
 build code. Step-by-step workflows: build123d://skill/modeling (build 3D
-parts, incl. from technical drawings) and build123d://skill/drawing
-(multi-view engineering drawings); install either into the project with
+parts, incl. from technical drawings), build123d://skill/drawing
+(multi-view engineering drawings), and build123d://skill/repair (heal a
+solid that fails the validity gate); install any into the project with
 install_skill().
 """
 
@@ -943,6 +944,18 @@ def build123d_modeling_skill() -> str:
     return _load_raw("modeling")
 
 
+@mcp.resource(
+    "build123d://skill/repair",
+    mime_type="text/plain",
+    description="The b123d-repair workflow skill: step-by-step guide for healing a solid that fails the validity gate — diagnose the defect class from the gate output + locate_gate_defects(), then work a field-proven repair ladder (ShapeFix, boolean re-computation, defeaturing, sliver-face surgery), verifying every attempt with the export gate.",
+)
+def build123d_repair_skill() -> str:
+    """b123d-repair workflow skill."""
+    from build123d_mcp.tools.install_skill import _load_raw
+
+    return _load_raw("repair")
+
+
 @mcp.tool(annotations=_MUTATING)
 def install_skill(target: str = "claude", force: bool = False, skill: str = "drawing") -> str:
     """Copy a b123d workflow skill into the current project.
@@ -953,6 +966,7 @@ def install_skill(target: str = "claude", force: bool = False, skill: str = "dra
     skill: which workflow to install (default "drawing")
       - drawing   → multi-view engineering drawings from build123d geometry
       - modeling  → build 3D parts/assemblies (incl. from technical drawings)
+      - repair    → heal a solid that fails the validity gate
     target: one of "claude" (default), "agents-md", "cursor", "windsurf"
       - claude     → .claude/skills/<skill-dir>/SKILL.md  (Claude Code)
       - agents-md  → AGENTS.md  (Codex CLI, Antigravity, GitHub Copilot, Cline)

--- a/src/build123d_mcp/skills/b123d-repair/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-repair/SKILL.md
@@ -1,0 +1,218 @@
+# Repair Invalid Geometry with build123d (b123d-repair)
+
+Use this skill when `validate()` or the `export()` gate reports FAIL on a shape —
+an imported STEP that arrives broken, or a solid your own construction damaged —
+and the goal is a watertight, manifold, BRepCheck-valid solid that passes the
+export gate **without changing the geometry** beyond the defect itself.
+
+Every recipe here was proven on a real defective part; each entry says when it
+applies, when it fails, and what to try next. Work the ladder in order — the
+cheap fixes first — and verify every attempt with the **export gate**, not
+`validate()` alone (Step 2 explains why).
+
+---
+
+## Step 0 — Diagnose before cutting
+
+Do not apply repairs blind. First identify the defect class and its location.
+
+1. **Read the gate output precisely.** The FAIL reason names the class, and the
+   class picks the recipe:
+   - `B-rep is not well-formed (BRepCheck failed)` → a malformed face
+     (usually unorientable, zero-area, or reversed) — Step 1, rungs 1-4.
+   - `N open edge(s) — not watertight` → unsewn/missing faces — rungs 4-5.
+   - `N non-manifold edge(s)` → an edge shared by 3+ faces — usually a
+     coincident-face construction defect; prefer re-construction (Step 4)
+     over surgery.
+   - `mesh open edge(s)` / `mesh non-manifold` / `face(s) failed to
+     tessellate` **with `brep_valid: true`** → a mesh-only defect (a
+     ~zero-area unmeshable face, or a self-touch) — rung 5.
+2. **Get coordinates.** `locate_gate_defects()` returns the failing edge/face's
+   3D position and B-rep identity — repair that exact spot, never chase the
+   defect blind.
+3. **Localize the face** when BRepCheck is the failure:
+
+   ```python
+   from OCP.BRepCheck import BRepCheck_Analyzer
+   suspects = []
+   for i, f in enumerate(part.faces()):
+       if not BRepCheck_Analyzer(f.wrapped).IsValid() or abs(f.area) < 1e-6:
+           suspects.append((i, f.geom_type, round(f.area, 6), f.center()))
+   print(suspects)   # match centers against locate_gate_defects() coordinates
+   ```
+
+4. **Decide: inherited or self-introduced?** If the shape was valid before your
+   last operation, the defect is self-introduced — `restore_snapshot()` and
+   rebuild that step using the avoidance rules in Step 4 instead of operating
+   on the damaged result. Surgery is for defects you cannot construct away
+   (imported files, or upstream steps too expensive to redo).
+
+---
+
+## Step 1 — The repair ladder (cheapest first)
+
+Try each rung in order; verify with Step 2 after every attempt; stop at the
+first rung whose result passes the export gate.
+
+### Rung 1 — `ShapeFix_Shape` (seconds, non-destructive)
+
+Fixes reversed faces (a boolean can flip a distant face — e.g. a hole-bottom
+sphere reporting negative area) and zero-area sliver faces a boolean leaves
+elsewhere on an imported shape.
+
+```python
+from OCP.ShapeFix import ShapeFix_Shape
+fix = ShapeFix_Shape(part.wrapped)
+fix.Perform()
+healed = Part(fix.Shape())
+```
+
+Fails when: the face is genuinely unorientable (its own wire is inconsistent) —
+ShapeFix reports success but the export gate still FAILs. Move to rung 2.
+
+### Rung 2 — a clean boolean heals the B-rep
+
+A well-formed OCCT fuse forces a full re-computation of the shell and can heal a
+BRepCheck-invalid import as a side effect. Fuse with a small solid that
+interpenetrates the part somewhere harmless (or union two halves of the part).
+
+Cautions, both observed in the field:
+- **Booleans can silently DROP an invalid solid** — always check
+  `healed.volume` is within a fraction of a percent of the original.
+- On a **self-intersecting** import, build123d `Part` operators can inflate
+  volume; use the raw OCCT API on the bare solid instead:
+
+  ```python
+  from OCP.BRepAlgoAPI import BRepAlgoAPI_Fuse
+  op = BRepAlgoAPI_Fuse(part.solids()[0].wrapped, tool.wrapped)
+  op.Build()
+  healed = Part(op.Shape())
+  ```
+
+### Rung 3 — defeature the malformed face
+
+`BRepAlgoAPI_Defeaturing` removes the named face(s) and extends the neighbours
+to close the gap — the right tool when the defect is a discrete face and its
+neighbours are healthy. Also removes a feature's faces cleanly (grooves, bores)
+without plugging.
+
+```python
+from OCP.BRepAlgoAPI import BRepAlgoAPI_Defeaturing
+df = BRepAlgoAPI_Defeaturing()
+df.SetShape(part.wrapped)
+df.AddFaceToRemove(bad_face.wrapped)
+df.Build()
+healed = Part(df.Shape())
+```
+
+**Volume check is mandatory here**: defeaturing can silently *fill an internal
+bore* whose wall included the removed face (observed: +14% volume — a ruined
+part that passed the gate). Accept the heal only if the volume delta is on the
+scale of the defect itself, not of a feature.
+
+Fails when: the sliver's neighbours can't extend to close the gap, or the
+defeature output fails the gate. Move to rung 4.
+
+### Rung 4 — face surgery for an unorientable sliver
+
+Thin sliver faces (a degenerate fillet remnant, a band between near-coincident
+arcs) are the classic BRepCheck killer on imported castings. Escalate through
+these four, in order:
+
+1. **Replace with a ruled face.** Build a `BRepFill` ruled face between the
+   sliver's two long edges, drop the original, sew everything at small
+   tolerance. Works when the sliver's bounding edges are clean but its surface
+   is garbage.
+2. **Drop + tolerant sew.** When the sliver's own wire is broken (a ruled/fill
+   replacement comes out unorientable too), delete the face entirely and sew
+   the neighbours with **tolerance greater than the sliver's width** (e.g.
+   0.6 mm for a 0.5 mm sliver), then `ShapeFix_Solid` to orient the shell:
+
+   ```python
+   from OCP.BRepBuilderAPI import BRepBuilderAPI_Sewing
+   from OCP.ShapeFix import ShapeFix_Solid
+   sew = BRepBuilderAPI_Sewing(0.6)          # tol > sliver width
+   for f in part.faces():
+       if not f.wrapped.IsSame(bad_face.wrapped):
+           sew.Add(f.wrapped)
+   sew.Perform()
+   # wrap the sewn shell into a solid, then ShapeFix_Solid to orient it
+   ```
+
+3. **Patch + small-tolerance sew.** On a *wide* sliver (~2-3 mm), drop+sew
+   goes non-manifold (the big tolerance welds faces that shouldn't meet).
+   Instead fill the sliver's boundary wire with a `BRepFill` patch face and
+   sew at small tolerance.
+4. **Cut it out.** When the sliver is intrinsic to the geometry (a curved band
+   between two near-coincident arcs), in-memory fixes only *fake-heal* — the
+   gate fails again after the export round-trip. Remove the region physically:
+   boolean-subtract a thin box enclosing the sliver. This changes geometry by
+   the sliver's own (near-zero) volume, which is the point of last resort.
+
+### Rung 5 — mesh-gate-only failures (B-rep valid, mesh check FAILs)
+
+A BRepCheck-valid import can still fail the gate on a ~zero-area **unmeshable**
+face (often a degenerate BSpline): the tessellated boundary can't close. Drop
+that face (plus any adjacent unorientable sliver), sew, and `ShapeFix_Solid`
+to orient — rung 4's mechanics, triggered by the mesh reasons instead of
+BRepCheck. A zero-area *torus* remnant that fails only the export gate heals
+the same way.
+
+---
+
+## Step 2 — Verify every heal with the export gate
+
+- **The export gate is authoritative.** An in-memory heal can be fake:
+  `validate()` on the live shape passes, then the written-and-reimported STEP
+  fails. Always `export()` to a throwaway path and read its gate verdict; on
+  large shapes `validate()` may also fall back to a bounded fast mesh check,
+  so its PASS is a screen, not a verdict.
+- **A heal must not change the geometry.** Compare `volume` and bounding box
+  before/after: the acceptable delta is the scale of the defect (a sliver's
+  near-zero volume), never a feature's. A heal that gains or loses real volume
+  replaced your part with a different part.
+- **Never keep iterating on an invalid solid.** If a rung's attempt fails the
+  gate, `restore_snapshot()` back to the pre-attempt state before trying the
+  next rung — stacked failed repairs compound.
+- `save_snapshot()` before each rung so the above is one call.
+
+---
+
+## Step 3 — Editing an invalid import: heal FIRST, then edit
+
+When the task is to *modify* an imported part whose STEP is already invalid,
+do not interleave healing with editing:
+
+1. Import, `validate()`, and if it FAILs, run this skill's ladder **first**.
+2. When the healed import passes the export gate, `save_snapshot("valid_baseline")`
+   **and** `export()` it to the real output path — from this moment a valid
+   artifact exists on disk no matter what happens later.
+3. Then perform the requested edit on the healed baseline, re-validating after
+   each step as usual; re-export only on PASS.
+
+If a heavy heal (a large ShapeFix or boolean on a big import) exceeds the
+`execute()` timeout, run that one operation as a standalone script via the
+shell, then `import_cad_file()` the result back — same pattern as heavy builds.
+
+---
+
+## Step 4 — Don't introduce the defect in the first place
+
+Most self-made gate failures are one of these constructions; fix the
+construction, not the corpse:
+
+- **Exactly-coincident faces don't fuse.** A union whose faces are coplanar
+  with the base's (a box bottom flush with a feature's bottom, a boss butted
+  on a same-radius lobe, a thread root exactly on the bore wall) can pass
+  `validate()` and FAIL the export gate with non-manifold or open edges.
+  Interpenetrate: bury the added feature 1-2 mm into the base, make the
+  footprint 2-3 mm larger, or extend past and trim with one planar cut.
+- **Tangencies leave open edges.** A hole tangent to a coaxial hub wall, a
+  boss grazing a torus fillet — nudge the position ~0.3 mm or extend the boss
+  coaxial with the adjacent straight cylinder so the intersection is clean.
+- **Patterned features must fuse into one solid.** If fusing a fin/rib field
+  leaves two disjoint solids, bury each feature's base 1-2 mm so it
+  interpenetrates.
+- After every boolean, `measure()` and confirm face counts changed and volume
+  moved in the right direction — a silently-failed boolean is tomorrow's gate
+  failure.

--- a/src/build123d_mcp/skills/b123d-repair/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-repair/SKILL.md
@@ -30,14 +30,20 @@ Do not apply repairs blind. First identify the defect class and its location.
 2. **Get coordinates.** `locate_gate_defects()` returns the failing edge/face's
    3D position and B-rep identity — repair that exact spot, never chase the
    defect blind.
-3. **Localize the face** when BRepCheck is the failure:
+3. **Localize the face** when BRepCheck is the failure — build ONE analyzer
+   over the whole solid, not one per face (`locate_gate_defects()` itself
+   runs out-of-process specifically because per-face BRepCheck work "can run
+   for minutes on a complex part"; reconstructing an analyzer per face inside
+   `execute()` on a large import risks the same timeout):
 
    ```python
    from OCP.BRepCheck import BRepCheck_Analyzer
-   suspects = []
-   for i, f in enumerate(part.faces()):
-       if not BRepCheck_Analyzer(f.wrapped).IsValid() or abs(f.area) < 1e-6:
-           suspects.append((i, f.geom_type, round(f.area, 6), f.center()))
+   analyzer = BRepCheck_Analyzer(part.wrapped)   # one pass over the whole solid
+   suspects = [
+       (i, f.geom_type, round(f.area, 6), f.center())
+       for i, f in enumerate(part.faces())
+       if not analyzer.IsValid(f.wrapped) or abs(f.area) < 1e-6
+   ]
    print(suspects)   # match centers against locate_gate_defects() coordinates
    ```
 
@@ -69,6 +75,15 @@ healed = Part(fix.Shape())
 
 Fails when: the face is genuinely unorientable (its own wire is inconsistent) —
 ShapeFix reports success but the export gate still FAILs. Move to rung 2.
+
+This rung operates on the whole shape, so it's the one place this ladder's
+"only touch the defect" discipline needs a caveat: the standing rule to
+**prefer targeted solid repair over broad shape healing** (global healing
+can reorient faces or collapse volume) still applies here. Treat `healed`
+as a candidate, not the result — the Step 2 volume/bbox check is what makes
+this rung safe to try first; if it moves anything beyond the defect's own
+faces, discard it and go straight to rung 3 (defeature), which is targeted
+by construction.
 
 ### Rung 2 — a clean boolean heals the B-rep
 
@@ -131,12 +146,15 @@ these four, in order:
    ```python
    from OCP.BRepBuilderAPI import BRepBuilderAPI_Sewing
    from OCP.ShapeFix import ShapeFix_Solid
+   from OCP.TopoDS import TopoDS
    sew = BRepBuilderAPI_Sewing(0.6)          # tol > sliver width
    for f in part.faces():
        if not f.wrapped.IsSame(bad_face.wrapped):
            sew.Add(f.wrapped)
    sew.Perform()
-   # wrap the sewn shell into a solid, then ShapeFix_Solid to orient it
+   shell = TopoDS.Shell_s(sew.SewedShape())       # sewn result -> TopoDS_Shell
+   solid = ShapeFix_Solid().SolidFromShell(shell)  # orient into a proper solid
+   healed = Part(solid)
    ```
 
 3. **Patch + small-tolerance sew.** On a *wide* sliver (~2-3 mm), drop+sew

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -271,7 +271,8 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
         if gate_shape is None:
             suffix += (
                 "\n⚠ VALIDITY GATE FAIL — the written STEP could not be re-imported; "
-                "a CAD scorer would reject this file (score zero). Fix the solid and re-export."
+                "a CAD scorer would reject this file (score zero). Fix the solid and re-export "
+                "(the build123d://skill/repair resource has the defect-class repair ladder)."
             )
         elif step_path is not None:
             # Run the mesh check OUT OF PROCESS for STEP exports. The mesh stitch is
@@ -302,7 +303,8 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
                 suffix += (
                     "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
                     + "; ".join(report["reasons"])
-                    + ". Fix the solid and re-export (run validate() for detail)."
+                    + ". Fix the solid and re-export (run validate() for detail; the "
+                    "build123d://skill/repair resource has the defect-class repair ladder)."
                 )
             elif report.get("mesh_check") == "skipped":
                 suffix += (
@@ -317,7 +319,8 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
                 suffix += (
                     "\n⚠ VALIDITY GATE FAIL — a CAD scorer would reject this file (score zero): "
                     + "; ".join(report["reasons"])
-                    + ". Fix the solid and re-export (run validate() for detail)."
+                    + ". Fix the solid and re-export (run validate() for detail; the "
+                    "build123d://skill/repair resource has the defect-class repair ladder)."
                 )
 
         # A single solid must land as a single STEP product. The #1356 ``Compound``

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -1,8 +1,9 @@
 """install_skill — write a b123d workflow skill to a project's agent config.
 
-Two skills are available:
+Three skills are available:
   drawing   → b123d-drawing  (multi-view engineering drawings from geometry)
   modeling  → b123d-modeling (build 3D parts/assemblies via the MCP session)
+  repair    → b123d-repair   (heal a solid that fails the validity gate)
 
 Supports four targets:
   claude     → .claude/skills/<skill-dir>/SKILL.md
@@ -32,6 +33,16 @@ SKILLS = {
         "cursor_description": (
             "3D CAD modeling workflow: build parts and assemblies with build123d "
             "via the build123d-mcp MCP server"
+        ),
+        # No path affinity — the rule is routed by description (agent-requested).
+        "cursor_globs": "",
+    },
+    "repair": {
+        "dir": "b123d-repair",
+        "cursor_description": (
+            "CAD geometry repair workflow: heal a solid that fails the validity "
+            "gate (BRepCheck / open edges / non-manifold / mesh defects) with the "
+            "build123d-mcp MCP server"
         ),
         # No path affinity — the rule is routed by description (agent-requested).
         "cursor_globs": "",

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -989,4 +989,6 @@ def _validate_report(shape) -> str:
         summary += " — " + "; ".join(report["reasons"])
     if report["warnings"]:
         summary += " (warning: " + "; ".join(report["warnings"]) + ")"
+    if not report["passes_gate"]:
+        summary += " — the build123d://skill/repair resource has the defect-class repair ladder"
     return summary + "\n" + json.dumps(report, indent=2)

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from build123d_mcp.tools.install_skill import (
     _END,
     _START,
+    SKILLS,
     TARGETS,
     _dest_exists,
     _load_raw,
@@ -72,7 +73,7 @@ def test_shipped_skills_have_no_personal_markers():
     """[SEND:]/[ASK:] are conventions of the maintainer's own client setup —
     the claude install target ships SKILL.md verbatim, so the source files
     must spell the instructions out in plain English instead."""
-    for skill in ("drawing", "modeling"):
+    for skill in SKILLS:
         raw = _load_raw(skill)
         assert "[SEND:" not in raw, f"{skill} skill contains a [SEND:] marker"
         assert "[ASK:" not in raw, f"{skill} skill contains an [ASK:] marker"

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -38,6 +38,12 @@ def test_load_raw_modeling_returns_skill_content():
     assert len(content) > 1000
 
 
+def test_load_raw_repair_returns_skill_content():
+    content = _load_raw("repair")
+    assert "Repair Invalid Geometry" in content
+    assert len(content) > 1000
+
+
 # ---------------------------------------------------------------------------
 # _strip_claude_markers
 # ---------------------------------------------------------------------------
@@ -274,10 +280,39 @@ def test_install_cursor_modeling_description_routed(tmp_path):
     assert "globs" not in content.split("---")[1]
 
 
+def test_install_claude_repair(tmp_path):
+    result = install_skill(target="claude", cwd=tmp_path, skill="repair")
+    dest = tmp_path / ".claude" / "skills" / "b123d-repair" / "SKILL.md"
+    assert dest.exists()
+    assert "Repair Invalid Geometry" in _read(dest)
+    assert "Installed" in result
+
+
+def test_agents_md_all_three_skills_coexist(tmp_path):
+    install_skill(target="agents-md", cwd=tmp_path, skill="drawing")
+    install_skill(target="agents-md", cwd=tmp_path, skill="modeling")
+    install_skill(target="agents-md", cwd=tmp_path, skill="repair")
+    content = _read(tmp_path / "AGENTS.md")
+    assert content.count("<!-- b123d-drawing:start -->") == 1
+    assert content.count("<!-- b123d-modeling:start -->") == 1
+    assert content.count("<!-- b123d-repair:start -->") == 1
+    assert "Repair Invalid Geometry" in content
+
+
+def test_install_cursor_repair_description_routed(tmp_path):
+    install_skill(target="cursor", cwd=tmp_path, skill="repair")
+    content = _read(tmp_path / ".cursor" / "rules" / "b123d-repair.mdc")
+    assert "description:" in content
+    assert "alwaysApply: false" in content
+    # repair has no path affinity — no globs line at all
+    assert "globs" not in content.split("---")[1]
+
+
 def test_dest_exists_tracks_skills_independently(tmp_path):
     install_skill(target="claude", cwd=tmp_path, skill="drawing")
     assert _dest_exists("claude", cwd=tmp_path, skill="drawing")
     assert not _dest_exists("claude", cwd=tmp_path, skill="modeling")
+    assert not _dest_exists("claude", cwd=tmp_path, skill="repair")
 
 
 def test_unknown_skill_returns_error():
@@ -298,7 +333,7 @@ def test_server_instructions_registered():
 
     assert mcp.instructions == _INSTRUCTIONS
     assert 0 < len(_INSTRUCTIONS.encode("utf-8")) <= 2048
-    for needle in ("execute()", "measure()", "skill/modeling", "skill/drawing"):
+    for needle in ("execute()", "measure()", "skill/modeling", "skill/drawing", "skill/repair"):
         assert needle in _INSTRUCTIONS
 
 
@@ -310,6 +345,7 @@ def test_modeling_skill_resource_registered():
     uris = {str(r.uri) for r in asyncio.run(mcp.list_resources())}
     assert "build123d://skill/modeling" in uris
     assert "build123d://skill/drawing" in uris
+    assert "build123d://skill/repair" in uris
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The server can *diagnose* an invalid solid — `validate()` names the defect class, `locate_gate_defects()` gives its coordinates — but offers no guidance on *fixing* one. `repair_hints` covers Python/API errors, not geometry. Field evidence from the latest full CADGenBench sweep: fixture 217 (BRepCheck-broken imported STEP) burned its **entire session** on failed heal attempts — 22 straight `validate()` FAILs — and shipped invalid, scoring zero. Every recipe that would have healed it is known, proven on real defective parts across many logged runs… and lived in no document an agent could read.

## What

A third workflow skill, `b123d-repair`, wired identically to `b123d-modeling`/`b123d-drawing`:

- **`src/build123d_mcp/skills/b123d-repair/SKILL.md`** — the cookbook (details below)
- `install_skill(skill="repair")` + SKILLS entry (claude / agents-md / cursor / windsurf targets all work)
- **`build123d://skill/repair`** resource
- `_INSTRUCTIONS` mention (1181 bytes total — under the 2 KB cap the test enforces)
- README + llms.md pointers
- **The `export()` gate-FAIL messages now point at the skill** — discovery at the moment of need, when the agent is staring at a failure it doesn't know how to fix

## The cookbook

Structured as **diagnose → escalation ladder → verify**, keyed by defect class from the gate output:

- **Step 0 — diagnose before cutting**: read the FAIL reason (BRepCheck / open edges / non-manifold / mesh-only each route differently), `locate_gate_defects()` for coordinates, per-face `BRepCheck_Analyzer` sweep to localize, and the *inherited vs self-introduced* fork (self-made defects want `restore_snapshot()` + reconstruction, not surgery).
- **Step 1 — the ladder, cheapest first**: `ShapeFix_Shape` → clean-boolean re-computation → `BRepAlgoAPI_Defeaturing` → four-stage sliver-face surgery (ruled-face replace → drop+tolerant-sew → patch+small-sew → thin-box local cut) → the mesh-gate-only variant for unmeshable ~zero-area faces. **Every rung states when it applies, when it fails, and which rung to try next.**
- **The two observed silent-failure traps are mandatory checks**, not footnotes: defeaturing silently filling an internal bore (+14% volume — the failure that shelved #303's auto-heal), and booleans silently dropping the invalid solid.
- **Step 2 — verify with the export gate**, never `validate()` alone: covers both the in-memory fake-heal round-trip problem and the large-shape fast-fallback screen.
- **Step 3 — heal-FIRST for editing an invalid import**: get a gate-PASSing baseline snapshot *and* export on disk before attempting the edit, so a valid artifact always exists.
- **Step 4 — avoidance**: the constructions that create these defects in the first place (exactly-coincident faces, tangencies, disjoint pattern fields).

Every recipe traces to a successful heal on a real defective part; collectively they cover the in-session heals behind a 100%-validity 81-fixture run (including all three known BRepCheck-invalid inputs).

## Tests

- Repair variants of the install_skill suite: `_load_raw`, claude/cursor/agents-md installs, three-skill coexistence in shared files, `dest_exists` independence, resource registration, `_INSTRUCTIONS` needle — **36/36 `test_install_skill.py` pass**
- Full suite: **959 passed**; the 11 initially-failing tests reduce to 9 path-traversal tests that **fail identically on clean `main` in this environment** (checkout under `/private/tmp`, where macOS's `/tmp` symlink trips the traversal guards) — verified by stash/checkout-main/re-run before pushing; unrelated to this change
- ruff + mypy + `ruff format --check` clean

## Related

- #382 — follow-up design for a *mechanism*-level `recover()` (this PR is the judgment layer; sequencing per that issue is skill-first, observe a run, then decide)
- #303 — the shelved auto-heal whose post-mortem ("the honest shape of this tool is advisory") this implements the advisory half of
- #381 — validate()'s large-shape accuracy gap, the other half of the validity story

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoMwBwMcpmgQeHGtd6MWSr