### PR TITLE
fix: flatten successful single-solid STEP exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`export()` now rewrites one-component assembly STEP output even when build123d's high-level writer reports success.** The v0.3.65 fix covered the import-derived solid path where `export_step()` raises, but fresh one-solid wrappers such as located primitives can return success while still writing `NEXT_ASSEMBLY_USAGE_OCCURRENCE`. `export()` now checks the written STEP structure for every single-solid export, bakes any non-identity location into the one solid, and retries the CAF writer so the output stays flat while preserving names and colours. Genuine multi-solid compounds still export as assemblies.
+
 ## v0.3.69
 
 ### Added

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -97,6 +97,48 @@ def _write_svg(shape, abs_path: str) -> None:
     exporter.write(abs_path)
 
 
+def _n_solids(shape) -> int:
+    try:
+        return len(shape.solids())
+    except Exception:  # noqa: BLE001 - no solid topology to reason about
+        return 0
+
+
+def _raw_step_write(shape, abs_path: str, *, single_solid: bool = False) -> bool:
+    from OCP.IFSelect import IFSelect_ReturnStatus
+    from OCP.STEPControl import STEPControl_AsIs, STEPControl_Writer
+
+    transfer_shape = shape.solids()[0] if single_solid else shape
+    writer = STEPControl_Writer()
+    writer.Transfer(transfer_shape.wrapped, STEPControl_AsIs)
+    return writer.Write(abs_path) == IFSelect_ReturnStatus.IFSelect_RetDone
+
+
+def _single_solid_step_is_flat(abs_path: str, n_solids: int) -> bool:
+    return n_solids != 1 or _nauo_count(abs_path) == 0
+
+
+def _flat_single_solid_copy(shape):
+    """Return one located solid as identity-location geometry for flat CAF STEP."""
+    from build123d import Solid
+    from OCP.BRepBuilderAPI import BRepBuilderAPI_Transform
+    from OCP.TopLoc import TopLoc_Location
+
+    solid = shape.solids()[0]
+    wrapped = solid.wrapped
+    loc = wrapped.Location()
+    if not loc.IsIdentity():
+        wrapped = BRepBuilderAPI_Transform(wrapped, loc.Transformation(), True, True).Shape()
+        wrapped.Location(TopLoc_Location())
+
+    recon = Solid(wrapped)
+    recon.label = getattr(shape, "label", "") or ""
+    color = getattr(shape, "color", None)
+    if color is not None:
+        recon.color = color
+    return recon
+
+
 def _write_step(shape, abs_path: str) -> None:
     """Write a STEP, working around build123d's high-level writer failing.
 
@@ -114,44 +156,41 @@ def _write_step(shape, abs_path: str) -> None:
     import blank in a stock document. Mesh viewers hide this because they flatten
     product structure, so it only bites in a real kernel.
 
-    #1356 is about the build123d ``Solid`` wrapper, not the geometry: a fresh
-    ``Solid`` over the same ``TopoDS`` gets the CAF writer to accept it and stays a
-    single product with the name intact. So for one solid we reconstruct and retry;
-    a genuine multi-solid keeps its ``Compound``, where the assembly structure is
-    correct. Raw ``STEPControl_Writer`` is the last resort — single product, but
-    drops CAF names/colours.
+    #1356 is about the build123d ``Solid`` wrapper, not the geometry. For one
+    solid, accept the CAF writer only when the written file is actually flat
+    (no ``NEXT_ASSEMBLY_USAGE_OCCURRENCE``); otherwise bake any location into the
+    one solid and retry the CAF writer so names/colours survive. A genuine
+    multi-solid keeps its ``Compound``, where the assembly structure is correct.
+    Raw ``STEPControl_Writer`` is the last resort — single product, but drops CAF
+    names/colours.
     """
     from build123d import export_step
 
+    n_solids = _n_solids(shape)
+
     try:
         export_step(shape, abs_path)
-        return
+        if _single_solid_step_is_flat(abs_path, n_solids):
+            return
     except Exception:  # noqa: BLE001 - CAF writer failed; work around #1356 below
         pass
 
-    try:
-        n_solids = len(shape.solids())
-    except Exception:  # noqa: BLE001 - no solid topology to reason about
-        n_solids = 0
-
     if n_solids == 1:
-        # Single part: reconstruct the ``Solid`` so the CAF writer takes it. Keeps
-        # the file a single product (no phantom ``NEXT_ASSEMBLY_USAGE_OCCURRENCE``)
-        # and the name/colour. Reconstructing from ``.wrapped`` does not touch
-        # ``shape``, so unlike the ``Compound`` wrap below there is no parent to
-        # save/restore.
-        from build123d import Solid
-
+        # Single part: reconstruct the ``Solid`` so the CAF writer takes
+        # import-derived solids, and bake non-identity locations into the geometry
+        # so fresh located wrappers do not become one-component assemblies.
         try:
-            recon = Solid(shape.solids()[0].wrapped)
-            recon.label = getattr(shape, "label", "") or ""
-            color = getattr(shape, "color", None)
-            if color is not None:
-                recon.color = color
+            recon = _flat_single_solid_copy(shape)
             export_step(recon, abs_path)
-            return
+            if _single_solid_step_is_flat(abs_path, n_solids):
+                return
         except Exception:  # noqa: BLE001 - fall through to the raw writer
             pass
+
+        if _raw_step_write(shape, abs_path, single_solid=True) and _single_solid_step_is_flat(
+            abs_path, n_solids
+        ):
+            return
     else:
         # Genuine multi-solid: a ``Compound`` is the right structure, and wrapping
         # also gets it through #1356 with names intact. Constructing a ``Compound``
@@ -169,17 +208,14 @@ def _write_step(shape, abs_path: str) -> None:
         except Exception:  # noqa: BLE001 - raw geometry-only fallback
             pass
 
-    from OCP.IFSelect import IFSelect_ReturnStatus
-    from OCP.STEPControl import STEPControl_AsIs, STEPControl_Writer
+        if _raw_step_write(shape, abs_path):
+            return
 
-    writer = STEPControl_Writer()
-    writer.Transfer(shape.wrapped, STEPControl_AsIs)
-    if writer.Write(abs_path) != IFSelect_ReturnStatus.IFSelect_RetDone:
-        raise RuntimeError(
-            "Failed to write STEP file (build123d export_step, the single-solid "
-            "reconstruct retry / multi-solid Compound-wrap retry, and the raw "
-            "STEPControl_Writer fallback all failed)"
-        )
+    raise RuntimeError(
+        "Failed to write STEP file (build123d export_step, the single-solid "
+        "reconstruct retry / multi-solid Compound-wrap retry, and the raw "
+        "STEPControl_Writer fallback all failed)"
+    )
 
 
 def _write_one(shape, abs_path: str, fmt: str) -> None:

--- a/tests/test_export_step.py
+++ b/tests/test_export_step.py
@@ -3,19 +3,29 @@
 build123d 0.11.0's high-level ``export_step`` (the ``STEPCAFControl_Writer`` path)
 raises ``RuntimeError: Failed to write STEP file`` on many imported-STEP-derived
 solids that 0.10.0 wrote fine — it hit ~38% of editing-fixture benchmark runs.
