### PR TITLE
docs: validate export gate gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ When using an AI to write build123d scripts, the AI writes blind — it cannot s
 
 **Import / export**
 - `export` — export as STEP / STL / DXF / SVG (or comma-separated like `step,stl`); auto-detects 2D vs 3D shape and routes to the appropriate format; targets a named object, the current shape, or `*` for all objects as an assembly
+- `validate` — fast pre-export validity screen. `export` repeats the gate with a
+  stricter, larger-budget check and is the authoritative verdict, so test-export
+  important parts before finalizing if the geometry has coincident faces,
+  near-tangent joins, or large imported B-reps
 - `import_cad_file` — load a STEP or STL file as a named object for comparison
 
 **Comparison**

--- a/default_prompt.md
+++ b/default_prompt.md
@@ -30,6 +30,10 @@ Follow this order — deterministic checks before visual:
 2. **After assembly positioning** — call `clearance()` between mating parts. Status should be `touching` or `apart`, not `interpenetrating`.
 3. **Only after (1) and (2) pass** — call `render_view()`.
 4. **Before finishing a parametric part** — call `design_audit()`. It surfaces the program's named numeric parameters and nudges each ±10%, re-running the validity gate, so you ship an *editable design* and not just a valid *shape*. A parameter flagged `brittle` (a small change that collapses the solid or fails the gate) is a design weakness worth fixing; if it reports "no named parameters", hoist your key dimensions into a top-of-program parameter block and re-run.
+5. **Before final export** — call `validate()`, then `export()` to a throwaway
+   path if the part is important. `validate()` is a fast in-loop screen;
+   `export()` runs the stricter authoritative gate and can still reject rare
+   coincident-face or near-tangent cases that passed validation.
 
 **When to render:** assembling parts for the first time; after fillet/shell/loft; when the user asks to see something specific. Do not render after a simple boolean that `measure()` already confirmed.
 
@@ -81,6 +85,22 @@ show(axle, "axle")
 
 - Use `quality="high"` when inspecting cylindrical surfaces or small features — it reduces tessellation artefacts.
 - Use `clip_plane="y"` (or `"x"` / `"z"`) to slice through the model and inspect internal geometry such as bores and wall thicknesses without exporting.
+- On large imported models, high-quality or clipped renders can hit the operation
+  timeout. Use `measure()`/`cross_sections()` first, then render the smallest
+  targeted view you need.
+
+## Geometry gotchas
+
+- Avoid large point grids with `is_inside()`; use `cross_sections()` or clipped
+  renders to inspect interiors.
+- For holes on curved or BSpline faces, use the bore axis returned by
+  `find_holes`. Face centers and bounding-box centers can be off-axis.
+- Do not rely on exactly coincident additive faces fusing cleanly. Interpenetrate
+  slightly, bury the feature into the base, or extend-and-trim with one planar
+  cut.
+- Prefer targeted solid repair for imports. Broad shape healing can reorient
+  faces or collapse volume; if a repair or boolean exceeds the worker timeout,
+  run that heavy operation separately, re-import, and verify.
 
 ## Snapshots
 

--- a/llms.md
+++ b/llms.md
@@ -150,13 +150,24 @@ Prefer `measure()` over `render_view()` for verifying geometry — numbers are u
 ---
 
 ### `validate`
-Check whether a shape would pass a CAD validity gate before exporting it. The gate mirrors what CAD scorers and downstream tools require — a well-formed (BRepCheck), watertight, manifold solid with non-zero volume.
+Run a fast validity screen before exporting. It checks the same classes of
+failure that CAD scorers and downstream tools reject — a well-formed
+(BRepCheck), watertight, manifold solid with non-zero volume — but it is tuned
+for repeated in-loop use.
 
 **Input:** `object_name` (string, default `""`) — named object from `show()`; empty = `current_shape`
 
