### PR TITLE
fix: b123d-repair skill refinements from field-log deep dives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.70
+
+### Changed
+
+- **`b123d-repair` skill refined with field evidence from three fixtures' full run histories.** A deep-dive across every logged attempt at three persistently-hard fixtures (spanning many mcp versions) surfaced three generalizable corrections, not fixture-specific overfitting: (1) **`Part(df.Shape())` on a freshly-defeatured shape can silently report `volume=0`** even when `IsDone()` is true and the geometry is genuinely fine — confirmed against the raw transcript, where switching to `Solid(TopoDS.Solid_s(df.Shape()))` recovered the correct volume on the identical shape; rung 3's snippet and every other rung now use the robust wrapper. (2) **Defeaturing is not merely slow on a complex/non-planar face — it can be flatly wrong** (a targeted single-face removal produced a degenerate near-zero-volume result on one fixture, confirmed by running it to completion without a timeout); the skill now names "healed volume comes back zero/wildly different despite `IsDone()` success" as its own failure signal, distinct from "ran out of time," so an agent doesn't waste turns retrying with longer timeouts or different tolerances. (3) **Rung 4 gains a same-wire-first, general-N-edge-second escalation**: rebuilding a face directly from its own (planar) boundary wire via `BRepBuilderAPI_MakeFace` is the cheapest fix and worked cleanly on edit-introduced slivers in the field, while a genuinely non-planar sliver needs `BRepFill_Filling` across its full N-edge boundary (the existing "ruled face" text only ever covered the narrower 2-edge case) — this is what actually healed a real 19-edge BSpline defect after the simpler `MakeFace` call failed outright on it. Step 2 also now calls out the session's own existing "shape was rebound but volume/topology/bbox unchanged" warning as a signal that an attempt changed nothing (a stealth non-fix, not a repair), and Step 4 gains a construction-level lever: prefer a subtractive (cut) reformulation over an additive (union) one whenever a spec is ambiguous between them, since additive unions must fuse flush against an existing boundary — the classic non-manifold/open-edge trap the same section already documents — while cuts merely remove material.
+
 ## v0.3.69
 
 ### Added

--- a/src/build123d_mcp/skills/b123d-repair/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-repair/SKILL.md
@@ -113,35 +113,97 @@ without plugging.
 
 ```python
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Defeaturing
+from OCP.TopoDS import TopoDS
 df = BRepAlgoAPI_Defeaturing()
 df.SetShape(part.wrapped)
 df.AddFaceToRemove(bad_face.wrapped)
 df.Build()
-healed = Part(df.Shape())
+healed = Solid(TopoDS.Solid_s(df.Shape()))   # NOT Part(df.Shape()) — see below
 ```
 
-**Volume check is mandatory here**: defeaturing can silently *fill an internal
+**Wrap the result in `Solid`, not `Part`.** `Part(df.Shape())` has been
+observed, on a real defeatured shape, to silently report `volume=0` even
+though `IsDone()` is True and the geometry is genuinely fine — the wrapper is
+broken, not the operation. `Solid(TopoDS.Solid_s(df.Shape()))` recovers the
+correct volume on the identical shape. Whichever wrapper you use, sanity-check
+the result's volume against the pre-heal volume before concluding anything
+about whether the defeature itself worked.
+
+**Volume check is mandatory too**: defeaturing can silently *fill an internal
 bore* whose wall included the removed face (observed: +14% volume — a ruined
 part that passed the gate). Accept the heal only if the volume delta is on the
 scale of the defect itself, not of a feature.
 
-Fails when: the sliver's neighbours can't extend to close the gap, or the
-defeature output fails the gate. Move to rung 4.
+Fails when: the sliver's neighbours can't extend to close the gap, the
+defeature output fails the gate, or the (correctly-wrapped) healed volume
+comes back zero or wildly different despite `IsDone()` reporting success —
+defeaturing can silently produce a degenerate shape on a genuinely
+non-planar/complex face, not just run slowly or need a longer timeout. Don't
+retry with different tolerances; move to rung 4.
 
 ### Rung 4 — face surgery for an unorientable sliver
 
 Thin sliver faces (a degenerate fillet remnant, a band between near-coincident
 arcs) are the classic BRepCheck killer on imported castings. Escalate through
-these four, in order:
+these, in order:
 