-``_write_step`` first retries through a ``Compound`` wrapper (which keeps the CAF
-path working, so names/colours survive), then falls back to the basic
-``STEPControl_Writer`` (geometry only). These tests pin the happy path, the
-forced fallback (high-level writer made to raise, so it runs on any version), and
-the real reimported-solid regression.
+``_write_step`` accepts high-level output only when single-solid files are flat,
+then falls back to the basic ``STEPControl_Writer`` (geometry only). These tests
+pin the happy path, the forced fallback (high-level writer made to raise, so it
+runs on any version), the real reimported-solid regression, and the high-level
+success path that can still write a one-component assembly.
 """
 
 import pytest
-from build123d import import_step
+from build123d import Color, import_step
 
 from build123d_mcp.session import Session
 from build123d_mcp.tools.execute import execute_code
 from build123d_mcp.tools.export import export_file
+
+
+def assert_no_assembly_links(step_path):
+    assert "NEXT_ASSEMBLY_USAGE_OCCURRENCE" not in step_path.read_text(errors="ignore")
+
+
+def assert_step_has_label_and_colour(step_path, label):
+    text = step_path.read_text(errors="ignore")
+    assert label in text
+    assert "COLOUR_RGB" in text or "DRAUGHTING_PRE_DEFINED_COLOUR" in text
 
 
 @pytest.fixture
@@ -144,10 +154,106 @@ def test_export_single_solid_is_not_written_as_assembly(tmp_path):
     export_step(Box(10, 10, 10), str(seed))
     s = import_step(str(seed))  # bare Solid, label 'COMPOUND' — the #1356 trigger
     s.label = "widget"
+    s.color = Color(1, 0, 0)
 
     out = tmp_path / "out.step"
     _write_step(s, str(out))
 
-    text = out.read_text(errors="ignore")
-    assert "NEXT_ASSEMBLY_USAGE_OCCURRENCE" not in text  # single product, not an assembly
-    assert "widget" in text  # name survived (not dropped to the raw geometry writer)
+    assert_no_assembly_links(out)  # single product, not an assembly
+    assert_step_has_label_and_colour(out, "widget")
+    back = import_step(str(out))
+    assert len(back.solids()) == 1
+    assert back.volume == pytest.approx(1000.0, rel=1e-3)
+
+
+def test_export_fresh_single_solid_wrapper_is_not_written_as_assembly(
+    session, tmp_path, monkeypatch
+):
+    """build123d's high-level writer can return success while still emitting a
+    one-component assembly for fresh one-solid wrappers such as located
+    primitives. That is not the #1356 exception path, so export() must inspect the
+    written file and rewrite it flat.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Pos(5, 0, 0) * Cylinder(2, 10), 'pin')")
+    session.objects["pin"].color = Color(1, 0, 0)
+
+    export_file(session, "pin", "step", object_name="pin")
+
+    out = tmp_path / "pin.step"
+    assert_no_assembly_links(out)
+    assert_step_has_label_and_colour(out, "pin")
+    back = import_step(str(out))
+    bbox = back.bounding_box()
+    assert len(back.solids()) == 1
+    assert back.volume == pytest.approx(session.objects["pin"].volume, rel=1e-3)
+    assert bbox.min.X == pytest.approx(3.0)
+    assert bbox.max.X == pytest.approx(7.0)
+
+
+def test_export_fresh_part_wrapper_is_not_written_as_assembly(session, tmp_path, monkeypatch):
+    """Part wrappers can also take the high-level success path; keep the same
+    flat-file invariant for them so the fix is not limited to primitives.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Pos(5, 0, 0) * (Part() + Box(10, 10, 10)), 'part')")
+    session.objects["part"].color = Color(1, 0, 0)
+
+    export_file(session, "part", "step", object_name="part")
+
+    out = tmp_path / "part.step"
+    assert_no_assembly_links(out)
+    assert_step_has_label_and_colour(out, "part")
+    back = import_step(str(out))
+    bbox = back.bounding_box()
+    assert len(back.solids()) == 1
+    assert back.volume == pytest.approx(1000.0, rel=1e-3)
+    assert bbox.min.X == pytest.approx(0.0)
+    assert bbox.max.X == pytest.approx(10.0)
+
+
+def test_export_rewrites_successful_single_solid_assembly_export(session, tmp_path, monkeypatch):
+    """Pin the invariant independent of build123d's current writer behavior:
+    even if the high-level writer reports success with a one-component assembly,
+    the final single-solid STEP must be flat.
+    """
+
+    from build123d import Compound
+    from build123d import export_step as real_export_step
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(session, "show(Box(10, 10, 10), 'part')")
+
+    def write_one_component_assembly(shape, file_path, *args, **kwargs):
+        return real_export_step(Compound(children=[shape]), file_path, *args, **kwargs)
+
+    monkeypatch.setattr("build123d.export_step", write_one_component_assembly)
+
+    export_file(session, "part", "step", object_name="part")
+
+    out = tmp_path / "part.step"
+    assert_no_assembly_links(out)
+    back = import_step(str(out))
+    assert len(back.solids()) == 1
+    assert back.volume == pytest.approx(1000.0, rel=1e-3)
+
+
+def test_export_multi_solid_compound_keeps_assembly_structure(session, tmp_path, monkeypatch):
+    """The single-solid flat-file invariant must not flatten real multi-body
+    assemblies.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    execute_code(
+        session,
+        "show(Compound(children=[Box(10, 10, 10), Pos(20, 0, 0) * Box(10, 10, 10)]), 'asm')",
+    )
+
+    export_file(session, "asm", "step", object_name="asm")
+
+    out = tmp_path / "asm.step"
+    assert "NEXT_ASSEMBLY_USAGE_OCCURRENCE" in out.read_text(errors="ignore")
+    reimported = import_step(str(out))
+    assert len(reimported.solids()) == 2


### PR DESCRIPTION
## Summary

This PR tightens STEP export around one rule:

_A STEP export that contains exactly one solid should open as a part, not as a one-component assembly._

The previous fix in #356 handled the failure path I had seen at the time. With build123d 0.11, `export_step()` could raise for imported or reimported single solids. The fix reconstructed the solid and retried the CAF writer, which kept the STEP output as a single product and avoided the `Compound` workaround that creates `NEXT_ASSEMBLY_USAGE_OCCURRENCE` records.

While regenerating downstream CAD packages, I found a second path in the same issue class. Some fresh one-solid wrappers, especially located primitives and located `Part` wrappers, do not raise. The high-level writer returns success, but the resulting STEP file still contains `NEXT_ASSEMBLY_USAGE_OCCURRENCE`. SolidWorks and similar CAD kernels then open the file as a one-component assembly rather than a part. Since the writer returned success, the previous fallback was never reached.

This PR changes the rule from "handle the known exception path" to "verify the written artifact before returning." `_write_step()` now counts the solids before writing. For single-solid exports, it only accepts high-level writer output if the STEP file has no assembly usage records.

If the high-level writer produces a one-component assembly for one solid, the fix does not immediately drop to the raw writer. It first bakes any non-identity location into the solid geometry, resets the TopoDS location to identity, and retries the CAF writer. That produces a flat single-product STEP while preserving names and colours in the normal fix path. The raw `STEPControl_Writer` remains only the last-resort fallback if CAF still cannot produce a flat single-solid file.

CAF here means Open Cascade's XCAF/OCAF document path, exposed through `STEPCAFControl_Writer`. In practical terms, that is the path that carries product names, labels, colours, and assembly structure into STEP. `STEPControl_Writer` is more basic and robust, but it writes geometry without that metadata. This PR keeps the metadata-preserving path for the cases where it can be made structurally correct.

## Why this should close the class

The underlying issue is not just that one writer call can fail. The broader issue is that a one-solid export can leave `export()` with assembly structure in the file.

The implementation now checks the final STEP structure before returning for every single-solid export path:

1. high-level writer succeeds and writes flat: return
2. high-level writer succeeds but writes assembly structure: bake the location into the single solid, retry the CAF writer, verify flat
3. high-level writer raises: reconstruct or bake the single solid, retry the CAF writer, verify flat
4. CAF retry still writes assembly structure or fails: fall back to raw `STEPControl_Writer`
5. genuine multi-solid export: keep assembly structure

That makes the behavior independent of which build123d wrapper type triggered it and independent of whether the high-level writer reports success or raises. It also keeps names and colours on the normal repaired path, so the fix improves part structure without unnecessarily regressing STEP metadata.

## Compatibility and tradeoffs

The normal repaired path should not make metadata worse. If CAF writes a bad one-solid STEP, the fix bakes the non-identity location into the solid, resets the TopoDS location to identity, and retries the CAF writer. That keeps the same world-space geometry, produces a flat part file, and preserves names and colours.

The main representation change is that the single solid no longer carries a separate location transform in the STEP structure. The transform is baked into the geometry instead. That is intentional: the separate location is what causes CAF to encode the solid as a component in a one-component assembly.

The raw `STEPControl_Writer` fallback can still lose CAF names and colours, but it is only used after the CAF path cannot produce a flat single-solid file. That was already the last-resort behavior for hard writer failures. This PR makes that path less likely, because located single solids now get a metadata-preserving CAF retry before falling back to raw geometry.

The priority order is unchanged: preserve geometry first, write the correct part-vs-assembly structure second, preserve names and colours when CAF can do so, and use the raw writer only when CAF cannot produce a correct flat part.

## Tests

Added regression coverage for the full behavior:

- import-derived single solids still export flat and preserve labels and colour metadata
- located primitive wrappers export flat and preserve labels and colour metadata
- located `Part` wrappers export flat and preserve labels and colour metadata
- a monkeypatched high-level writer that reports success while writing a one-component assembly is detected and rewritten flat
- real multi-solid compounds still export with assembly structure and preserve all solids

Commands run:

```powershell
uv run --native-tls --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org pytest tests\test_export_step.py -q
uv run --native-tls --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org ruff check src\build123d_mcp\tools\export.py tests\test_export_step.py
uv run --native-tls --allow-insecure-host pypi.org --allow-insecure-host files.pythonhosted.org ruff format --check src\build123d_mcp\tools\export.py tests\test_export_step.py
```

Full `pytest -q` also completed on my Windows host with `955 passed, 26 skipped`. The only failure was `tests\test_tools.py::test_export_symlink_escape_rejected`, which fails before reaching this change because the current Windows session does not have symlink creation privilege (`WinError 1314`).