-**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `watertight_manifold`, `open_edges`, `nonmanifold_edges`, `mesh_nonmanifold_edges`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task). Watertightness/manifoldness is judged by the edge→face map (not build123d's `is_manifold`, which false-negates on imported solids) plus a welded tessellated-mesh check that catches self-touching / coincident faces — valid B-reps that a CAD scorer still rejects.
+**Returns:** a `PASS`/`FAIL` line plus JSON: `passes_gate`, `n_solids`, `volume`, `watertight_manifold`, `open_edges`, `nonmanifold_edges`, `mesh_nonmanifold_edges`, `brep_valid`, `reasons` (fatal failure causes), and `warnings` (non-fatal advisories — e.g. multiple disjoint solid bodies, which pass the gate but hurt the topology score on a single-part task). Watertightness/manifoldness is judged by the edge→face map (not build123d's `is_manifold`, which false-negates on imported solids) plus a bounded tessellated-mesh check that catches self-touching / coincident faces — valid B-reps that a CAD scorer still rejects.
 
-A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off; `export()` re-runs the gate and warns on a 3D export that would fail.
+A `FAIL` means a STEP/STL export would be rejected outright (a CAD scorer like CADGenBench scores it zero) — typically a leftover 2D sketch or open shell as the current shape, an un-fused compound, or a degenerate boolean result. Run this immediately before `export()` on any part you intend to submit or hand off.
+
+`validate()` is not the final authority. It is deliberately cheaper than export:
+small parts get the exact mesh stitch, but large or expensive shapes may fall
+back to the fast mesh screen to avoid timing out an interactive session.
+`export()` runs the slower, stricter pre-export gate with a larger budget and is
+the authoritative verdict. Expect rare `validate()` PASS → `export()` warning or
+failure outcomes on coincident faces, near-tangent joins, or large imported
+B-reps; test-export to a throwaway path before finalizing.
 
 ---
 
@@ -530,6 +541,23 @@ All units are millimetres by default.
 - **Dirty session:** unexpected results often mean leftover state. Call `reset` first, or `session_state` to inspect what's active.
 - **Boolean succeeded but geometry is wrong:** always call `measure()` after a boolean and check `topology.faces` — a failed cut leaves counts unchanged.
 - **Using render_view as geometric proof:** renders can look correct even when geometry is wrong. Use `measure()` to verify numerically first.
+- **Point-grid `is_inside()` on large solids:** thousands of point probes are slow
+  and can hit the operation timeout. Prefer `cross_sections()` or
+  `render_view(clip_plane=...)` to inspect interiors.
+- **Heavy clipped/high-quality renders on big imports:** `render_view` can be as
+  expensive as a geometry operation. Inspect numerically first on large imported
+  shapes, and keep clipped/high-quality renders for targeted checks.
+- **Curved-sheet hole centers:** when using `find_holes` on curved or BSpline
+  faces, trust the returned bore axis. Face centers or bounding-box centers can
+  be off-axis; "already at target" is a reason to re-measure, not proof the edit
+  is done.
+- **Coincident faces don't reliably fuse:** don't butt additive features exactly
+  coplanar with the base. Interpenetrate slightly, bury the feature into the
+  base, or extend-and-trim with a clean planar cut.
+- **Healing imported solids:** prefer targeted solid repair over global shape
+  repair; broad healing can reorient faces or collapse volume. Run very heavy
+  booleans as a standalone script when they exceed the worker timeout, then
+  re-import and verify.
 - **Assembling with raw `.move()` instead of joints:** placing parts by absolute position works once but breaks the moment anything changes — the child has no relationship to the parent. Use `RigidJoint`/`RevoluteJoint`/etc. so the relationship is preserved.
 - **Failed execute advancing state:** it doesn't — failed code preserves the previous `current_shape`.
 - **Library tools without --library:** `search_library` and `load_part` return an error if the server wasn't started with `--library PATH`.

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -113,6 +113,12 @@ large shapes. The standalone MCP tools remain for one-shot queries.
   displacement — confirm the changed region and magnitude match the request, and
   that the rest stayed put. A tangential move (sliding a hole) shows no region;
   cross-check `find_holes` and the bbox/center deltas for those.
+- Use `find_holes`' bore axis for holes on curved or BSpline faces. Face centers
+  and bounding-box centers can be off-axis; an apparent "already at target"
+  result is a prompt to re-measure against the axis.
+- Avoid large point grids with `is_inside()` on big solids. They are slow and can
+  hit the operation timeout; prefer `cross_sections()` or a targeted clipped
+  render for interiors.
 
 ## Step 4 — Experiments and recovery
 
@@ -134,6 +140,12 @@ heavy step into smaller `execute()` calls (build up incrementally — a timed-ou
 is dropped, not the session) and/or raise the ceiling with `--exec-timeout N` or
 `BUILD123D_EXEC_TIMEOUT=N` (this also extends the import budget for heavy STEP files).
 
+For additive edits, avoid exactly coincident faces: they often do not fuse into a
+clean solid. Interpenetrate slightly, bury the added feature into the base, or
+extend-and-trim with one planar cut. For imported solids, prefer targeted solid
+repair over broad shape healing; global healing can reorient faces or collapse
+volume.
+
 Only if a single unavoidable operation (IsoThread, a multi-body fillet, a very
 high-face-count boolean) still can't fit, drop out of the session for that one op:
 
@@ -150,8 +162,14 @@ high-face-count boolean) still can't fit, drop out of the session for that one o
    tooling (CADGenBench scores it zero) — no matter how close the geometry is.
    A `FAIL` here almost always means the current shape is a leftover 2D sketch,
    an open shell, an un-fused compound (`Part() + ...`), or a degenerate boolean
-   result; fix it and re-validate until it passes. `export()` re-runs this gate
-   and warns, but catch it here rather than shipping a zero.
+   result; fix it and re-validate until it passes.
+   `validate()` is a fast in-loop screen: small parts get the exact mesh stitch,
+   but large or expensive shapes may fall back to the fast mesh check so the
+   session does not time out. `export()` runs the slower, stricter pre-export
+   gate with a larger budget and is the authoritative verdict. A rare
+   `validate()` PASS followed by an `export()` warning/failure is expected for
+   coincident faces, near-tangent joins, or large imported B-reps; test-export
+   to a throwaway path before finalizing.
 3. `export("part.step", "step", object_name="part")` — STEP for CAD interchange,
    STL for printing. If the project slices with
    [estampo](https://github.com/estampo/estampo) (`estampo.toml` present),


### PR DESCRIPTION
Adds docs guidance around export gate behavior and validation expectations for #320-era workflows.

No API changes; this is a docs-only hardening for contributor discoverability.