-1. **Replace with a ruled face.** Build a `BRepFill` ruled face between the
-   sliver's two long edges, drop the original, sew everything at small
-   tolerance. Works when the sliver's bounding edges are clean but its surface
-   is garbage.
-2. **Drop + tolerant sew.** When the sliver's own wire is broken (a ruled/fill
-   replacement comes out unorientable too), delete the face entirely and sew
-   the neighbours with **tolerance greater than the sliver's width** (e.g.
-   0.6 mm for a 0.5 mm sliver), then `ShapeFix_Solid` to orient the shell:
+1. **Rebuild directly from the face's own wire, if planar.** The cheapest,
+   most literal fix — zero geometry change, since the boundary itself is
+   untouched:
+
+   ```python
+   from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeFace
+   from OCP.BRepTools import BRepTools_ReShape
+   from OCP.TopExp import TopExp_Explorer
+   from OCP.TopAbs import TopAbs_WIRE
+   from OCP.TopoDS import TopoDS
+   wire = TopoDS.Wire_s(TopExp_Explorer(bad_face.wrapped, TopAbs_WIRE).Current())
+   mk = BRepBuilderAPI_MakeFace(wire, True)
+   if mk.IsDone():
+       reshaper = BRepTools_ReShape()
+       reshaper.Replace(bad_face.wrapped, mk.Face())
+       healed = Solid(TopoDS.Solid_s(reshaper.Apply(part.wrapped)))
+   ```
+
+   Only works when the wire is (at least close to) planar — on a genuinely
+   non-planar/BSpline surface `MakeFace` raises `Standard_Failure ... NULL
+   shape` (or `IsDone()` is False). That failure **is** the signal to move to
+   option 2, not a reason to retry this one.
+2. **Fill the boundary with a new surface.** For a non-planar face, build a
+   fresh surface spanning the *same* wire's edges instead of assuming
+   planarity — `BRepFill_Filling`, adding every edge of the wire, handles an
+   arbitrary N-edge boundary (a plain `BRepFill` ruled face only spans exactly
+   2 edges — use that simpler form only when the sliver truly has just 2 long
+   bounding edges):
+
+   ```python
+   from OCP.BRepFill import BRepFill_Filling
+   from OCP.GeomAbs import GeomAbs_C0
+   from OCP.TopExp import TopExp_Explorer
+   from OCP.TopAbs import TopAbs_EDGE
+   from OCP.TopoDS import TopoDS
+   from OCP.BRepTools import BRepTools_ReShape
+   edges, exp = [], TopExp_Explorer(bad_face.wrapped, TopAbs_EDGE)
+   while exp.More():
+       edges.append(TopoDS.Edge_s(exp.Current())); exp.Next()
+   filling = BRepFill_Filling()
+   for e in edges:
+       filling.Add(e, GeomAbs_C0, True)
+   filling.Build()
+   reshaper = BRepTools_ReShape()
+   reshaper.Replace(bad_face.wrapped, filling.Face())
+   healed = Solid(TopoDS.Solid_s(reshaper.Apply(part.wrapped)))
+   ```
+
+   `filling.IsDone()` can be True while `BRepCheck_Analyzer` still reports the
+   raw filled face invalid — that's expected here; verify via a full re-sew
+   (next) and the export gate, not the raw face check. A follow-up re-sew of
+   every face at a small tolerance (0.005-0.05 mm) after the patch often
+   closes the residual gap the fill alone leaves.
+3. **Drop + tolerant sew.** When the wire itself is broken (both options above
+   fail), delete the face entirely and sew the neighbours with **tolerance
+   greater than the sliver's width** (e.g. 0.6 mm for a 0.5 mm sliver), then
+   `ShapeFix_Solid` to orient the shell:
 
    ```python
    from OCP.BRepBuilderAPI import BRepBuilderAPI_Sewing
@@ -154,14 +216,14 @@ these four, in order:
    sew.Perform()
    shell = TopoDS.Shell_s(sew.SewedShape())       # sewn result -> TopoDS_Shell
    solid = ShapeFix_Solid().SolidFromShell(shell)  # orient into a proper solid
-   healed = Part(solid)
+   healed = Solid(solid)
    ```
 
