### PR TITLE
test: warm build123d before design audit baseline

### DIFF
--- a/src/build123d_mcp/_design_audit_subprocess.py
+++ b/src/build123d_mcp/_design_audit_subprocess.py
@@ -32,6 +32,11 @@ _BASELINE_CAP_FACTOR = 4
 _MIN_PERTURB_S = 8
 
 
+def _warm_build123d_import() -> None:
+    """Load build123d before timing the baseline rebuild."""
+    __import__("build123d")
+
+
 def _const_number(node):
     """Return the numeric value of a constant / signed-constant node, else None.
 
@@ -284,6 +289,8 @@ def run_audit(
         with open(tmp, "w") as f:
             json.dump(state, f)
         os.replace(tmp, out_path)
+
+    _warm_build123d_import()
 
     # Baseline gets the full per-run budget (it may be the heaviest single build);
     # time it so perturbations can be capped relative to it.

--- a/tests/test_design_audit_subprocess.py
+++ b/tests/test_design_audit_subprocess.py
@@ -1,0 +1,51 @@
+"""Unit tests for the design_audit subprocess budget accounting."""
+
+import build123d_mcp._design_audit_subprocess as subprocess_mod
+
+
+def test_import_warmup_not_counted_in_baseline_cap(tmp_path, monkeypatch):
+    class Clock:
+        now = 100.0
+
+        def monotonic(self):
+            return self.now
+
+        def advance(self, seconds):
+            self.now += seconds
+
+    clock = Clock()
+    caps = []
+    warmed = {"done": False}
+
+    def warm_import():
+        clock.advance(10)
+        warmed["done"] = True
+
+    def evaluate_program(_program, cap_s):
+        if not warmed["done"]:
+            clock.advance(10)
+            warmed["done"] = True
+        caps.append(cap_s)
+        clock.advance(1)
+        return {
+            "rebuilt": True,
+            "passes_gate": True,
+            "n_solids": 1,
+            "volume": 100.0,
+            "reasons": [],
+        }
+
+    monkeypatch.setattr(subprocess_mod.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(subprocess_mod, "_warm_build123d_import", warm_import)
+    monkeypatch.setattr(subprocess_mod, "evaluate_program", evaluate_program)
+
+    subprocess_mod.run_audit(
+        "t = 10.0\n",
+        [{"name": "t", "value": 10.0, "type": "float"}],
+        0.1,
+        60,
+        60,
+        str(tmp_path / "audit.json"),
+    )
+
+    assert caps == [50, 8, 8]


### PR DESCRIPTION
This adds a lightweight build123d warm-up step before design audit timing so timing checks are stable and less flaky.

It also keeps the same test coverage and command behavior and is scoped to the validation/export path.