### PR TITLE
[codex] Simplify README onboarding

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        libegl1 \
+        libgl1 \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        xvfb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON=3.12

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "build123d-mcp",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "uv sync --all-groups && uv run build123d-mcp --version",
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": {
+      "label": "build123d-mcp HTTP transport",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+        "python.analysis.extraPaths": ["${workspaceFolder}/src"],
+        "python.terminal.activateEnvironment": true
+      }
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "build123d-mcp": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "build123d-mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,212 +6,57 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![build123d-mcp MCP server](https://glama.ai/mcp/servers/pzfreo/build123d-mcp/badges/score.svg)](https://glama.ai/mcp/servers/pzfreo/build123d-mcp)
 
-An MCP (Model Context Protocol) server that exposes build123d CAD operations as tools, enabling AI assistants to build, inspect, and iterate on 3D geometry interactively.
+Give your AI CAD eyes.
 
-## Why
+build123d-mcp is not a standalone chatbot or CAD program. It is a CAD toolbox
+that an AI/LLM app can use through MCP.
 
-When using an AI to write build123d scripts, the AI writes blind — it cannot see the geometry it produces. This server closes the feedback loop: the AI can create geometry, render views, query dimensions, and catch errors incrementally rather than writing complete scripts and hoping they are correct.
+With an LLM app such as Claude, Cursor, VS Code, Continue, Cline, or Codex CLI,
+build123d-mcp lets the assistant create build123d CAD models, render previews,
+measure geometry, fix mistakes, and export files such as STEP, STL, SVG, and
+DXF. Instead of writing a whole CAD script blindly, the assistant can build a
+part in small steps and check the result as it goes.
 
-**Evidence it works:** on the public [CADGenBench](https://huggingface.co/spaces/HuggingAI4Engineering/CADGenBench) leaderboard (June 2026), driving GPT‑5.5 through build123d‑mcp scores **0.457 — the top result on the board** — versus **0.360** for the same model writing build123d scripts blind: a **+27%** gain that also raises CAD validity from 88% to 100%, and beats even the larger GPT‑5.5 Pro baseline. The feedback loop measurably improves what an LLM can model.
+On the public [CADGenBench](https://huggingface.co/spaces/HuggingAI4Engineering/CADGenBench)
+leaderboard in June 2026, using build123d-mcp raised the same model's score from
+0.360 to 0.457 and CAD validity from 88% to 100%.
 
-## Tools
+## Quick Start
 
-**Core**
-- `execute` — run build123d Python code in a persistent session; use `show(shape, name)` to register named parts. The analysis functions (`measure`, `clearance`, `cross_sections`, `find_holes`, `find_bosses`, `find_countersinks`, `find_hole_patterns`, `align_check`) are also callable *in code* and return real Python objects — `measure(part)["volume"]`, `[h for h in find_holes(part) if h.location[0] < 5]` — so results compose without copying numbers between tool calls
-- `reset` — clear session back to empty state (namespace, shapes, snapshots)
-
-**Geometry inspection**
-- `measure` — full geometric summary: volume, area, topology, bounding box, centre of mass, inertia tensor, face-type inventory
-- `clearance` — minimum distance (mm) between two named shapes
-- `cross_sections` — cross-sectional areas at evenly spaced planes along X/Y/Z; useful for detecting voids and wall-thickness variation
-- `resolve` — evaluate a selector expression (e.g. `.faces().filter_by(Axis.Z).last()`) against a named object and return a geometry descriptor
-- `find_holes` / `find_bosses` / `find_hole_patterns` — feature recognition: coaxial drill + counterbore + spotface stacks as one hole record (axis, location, diameter, depth, bottom: through/flat/drill_point/unknown), external bosses with height, bolt-circle and linear-array patterns
-- `find_countersinks` — recognise conical countersinks (major/drill diameter, included angle, depth) that `find_holes` reports only as plain openings
-- `analyze_printability` — BREP-exact FDM printability analysis: overhangs, thin walls, minimum features, bed fit, tip-over risk
-- `design_audit` — audit the session program as a *design*, not just a shape: surface its named numeric parameters and perturb each ±ε in isolation, re-running the validity gate to flag *brittle* parameters where a small edit collapses the solid (Arko-T design-state robustness)
-- `verify_spec` / `suggest_spec` *(experimental — off by default, enable with `--experimental`)* — check the built solid against a declared design-intent spec (envelope, solid count/validity, hole/boss features, parameter ranges): answers *"did I build what was requested?"* with an evidence-tiered PASS/FAIL/UNVERIFIED conformance report; `suggest_spec` drafts a starter spec from the current shape. Gated pending more maturity — see [#362](https://github.com/pzfreo/build123d-mcp/issues/362)
-- `session_state` — full JSON snapshot of active shapes, named objects, snapshot names, and Python namespace variables
-- `last_error` — details of the last failed `execute()`: type, message, line number, and code excerpt
-
-**Viewing**
-- `render_view` — render one or more shapes as PNG / SVG / DXF; auto-detects 3D vs 2D inputs (composed dimensioned drawings via `build123d.drafting` rasterise via ezdxf+matplotlib); supports assembly compositing, high-quality tessellation, cross-section clip planes, and optional labels for named shapes or specific faces/edges
-
-**Engineering drawings**
-- `suggest_view_layout` — auto-calculate safe page positions for a standard multi-view drawing layout
-- `view_axes` — world-to-page axis mapping for a projected view, computed analytically before rendering
-- `render_drawing` — rasterise an SVG file from disk to PNG
-- `inspect_drawing` — structured bbox/annotation report for a 2D drawing (session objects or an SVG on disk)
-- `lint_drawing` — structural drawing-quality checks: label/geometry divergence, overlapping annotations, page overshoot
-- `save_drawing_annotations` — write a `.dims.json` sidecar capturing label metadata alongside an exported SVG
-
-**Import / export**
-- `export` — export as STEP / STL / DXF / SVG (or comma-separated like `step,stl`); auto-detects 2D vs 3D shape and routes to the appropriate format; targets a named object, the current shape, or `*` for all objects as an assembly
-- `validate` — fast pre-export validity screen. `export` repeats the gate with a
-  stricter, larger-budget check and is the authoritative verdict, so test-export
-  important parts before finalizing if the geometry has coincident faces,
-  near-tangent joins, or large imported B-reps
-- `import_cad_file` — load a STEP or STL file as a named object for comparison
-
-**Comparison**
-- `shape_compare` — compare two named shapes by volume, bbox, topology, and centre offset, plus a localized surface-deviation diff that pinpoints *where* the geometry changed (changed region centroid/bbox), with an exact-boolean magnitude (true surface displacement + added/removed volume) for verifying an edit landed where and by how much it was requested
-- `align_check` — check alignment between two named objects along an axis (flush / center / clearance modes)
-
-**Session checkpoints**
-- `save_snapshot` / `restore_snapshot` / `diff_snapshot` — checkpoint, recover, and compare geometric state
-
-**Part library** *(requires `--library` flag)*
-- `search_library` — search the part library by keyword; returns full parameter specs
-- `load_part` — load a named part with optional parameter overrides
-
-**Utility**
-- `version` — return the server version
-- `health_check` — verify VTK/SVG/STEP/STL dependencies work end-to-end
-- `repair_hints` — get targeted fix suggestions for a given `execute()` error message
-- `workflow_hints` — guidance on using the tools effectively
-- `script` — assemble a reproducible Python script from the session's executed code blocks
-- `install_skill` — copy a b123d workflow skill (modeling, drawing, or repair) into the current project
-
-## Resources
-
-Read-only MCP resources available to LLM clients:
-
-- `build123d://quickref` — build123d API quick reference (primitives, booleans, positioning, selectors, fillets)
-- `build123d://selectors` — task-indexed selector cookbook (get the top face, find circular edges, filter by area/length/radius, `Select.LAST` in builder context, fillet detection)
-- `build123d://drafting` — code-first 2D engineering drawings cookbook (project a 3D part, dimension with ExtensionLine/DimensionLine, tolerances, hole-table pattern, multi-view sheet, title block, export to DXF)
-- `build123d://drafting-api` — API reference for build123d-drafting-helpers, generated from the installed library (exact signatures for Dimension, Leader, TitleBlock, Drawing, and every other public symbol)
-- `build123d://session` — live session state as JSON (current shape, named objects, snapshots, variables)
-- `build123d://bd_warehouse` — catalogue of pre-built parametric parts from bd_warehouse (bearings, fasteners, gears, pipes, threads, and more)
-
-> **build123d version**: examples in `quickref` and `selectors` are tested against build123d 0.10.x and 0.11.x (soft-pinned in `pyproject.toml` as `>=0.10,<0.12`). The exact installed version is reported at the top of each resource. If you need a different build123d version, override the dependency and verify the examples still match the API.
-
-## Prompts
-
-- `start-cad-session` — primes a new CAD design session with the task description and step-by-step workflow reminders
-
-See [llms.md](llms.md) for full tool reference and usage patterns.
-
-## Recommended workflow
-
-Build complexity falls into two tiers and the right approach differs between them.
-
-**Simple shapes** (a few primitives, up to ~5 booleans): build entirely in `execute()`.
-
-**Complex shapes** (IsoThread, multi-body fillets, high face counts): the `execute()` timeout (default 120 s) is a hard ceiling on a *single* call — not the session. The efficient pattern stays in the MCP:
-
-1. **Build incrementally** — one feature/boolean per `execute()` call. If a call times out, only that step is dropped; the session is rebuilt from your prior `execute()` history (variables, shapes, named objects come back), so you just retry it smaller.
-2. **Raise the ceiling** if one step legitimately needs longer: `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N` (also extends the import budget for heavy STEP files).
-3. **Verify** as you go: `measure("part")`, `render_view(objects="part")`.
-
-Only if a single unavoidable op still won't fit, drop out for that one op — build it in a Python script, run it with Bash, then `import_cad_file("/path/to/part.step", "part")` and verify with `measure()` / `render_view()`.
-
-> **Timeout note:** the default is 120 s (raise with `--exec-timeout N` or `BUILD123D_EXEC_TIMEOUT=N`). When a call times out the worker restarts, but the session is **rebuilt by replaying your prior `execute()` history** — only the timed-out step is dropped. Snapshots and geometry imported via other tools aren't in the log, so they don't come back; and a very long session may rebuild only partially.
-
-> **Sandboxed-host note:** if every `execute()` fails with "Worker process failed to start", your MCP host is likely blocking subprocess creation (seen with sandboxed hosts on Windows). Relaunch with `--in-process` or `BUILD123D_IN_PROCESS=1` — a degraded mode that runs the CAD session inside the server process: no crash containment, no operation timeouts.
-
-> **Import note:** after `import_cad_file()` the shape is a named session object. Always render it by name (`objects="part"`) when other shapes from the same build are also in session — two co-located shapes cause Z-fighting (striped colour artifacts). STL imports produce a shell (volume = 0); `render_view` and `measure` work, but `clearance()` and boolean operations require a solid.
-
-## bd_warehouse fasteners
-
-bd_warehouse is a full fastener system, not just a thread library. Always:
-
-1. **Probe sizes first** (correct string format is `"M6-1"` not `"M6-1.0"`):
-   ```python
-   from bd_warehouse.fastener import CounterSunkScrew
-   print(CounterSunkScrew.sizes("iso10642"))
-   ```
-2. **Instantiate the fastener object**, then pass it to the hole operation — never compute head geometry or tap-drill diameters manually:
-   ```python
-   from bd_warehouse.fastener import CounterSunkScrew, CounterSinkHole, TapHole
-   screw = CounterSunkScrew(size="M6-1", fastener_type="iso10642", length=10)
-
-   with BuildPart() as wheel:
-       Cylinder(radius=20, height=10)
-       CounterSinkHole(fastener=screw, depth=10)   # countersunk through-hole
-       TapHole(fastener=screw, depth=8)             # tapped bore
-   ```
-
-See `build123d://bd_warehouse` (MCP resource) for the full catalogue and usage patterns.
-
-## Security
-
-Unlike CAD MCP servers that simply `exec()` user code, build123d-mcp ships with **defence-in-depth sandboxing** so the server is reasonable to expose to LLM-generated and untrusted prompts. Three layers, all applied before user code runs:
-
-1. **AST inspection** — rejects imports of anything outside the allowlist (`build123d`, `bd_warehouse`, `math`, `numpy`, `inspect`, plus the rest of the safe stdlib subset and a curated set of geometric OCP submodules), blocks `eval`/`exec`/`compile`/`open`, and refuses dunder attribute access (the most common Python sandbox-escape route).
-2. **Restricted builtins** — the `__builtins__` exposed to user code has the dangerous functions removed and `__import__` rewrapped to enforce the same allowlist at runtime, so a payload that bypasses the AST check still hits the wall on import.
-3. **Execution timeout** — wall-clock limit (default 120 s, `--exec-timeout N` to override) enforced via SIGALRM, with the worker process restarted on breach so a hung script can't hold the session forever. In `--in-process` mode this layer is absent on Windows (no SIGALRM, no worker to restart) — a runaway script blocks the server.
-
-Filesystem I/O modules (`os`, `pathlib`, `shutil`), networking (`socket`, `urllib`, `requests`), shell access (`subprocess`), and the OCP file-I/O submodules (`STEPControl`, `IGESControl`, `OSD`, …) are **all blocked**. Path traversal is rejected for `export()` and `render_view(save_to=)`.
-
-This is not a perfect sandbox — memory exhaustion isn't bounded, and Python introspection chains via build123d internals could in principle escape — but it raises the bar significantly against realistic prompt-injection payloads.
-
-**The part library is trusted input.** Files under `--library` run with the same restricted builtins as user code, but the AST check inspects only each file's own top-level imports — it is a guard against accidents, not sandbox-equivalent isolation. Point `--library` only at directories you control, never at untrusted downloads.
-
-### Extending or relaxing the sandbox
-
-Two CLI flags let you adjust the import policy without giving up the rest of the layers:
-
-- `--allow-imports scipy,pandas` — extend the allowlist with named modules. Each entry permits the named root and all its submodules. Use for CAD scripts that need extra packages.
-- `--allow-all-imports` — disable the import allowlist entirely. The other layers (restricted builtins for `open`/`eval`/etc, exec timeout, dunder-attribute block) still apply. **Use only in trusted environments or under OS-level isolation** (see below).
-- `--no-sandbox` — disable **all** sandbox layers: the AST check is skipped and user code runs with unrestricted builtins (`open`/`eval`/`exec`/`__import__`). The exec timeout still applies. **Dangerous — for trusted, isolated environments only** (e.g. a benchmark harness); never expose to untrusted input. The import allowlist is lifted too (the AST check is skipped entirely), so `--allow-all-imports` is redundant alongside it.
-
-These flags also accept their values via env var (`BUILD123D_ALLOW_IMPORTS`, `BUILD123D_ALLOW_ALL_IMPORTS`, `BUILD123D_NO_SANDBOX`).
-
-> Note: `hasattr()` and `dir()` are permitted by the default sandbox; `getattr`/`vars`/`eval`/`exec`/`open` and explicit dunder access are blocked. Use `--no-sandbox` if you need the blocked ones.
-
-### Experimental tools
-
-`--experimental` (or `BUILD123D_EXPERIMENTAL=1`) enables tools that aren't production-ready yet — currently `verify_spec` and `suggest_spec`. They are **not registered without this flag**, so a default deployment never exposes them. They're gated because field data shows a `conforms: true` verdict can read to an autonomous agent as a stop signal, overriding the tool's own "not a certification" caveat ([#362](https://github.com/pzfreo/build123d-mcp/issues/362)).
-
-### Slimming the tool surface
-
-Every tool schema is loaded into the client's context on every request, and a heavy list can make clients defer the tools behind a search step. Two non-breaking ways to trim it ([#367](https://github.com/pzfreo/build123d-mcp/issues/367)):
-
-- The part-library tools (`search_library`, `load_part`) **auto-hide when no `--library` is configured** — without a library they only answer "No part library configured".
-- `--disable-tool-groups drawing` (or `BUILD123D_DISABLE_TOOL_GROUPS=drawing`) drops the 2D drawing-authoring suite (`inspect_drawing`, `lint_drawing`, `render_drawing`, `view_axes`, `save_drawing_annotations`, `suggest_view_layout`) — useful for modeling-only fleets or benchmark harnesses. Comma-separate multiple groups. Everything is on by default.
-
-> Trimming hides the *tools* only; the guidance that references them (the `workflow_hints()` guide, the `build123d://skill/drawing` resource) isn't gated yet — so don't install/read the drawing skill in a drawing-disabled deployment ([#374](https://github.com/pzfreo/build123d-mcp/issues/374)).
-
-### Stronger isolation: OS-level sandboxing
-
-For deployments that need stronger guarantees than Python-level checks (e.g. exposing the server to truly untrusted input, or running with `--allow-all-imports`), wrap the whole MCP server in an OS-level sandbox:
-
-- **[`@anthropic-ai/sandbox-runtime`](https://github.com/anthropic-experimental/sandbox-runtime)** — Anthropic's official sandbox runtime, designed exactly for this. The Claude Code docs explicitly call out wrapping MCP servers: `npx @anthropic-ai/sandbox-runtime <command-to-sandbox>`.
-- **Docker / containers** — generic approach; many community MCP-sandbox wrappers exist (e.g. [`pottekkat/sandbox-mcp`](https://github.com/pottekkat/sandbox-mcp), [`Automata-Labs-team/code-sandbox-mcp`](https://github.com/Automata-Labs-team/code-sandbox-mcp)). Run build123d-mcp inside a minimal container with no host filesystem mounts and no network egress.
-- **Claude Code's sandbox** (`/sandbox` command, macOS Seatbelt or Linux bubblewrap) — if you're running build123d-mcp under Claude Code, the host's sandbox already restricts what subprocesses can touch.
-- **Cursor / IDE dev containers** — Cursor doesn't ship MCP-specific sandboxing, but you can run the server inside a dev container that the IDE attaches to.
-
-Inside any of these, **`--allow-all-imports` becomes a reasonable default**: the OS-level isolation handles the security, and the Python-level allowlist becomes redundant friction. The recommended high-security recipe is `sandbox-runtime` (or a container) + `--allow-all-imports` + a strict exec timeout.
-
-## Requirements
+You need:
 
 - [uv](https://github.com/astral-sh/uv)
-- An MCP-compatible client (Claude Code, Claude Desktop, Cursor, etc.)
+- An AI/LLM app that supports MCP, such as Claude Code, Claude Desktop, Cursor,
+  VS Code, Continue, Cline, or Codex CLI
 
-All Python dependencies (build123d, vtk, etc.) are installed automatically by uv.
-
-## Installation
-
-No clone needed. Install directly from PyPI:
+No repository clone is needed for normal use. First check that the package can
+start:
 
 ```bash
-pip install build123d-mcp
+uv tool run --python 3.12 build123d-mcp@latest --version
 ```
 
-Or just use `uv tool run` — it fetches and runs the package in one step with no prior install required (see below).
+Then add the same command to your AI app's MCP config.
 
----
+> Python 3.11, 3.12, 3.13, and 3.14 are supported. The examples use 3.12 because
+> it is a conservative default, and uv can download it if you do not already
+> have it installed.
 
-## Adding to MCP clients
+## Connect To Your AI App
 
-The server runs over stdio — the client launches it as a subprocess using `uv tool run build123d-mcp`.
+The beginner setup is LLM app + MCP + build123d-mcp:
 
-> **Note on Python version.** The examples below pass `--python 3.12`, but **Python 3.11, 3.12, 3.13, and 3.14 are all supported and CI-tested**. 3.12 is just a safe, widely-available default — swap in whichever interpreter you have. uv will auto-download a managed Python if you don't already have one.
+- The LLM app is where you chat with the assistant.
+- MCP is the connection that lets the assistant call tools.
+- build123d-mcp is the CAD tool server the assistant calls.
 
-> **Note on `@latest`.** The examples request `build123d-mcp@latest` so each launch re-resolves to the latest published release instead of reusing uv's cached environment — without it, the client can stay pinned to whatever version uv first cached and silently miss releases. The trade-off is a short dependency-resolution step at every startup (and it needs network access to check for updates). Use plain `build123d-mcp` if you prefer faster, offline-capable starts and update manually with `uv tool upgrade build123d-mcp`. (Older versions of this README passed `--upgrade` instead; recent uv ignores that flag in `uv tool run` and warns on every launch — swap to `@latest` if you have the old config.)
+The server normally runs over stdio. Your AI app starts it as a local subprocess
+when it needs the CAD tools.
 
 ### Claude Code
 
-Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
+Add this to your project's `.mcp.json`, or to `~/.claude/mcp.json` for global
+use:
 
 ```json
 {
@@ -224,11 +69,12 @@ Add to your project's `.mcp.json` (or `~/.claude/mcp.json` for global use):
 }
 ```
 
-Restart Claude Code after editing. The tools appear automatically once connected.
+Restart Claude Code after editing.
 
 ### Claude Desktop
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS,
+or `%APPDATA%\Claude\claude_desktop_config.json` on Windows:
 
 ```json
 {
@@ -245,7 +91,8 @@ Restart Claude Desktop after saving.
 
 ### Cursor
 
-Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.json`:
+Open **Settings -> MCP** and add a new server entry, or edit
+`~/.cursor/mcp.json`:
 
 ```json
 {
@@ -258,23 +105,19 @@ Open **Settings → MCP** and add a new server entry, or edit `~/.cursor/mcp.jso
 }
 ```
 
-### VS Code (GitHub Copilot / Continue)
+### VS Code, Continue, Cline, Codex CLI
 
-For **Continue** extension, add to `.continue/config.json`:
+Use the same command and arguments in whichever MCP config your AI app or
+extension reads:
 
-```json
-{
-  "mcpServers": [
-    {
-      "name": "build123d-mcp",
-      "command": "uv",
-      "args": ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
-    }
-  ]
-}
+```text
+command: uv
+args:    ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
 ```
 
-For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your workspace:
+For GitHub Copilot MCP support in VS Code, this repository includes a
+`.vscode/mcp.json` for development checkouts and Codespaces. For another
+workspace, the config looks like this:
 
 ```json
 {
@@ -288,83 +131,181 @@ For **GitHub Copilot** with MCP support, add to `.vscode/mcp.json` in your works
 }
 ```
 
-### Codex CLI / Antigravity / Copilot / Cline (AGENTS.md)
+## First Test Prompt
 
-These agents read project guidance from `AGENTS.md`. Add the server to your agent's MCP config with the same launch command as the clients above:
+Once your AI app is connected to the server, ask your assistant something
+concrete:
 
-```
-command: uv
-args:    ["tool", "run", "--python", "3.12", "build123d-mcp@latest"]
-```
-
-Then install the workflow guidance into `AGENTS.md` so the agent follows the build → `validate()` → `export()` loop:
-
-```
-install_skill(target="agents-md", skill="modeling")   # 3D modeling from a spec / drawing
-install_skill(target="agents-md", skill="drawing")    # engineering drawings from geometry
-install_skill(target="agents-md", skill="repair")     # heal a solid that fails the validity gate
+```text
+Use build123d-mcp to make a 60 mm x 40 mm x 6 mm mounting plate with two
+5 mm through holes 40 mm apart. Render it, measure it, then export STEP and STL.
 ```
 
-(`install_skill` also supports `target="claude"`, `"cursor"`, and `"windsurf"`.)
+The useful loop is:
 
-### HTTP transport (advanced)
+1. Build one feature at a time.
+2. Render or measure after important steps.
+3. Validate before export.
+4. Export the final part.
 
-By default the server runs over **stdio** — one isolated session per client process. With `--transport http` it serves [Streamable HTTP](https://modelcontextprotocol.io/docs/concepts/transports) (via uvicorn/ASGI) for web/embedded deployments (a shared server, a Docker container, or a cloud instance):
+If something goes wrong, ask the assistant to inspect `last_error`, repair the
+script, and try the next smaller step.
+
+## Try It In GitHub Codespaces With Copilot
+
+You can also run the project in a browser with GitHub Codespaces:
+
+[Open in GitHub Codespaces](https://codespaces.new/pzfreo/build123d-mcp)
+
+For a beginner, this is the closest path to "GitHub-hosted LLM + MCP":
+
+- GitHub Codespaces gives you VS Code in the browser.
+- GitHub Copilot Chat gives you the LLM assistant.
+- build123d-mcp runs inside the codespace as the MCP CAD tool server.
+
+You need GitHub Copilot access for the LLM part. The codespace itself gives you
+a throwaway workspace with the project already checked out and the right
+Python/CAD dependencies installed. It is useful when you want to:
+
+- Try the project without changing your laptop setup
+- Run the tests before making a contribution
+- Use Copilot Chat and build123d-mcp together in the same browser workspace
+
+GitHub's docs cover:
+
+- [Using Copilot in Codespaces](https://docs.github.com/en/codespaces/reference/using-github-copilot-in-github-codespaces)
+- [Extending Copilot Chat with MCP](https://docs.github.com/copilot/customizing-copilot/using-model-context-protocol/extending-copilot-chat-with-mcp)
+
+This repository includes a dev container that installs Python 3.12, uv, and the
+Linux display packages needed for headless rendering. It also installs the
+GitHub Copilot VS Code extensions and includes a workspace MCP config at
+`.vscode/mcp.json`.
+
+When the codespace opens, it runs:
 
 ```bash
-uv tool run --python 3.12 build123d-mcp --transport http --host 0.0.0.0 --port 8000
+uv sync --all-groups
 ```
 
-Clients connect to `http://<host>:8000/mcp`.
+To check the development install:
 
-| Flag | Env var | Default | Description |
-|---|---|---|---|
-| `--transport http` | `BUILD123D_TRANSPORT=http` | `stdio` | Enable HTTP mode |
-| `--host ADDR` | `BUILD123D_HOST` | `127.0.0.1` | Bind address (`0.0.0.0` to expose externally) |
-| `--port N` | `BUILD123D_PORT` | `8000` | Listen port |
+```bash
+uv run build123d-mcp --version
+uv run pytest
+```
 
-**Claude Code with HTTP:**
+To use Copilot with the local CAD server:
+
+1. Open the codespace.
+2. Wait for setup to finish.
+3. Open Copilot Chat and choose Agent mode.
+4. Open `.vscode/mcp.json` and start the `build123d-mcp` server if VS Code has
+   not started it already.
+5. Ask the first test prompt from the previous section.
+
+The Codespaces MCP config points at the local checkout rather than the PyPI
+package:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "build123d-mcp": {
-      "type": "http",
-      "url": "http://localhost:8000/mcp"
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "build123d-mcp"]
     }
   }
 }
 ```
 
-> ⚠️ **HTTP mode uses one shared CAD session for every request** unless your host installs middleware that sets a per-request `WorkerSession` on the `_session_var` contextvar (see `http_app()`). Do **not** expose HTTP mode to more than one user without that middleware — they would all read and mutate the same session state.
+Codespaces is a good fit for trying the project, contributing, or using GitHub
+Copilot and build123d-mcp in one remote environment. For desktop AI apps on your
+own machine, the normal `uv tool run ... build123d-mcp@latest` setup is simpler
+because those apps expect to start the MCP server locally.
 
-> **Security note.** The server has no built-in authentication. When binding to `0.0.0.0`, place it behind a reverse proxy with auth (e.g. nginx + mTLS, or a VPN).
+## What It Can Do
 
-### Live session viewer (experimental)
+build123d-mcp gives an assistant tools to:
 
-Start the server with `--viewer-socket PATH` (or `BUILD123D_VIEWER_SOCKET=PATH`) to
-stream the session's geometry to an interactive 3D viewer over a Unix domain socket,
-so a human can watch and rotate the model while an agent drives the tools. Each
-shape is broadcast as a glTF-binary (glb) and updated after every geometry-mutating
-tool call. The publisher runs on a background thread in the server process and does
-not stall the agent path; a pure agent run (no `--viewer-socket`) does no extra work.
+- Execute build123d code in a persistent CAD session
+- Render PNG, SVG, and DXF previews
+- Measure volume, area, bounding boxes, topology, and centers of mass
+- Find holes, bosses, countersinks, and hole patterns
+- Check printability, clearances, alignment, and export validity
+- Import STEP/STL files for comparison
+- Export STEP, STL, DXF, SVG, or multiple formats at once
+- Save and restore session snapshots
+- Produce 2D engineering drawing previews
 
-Two example consumers ship with it, neither a package dependency: an interactive
-pyvista window ([`examples/live_viewer_pyvista.py`](examples/live_viewer_pyvista.py),
-run via `uv run --with pyvista`) and a dependency-free text client
-([`examples/live_viewer_client.py`](examples/live_viewer_client.py)). The wire
-protocol and design are in [docs/live-viewer.md](docs/live-viewer.md). POSIX only.
+For the complete tool and resource reference, see [llms.md](llms.md).
 
----
+## Guidance For Assistants
 
-## System prompt
+The server includes workflow guidance that helps assistants use the CAD loop
+properly. After connecting the server, ask your assistant to install the relevant
+guidance into your project:
 
-For best results, paste the contents of [default_prompt.md](default_prompt.md) as a system prompt in your AI client. This tells the assistant to work incrementally, verify geometry after each step, and use the tools in the right order.
+```text
+install_skill(target="agents-md", skill="modeling")
+install_skill(target="agents-md", skill="drawing")
+install_skill(target="agents-md", skill="repair")
+```
 
----
+`install_skill` also supports `target="claude"`, `"cursor"`, and `"windsurf"`.
+
+You can also paste [default_prompt.md](default_prompt.md) into your AI app as a
+system prompt.
+
+## Developer Setup
+
+For local development:
+
+```bash
+git clone https://github.com/pzfreo/build123d-mcp.git
+cd build123d-mcp
+uv sync --all-groups
+uv run build123d-mcp --version
+uv run pytest
+```
+
+To run the server from this checkout in an AI app, use:
+
+```text
+command: uv
+args:    ["run", "build123d-mcp"]
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+## Advanced Use
+
+The default stdio transport gives each app process its own isolated session.
+HTTP mode is available for web, container, or remote deployments:
+
+```bash
+uv tool run --python 3.12 "build123d-mcp[http]@latest" \
+  --transport http --host 127.0.0.1 --port 8000
+```
+
+HTTP-capable apps then connect to:
+
+```text
+http://localhost:8000/mcp
+```
+
+HTTP mode has no built-in authentication and uses one shared CAD session unless
+the host provides per-request session middleware. Do not expose it to multiple
+users directly.
+
+Other advanced topics:
+
+- Security model and sandboxing: [security.md](security.md)
+- Complete tool reference: [llms.md](llms.md)
+- Live session viewer: [docs/live-viewer.md](docs/live-viewer.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)
 
 ## Status
 
-Active development (v0.3.14).
+Active development.
 
 <!-- mcp-name: io.github.pzfreo/build123d-mcp -->


### PR DESCRIPTION
## What changed

- Reworked the README to lead with a beginner mental model: LLM app + MCP + build123d-mcp.
- Moved the front page away from a full tool inventory and toward quick start, AI app configuration, and a first test prompt.
- Added a GitHub Codespaces + Copilot path for a browser-based LLM + MCP setup.
- Added a devcontainer with Python 3.12, uv, Copilot extensions, Xvfb/display libraries for headless rendering, and port 8000 forwarding for HTTP experiments.
- Added `.vscode/mcp.json` so VS Code/Copilot in a checkout or Codespace can start `uv run build123d-mcp` directly.

## Why

The README was technically complete but hard for a new user to act on. This makes the first decision clear: build123d-mcp is not the LLM; it is the CAD tool server an LLM app calls through MCP. Codespaces is documented as an optional low-local-setup route, especially for users who want GitHub-hosted VS Code + GitHub Copilot Chat + the local MCP server in one place.

The devcontainer Dockerfile removes the unused Yarn apt source before `apt-get update`; the current base image otherwise fails because that source has a missing signing key.

## Validation

- `python -m json.tool .devcontainer/devcontainer.json`
- `python -m json.tool .vscode/mcp.json`
- `git diff --check`
- `uv run build123d-mcp --version`
- `uv run pytest tests/test_packaging.py`
- `docker build -f .devcontainer/Dockerfile .devcontainer`