-3. **Patch + small-tolerance sew.** On a *wide* sliver (~2-3 mm), drop+sew
+4. **Patch + small-tolerance sew.** On a *wide* sliver (~2-3 mm), drop+sew
    goes non-manifold (the big tolerance welds faces that shouldn't meet).
-   Instead fill the sliver's boundary wire with a `BRepFill` patch face and
+   Instead fill the sliver's boundary wire with a filling face (option 2) and
    sew at small tolerance.
-4. **Cut it out.** When the sliver is intrinsic to the geometry (a curved band
+5. **Cut it out.** When the sliver is intrinsic to the geometry (a curved band
    between two near-coincident arcs), in-memory fixes only *fake-heal* — the
    gate fails again after the export round-trip. Remove the region physically:
    boolean-subtract a thin box enclosing the sliver. This changes geometry by
@@ -186,10 +248,14 @@ the same way.
   huge shape `validate()`'s own mesh check can come back `mesh_check: "skipped"`
   (too large to stitch even out-of-process) with a "not verified" warning, so
   treat its PASS as a screen, not a verdict.
-- **A heal must not change the geometry.** Compare `volume` and bounding box
-  before/after: the acceptable delta is the scale of the defect (a sliver's
-  near-zero volume), never a feature's. A heal that gains or loses real volume
-  replaced your part with a different part.
+- **A heal must not change the geometry — but it must change *something*.**
+  Compare `volume` and bounding box before/after: the acceptable delta is the
+  scale of the defect (a sliver's near-zero volume), never a feature's. A heal
+  that gains or loses real volume replaced your part with a different part.
+  Conversely, `show()`'s own "shape was rebound but volume/topology/bbox
+  unchanged" warning means the attempt changed nothing at all — a rewrap, not
+  a repair — so the original defect is still there even though no error was
+  raised; move to the next rung rather than trusting it.
 - **Never keep iterating on an invalid solid.** If a rung's attempt fails the
   gate, `restore_snapshot()` back to the pre-attempt state before trying the
   next rung — stacked failed repairs compound.
@@ -226,6 +292,15 @@ construction, not the corpse:
   `validate()` and FAIL the export gate with non-manifold or open edges.
   Interpenetrate: bury the added feature 1-2 mm into the base, make the
   footprint 2-3 mm larger, or extend past and trim with one planar cut.
+- **When a feature can be built either as an addition or a removal, prefer the
+  removal.** Raising/relocating a face by *unioning new material onto an
+  existing boundary* runs straight into the coincident-face trap above — the
+  new material must fuse exactly flush with what's already there. The same
+  visible result reached by *cutting material away* instead (e.g. treating a
+  face move as an internal step/ledge to deepen rather than an external boss
+  to add) only has to remove material cleanly, with no flush-fuse boundary to
+  get wrong. When a spec is genuinely ambiguous between an additive and a
+  subtractive reading, the subtractive one is the safer default.
 - **Tangencies leave open edges.** A hole tangent to a coaxial hub wall, a
   boss grazing a torus fillet — nudge the position ~0.3 mm or extend the boss
   coaxial with the adjacent straight cylinder so the intersection is clean.


### PR DESCRIPTION
## Why

After #383 shipped, three deep-dive investigations were run across every logged attempt at three persistently-hard CADGenBench editing fixtures — spanning many mcp versions, not a single run — specifically to check whether the shipped skill's guidance held up against a much larger body of field evidence than the original PR had. It surfaced three real, generalizable technique corrections (not fixture-specific overfitting) and one confirmed-but-previously-undocumented tooling gotcha.

## What

- **`Part(df.Shape())` on a freshly-defeatured shape can silently report `volume=0`**, even when `IsDone()` is `True` and the geometry is genuinely fine. Confirmed directly against the raw field transcript (not inferred): the same session tried `Part()` first (got `volume=0`), then switched to `Solid(TopoDS.Solid_s(...))` on the *identical* shape and got the correct, non-zero volume. Rung 3's snippet (and the two new snippets added below) now use the robust wrapper throughout.
- **Defeaturing is not merely slow on a complex/non-planar face — it can be flatly wrong.** A targeted single-face `BRepAlgoAPI_Defeaturing` call, run to completion *without* a timeout (confirmed independently, not just assumed from a timeout), produced a degenerate near-zero-volume result on one fixture. Rung 3 now names "healed volume comes back zero/wildly different despite `IsDone()` success" as its own distinct failure signal — separate from "needs more time" — so an agent doesn't burn turns retrying with longer timeouts or different tolerances on a technique that was never going to work on that face.
- **Rung 4 gains a same-wire-first, general-N-edge-second escalation.** Rebuilding a face directly from its own boundary wire via `BRepBuilderAPI_MakeFace` is the cheapest fix and worked cleanly in the field on edit-introduced (planar) slivers. A genuinely non-planar sliver needs `BRepFill_Filling` across its full N-edge boundary instead — the previous text only ever described the narrower 2-edge ruled-face case. This is what actually healed a real 19-edge BSpline defect in the field, after the simpler `MakeFace` call failed outright (`Standard_Failure ... NULL shape`) on that same face.
- **Step 2** now calls out the session's own existing `"shape was rebound but volume/topology/bbox unchanged"` warning (confirmed present in `session.py`, not something the agent's own code happened to print) as a signal that an attempt changed nothing at all — a stealth non-fix, not a repair.
- **Step 4** gains a construction-level lever: prefer a subtractive (cut) reformulation over an additive (union) one whenever a spec is ambiguous between them. Field evidence: every subtractive attempt at an ambiguous "raise this face" edit passed clean on the first try; every additive attempt either failed outright or needed many grinding iterations — the same coincident-face trap the section already documents, just framed as a constructional choice instead of a mitigation after the fact.

## Verification

- 36/36 `test_install_skill.py` pass; full suite green; ruff/mypy/`ruff format --check` clean.
- Two of the three new/changed code snippets were independently smoke-tested against a **genuinely imported `Solid`** (via a real STEP export/re-import round-trip), not a build123d-native primitive — `Box().wrapped` is itself a `Compound`, which gives a misleading test for code meant to run on an imported shape. Caught and corrected one snippet along the way (`reshaper.Apply()`'s return type differs depending on whether the input was a bare `Solid` vs. a `Compound`).
- The `Part()`-vs-`Solid()` volume=0 claim and the `BRepFill_Filling` recipe were each verified by reading the actual raw `stream.jsonl` transcript lines they're drawn from, not taken at face value from a summarized research pass.

## Related

Follow-up to #383 (the original skill). No code paths changed — SKILL.md and CHANGELOG.md only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoMwBwMcpmgQeHGtd6MWSr