### PR TITLE
[codex] Add bored boss edit diagnostics

### DIFF
--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -152,7 +152,7 @@ def http_app():
 
 @mcp.tool(annotations=_MUTATING)
 def execute(code: str) -> str:
-    """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly. find_edges(shape, geom='circle', radius=4.25, at_z=10.2, length=None, tol=0.05) filters edges for fillet/chamfer selection and prints what matched. Analysis primitives are callable IN code and return real Python objects so you compose (filter, do arithmetic) instead of copying numbers out of a tool result: measure(shape) -> dict (measure(part)['volume']), clearance(a, b) -> dict, cross_sections(shape) -> list of {position,area}, find_holes(shape) -> hole records with .location (an (x,y,z) tuple), .diameter, .depth, … ([h for h in find_holes(part) if h.location[0] < 5]); find_bosses(shape) / find_countersinks(shape) / find_hole_patterns(shape) return recogniser records too; align_check(a, b, axis='Z', mode='flush') -> dict (align_check(a,b)['delta'] is a float). shape defaults to the current shape, and measure/clearance/cross_sections stay bounded on large shapes. save_json(name, obj) writes structured analysis data (face inventories, hole tables) to a server scratch file and returns its path — use it instead of printing large results; open()/os stay blocked."""
+    """Execute build123d Python code in the persistent session. Errors include automatic fix hints — read them before retrying. Use show(shape, name) to register named objects (name defaults to 'shape'); show() immediately prints volume and face count confirming the shape is non-empty. After any boolean operation (-, +, &) call measure() to confirm it succeeded (check topology.faces). named_face(shape, name) is a built-in helper: named_face(box, 'top') returns the highest-Z face, 'bottom'/'front'/'back'/'left'/'right' work similarly. find_edges(shape, geom='circle', radius=4.25, at_z=10.2, length=None, tol=0.05) filters edges for fillet/chamfer selection and prints what matched. Analysis primitives are callable IN code and return real Python objects so you compose (filter, do arithmetic) instead of copying numbers out of a tool result: measure(shape) -> dict (measure(part)['volume']), clearance(a, b) -> dict, cross_sections(shape) -> list of {position,area}, find_holes(shape) -> hole records with .location (an (x,y,z) tuple), .diameter, .depth, … ([h for h in find_holes(part) if h.location[0] < 5]); find_bosses(shape) / find_bored_bosses(shape) / find_countersinks(shape) / find_hole_patterns(shape) return recogniser records too; align_check(a, b, axis='Z', mode='flush') -> dict (align_check(a,b)['delta'] is a float). shape defaults to the current shape, and measure/clearance/cross_sections stay bounded on large shapes. save_json(name, obj) writes structured analysis data (face inventories, hole tables) to a server scratch file and returns its path — use it instead of printing large results; open()/os stay blocked."""
     from build123d_mcp.tools.execute import execute_code
 
     result = execute_code(_resolve_session(), code)
@@ -587,6 +587,12 @@ def find_bosses(object_name: str = "") -> str:
 
 
 @mcp.tool(annotations=_READ_ONLY)
+def find_bored_bosses(object_name: str = "") -> str:
+    """Find candidate bored bosses and report target-selection/edit evidence: bore opening location, axis into the part, outward axis, bore diameter/depth, planar cap faces at the opening, whether the cap is split across multiple faces, and construction advice. Use this before extending a square/rounded-square boss with a central bore; it is read-only and diagnostic, not proof of the requested target."""
+    return _resolve_session().find_bored_bosses(object_name)
+
+
+@mcp.tool(annotations=_READ_ONLY)
 def find_countersinks(object_name: str = "") -> str:
     """Recognise countersinks (conical screw-head recesses) on a session object (defaults to current shape) — the feature find_holes reports only as a plain opening. A countersink is an internal cone flaring from a drilled bore out to a larger opening, coaxial with the drill; drill-point cones and external edge chamfers are excluded. Returns JSON: {count, countersinks: [{location (opening centre), axis (into the part), major_diameter (countersink Ø at the surface), drill_diameter, included_angle (deg, e.g. 82/90/100/120), depth}]}. object_name: named object from show() (default: current shape)."""
     return _resolve_session().find_countersinks(object_name)
@@ -670,7 +676,7 @@ BUILD123D-MCP WORKFLOW GUIDE
    Numbers are unambiguous; renders can look correct even when the geometry is wrong.
    Recommended order: execute → measure → render_view (if you need to see it).
    Compose in code: measure/clearance/cross_sections/find_holes/find_bosses/
-   find_countersinks/find_hole_patterns/align_check are callable INSIDE execute() and
+   find_bored_bosses/find_countersinks/find_hole_patterns/align_check are callable INSIDE execute() and
    return real objects — measure(part)["volume"], [h for h in find_holes(part) if
    h.location[0] < 5] — so filter/compute in code instead of copying numbers out of a
    JSON tool result. The standalone tools remain for one-shot queries.

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -513,6 +513,22 @@ class Session:
 
         self.namespace["find_bosses"] = find_bosses
 
+        def find_bored_bosses(shape: Any = None) -> list:
+            """Candidate bored bosses with bore/cap evidence.
+
+            Returns dict records: bore location/axis/diameter/depth, cap face
+            indices at the opening, split-cap risk flags, and construction
+            advice. Use before extending a square/rounded-square boss with a
+            central bore.
+            """
+            from build123d_mcp.tools.find_features import _find_bored_boss_candidates
+
+            candidates = _find_bored_boss_candidates(_resolve(shape, "find_bored_bosses"))
+            print(f"find_bored_bosses: {len(candidates)} candidate(s)")
+            return candidates
+
+        self.namespace["find_bored_bosses"] = find_bored_bosses
+
         def find_countersinks(shape: Any = None) -> list:
             """Recognise conical countersinks → list of dicts (major/drill diameter,
             included angle, depth). Filter in code. shape defaults to current shape."""

--- a/src/build123d_mcp/session.py
+++ b/src/build123d_mcp/session.py
@@ -31,6 +31,7 @@ _INJECTED = frozenset(
         "cross_sections",
         "find_holes",
         "find_bosses",
+        "find_bored_bosses",
         "find_countersinks",
         "find_hole_patterns",
         "align_check",

--- a/src/build123d_mcp/skills/b123d-edit/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-edit/SKILL.md
@@ -42,11 +42,14 @@ Classify the edit before changing code:
 - **Assembly/edit-in-context**: move or resize one part relative to another.
   Use `clearance()`, `align_check()`, and named objects to verify fit.
 - **Validity edit**: change construction so the output remains manifold.
-  Use `validate()`, `locate_gate_defects()`, `repair_advice()`, and the repair
-  skill only for diagnostics and patterns. `repair_advice()` is especially
-  useful when the intended edit is generic but topology-sensitive, such as
-  extending a bored boss, moving an annular shoulder, or fixing an
-  export-roundtrip sliver after a boolean.
+  Use `validate()`, `locate_gate_defects()`, `find_bored_bosses()`,
+  `repair_advice()`, and the repair skill only for diagnostics and patterns.
+  `find_bored_bosses()` is useful before extending a square/rounded-square
+  boss with a central bore: it reports candidate bore axes, cap faces, split
+  caps, and construction warnings. `repair_advice()` is especially useful when
+  the intended edit is generic but topology-sensitive, such as extending a
+  bored boss, moving an annular shoulder, or fixing an export-roundtrip sliver
+  after a boolean.
 
 If the requested edit is ambiguous, ask for the missing design intent before
 guessing: which face, which hole pattern, which mating clearance, or which
@@ -71,9 +74,10 @@ Avoid:
 - changing unrelated dimensions because they make the gate pass
 
 Use `measure()` face inventory, `find_holes()`, `find_hole_patterns()`,
-`find_bosses()`, and `find_countersinks()` to identify the feature in code. For
-spatial edits, render with labels or use `render_view(highlights=...)` to confirm
-the face/edge index before changing construction.
+`find_bosses()`, `find_bored_bosses()`, and `find_countersinks()` to identify
+the feature in code. For spatial edits, render with labels or use
+`render_view(highlights=...)` to confirm the face/edge index before changing
+construction.
 
 ## Step 3 - Make One Explicit Edit
 
@@ -212,6 +216,13 @@ repair_advice(
 Typical matches include split bored-boss extension, export-roundtrip sliver
 cleanup, mesh-fragile face repatching, and self-touch boolean redesign. The
 result should guide explicit build123d/OCP code in `execute()`.
+
+Before extending a bored boss, run `find_bored_bosses()` on the baseline. If it
+reports `is_split_cap=true` or multiple `cap_faces`, do not extrude one cap face:
+construct a full extension sleeve/profile from the measured bore axis and
+opening plane, then re-cut the bore continuously through old plus new material.
+Reject candidates that fill the bore, create a second bore segment, or leave
+more than one solid.
 
 ### Preserve Editability
 

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -148,6 +148,9 @@ volume. When a validity/export failure has a recognizable topology pattern,
 call `repair_advice(error_text=..., goal=..., context=...)` before writing the
 repair code. It returns generic recipes and stop conditions for the agent to
 implement explicitly in `execute()`, rather than silently mutating the B-rep.
+For an edit to a boss with a central bore, call `find_bored_bosses()` first to
+enumerate plausible bore/cap candidates and detect split cap faces before
+choosing a construction method.
 
 **Extending a boss, or relocating any planar/annular face along its own normal
 (raising a bore's counterbore opening, moving a shoulder) is a common instance
@@ -158,11 +161,19 @@ as a duplicate internal face the fuse won't dissolve (`validate()` FAILs with
 "N mesh non-manifold edge(s) — faces meet >2-ways", the two pieces stay
 separate solids, or a `validate()` PASS is followed by an `export()` failure
 after the STEP round-trip re-checks orientation on the old face's remnants).
-Extrude the feature's *own* face instead of adding a separately-built
+If `find_bored_bosses()` reports a single complete cap face, extrude the
+feature's *own* face instead of adding a separately-built
 primitive — a face extruded from the part's own boundary shares the exact
 underlying geometry, so a follow-up fuse dissolves it cleanly where a
 coincidentally-matching new primitive would not, even when it's positioned to
 match exactly:
+
+If the cap is split across multiple faces, do **not** extrude one face and then
+try to sew the damaged result. Build an explicit full-profile extension/sleeve
+from the measured bore axis and opening plane, fuse with small overlap, and
+re-cut the central bore continuously through old plus new material. This is the
+same generic pattern returned by `repair_advice()` as
+`split_bored_boss_extension`.
 
 If the boss/annular edit still fails, pass the gate text and edit goal to
 `repair_advice()`. The `split_bored_boss_extension` and

--- a/src/build123d_mcp/skills/b123d-repair/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-repair/SKILL.md
@@ -17,6 +17,9 @@ answering:
 - `validate()` / `export()` — is the current or written shape structurally
   acceptable?
 - `locate_gate_defects()` — where is the failing face, edge, or mesh defect?
+- `find_bored_bosses()` — when a failed edit involved extending a bored boss,
+  which bore/cap candidates exist, and whether the cap is split across several
+  faces?
 - `repair_advice()` — which field-proven, generic repair/edit recipe fits this
   defect and requested goal, with acceptance checks and stop conditions?
 - this repair skill — which generic repair pattern fits that defect class?

--- a/src/build123d_mcp/tools/find_features.py
+++ b/src/build123d_mcp/tools/find_features.py
@@ -6,6 +6,7 @@ run the recognition, serialise the dataclass records to JSON.
 """
 
 import json
+import math
 import re
 from dataclasses import asdict, is_dataclass
 
@@ -20,7 +21,11 @@ def _snake(name: str) -> str:
 def _round(value):
     if isinstance(value, float):
         return round(value, 4)
+    if is_dataclass(value) and not isinstance(value, type):
+        return _round(asdict(value))
     if isinstance(value, tuple):
+        return [_round(v) for v in value]
+    if isinstance(value, list):
         return [_round(v) for v in value]
     if isinstance(value, dict):
         return {k: _round(v) for k, v in value.items()}
@@ -29,6 +34,172 @@ def _round(value):
 
 def _record(feature) -> dict:
     return {k: _round(v) for k, v in asdict(feature).items()}
+
+
+def _vec3(value) -> tuple[float, float, float]:
+    if hasattr(value, "X"):
+        return (float(value.X), float(value.Y), float(value.Z))
+    return (float(value[0]), float(value[1]), float(value[2]))
+
+
+def _sub(a, b) -> tuple[float, float, float]:
+    return (a[0] - b[0], a[1] - b[1], a[2] - b[2])
+
+
+def _dot(a, b) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _norm(a) -> float:
+    return math.sqrt(_dot(a, a))
+
+
+def _unit(a) -> tuple[float, float, float]:
+    n = _norm(a)
+    if n <= 1e-12:
+        return (0.0, 0.0, 0.0)
+    return (a[0] / n, a[1] / n, a[2] / n)
+
+
+def _neg(a) -> tuple[float, float, float]:
+    return (-a[0], -a[1], -a[2])
+
+
+def _axis_distance(point, origin, axis) -> float:
+    rel = _sub(point, origin)
+    along = _dot(rel, axis)
+    perp = (rel[0] - along * axis[0], rel[1] - along * axis[1], rel[2] - along * axis[2])
+    return _norm(perp)
+
+
+def _bbox_projection(shape, axis) -> tuple[float, float]:
+    bb = shape.bounding_box()
+    xs = (float(bb.min.X), float(bb.max.X))
+    ys = (float(bb.min.Y), float(bb.max.Y))
+    zs = (float(bb.min.Z), float(bb.max.Z))
+    vals = [_dot((x, y, z), axis) for x in xs for y in ys for z in zs]
+    return (min(vals), max(vals))
+
+
+def _face_geom_name(face) -> str:
+    geom = getattr(face, "geom_type", "")
+    return getattr(geom, "name", str(geom)).upper()
+
+
+def _cap_faces_for_hole(shape, location, axis_into_part, bore_diameter: float) -> list[dict]:
+    outward = _neg(axis_into_part)
+    cap_plane_tol = max(0.08, bore_diameter * 0.03)
+    radial_limit = max(10.0, bore_diameter * 3.0)
+    cap_faces = []
+
+    for idx, face in enumerate(shape.faces()):
+        if "PLANE" not in _face_geom_name(face):
+            continue
+        try:
+            center = _vec3(face.center())
+            normal = _unit(_vec3(face.normal_at()))
+            area = float(face.area)
+        except Exception:
+            continue
+        plane_distance = abs(_dot(_sub(center, location), axis_into_part))
+        if plane_distance > cap_plane_tol:
+            continue
+        normal_alignment = _dot(normal, outward)
+        if abs(normal_alignment) < 0.85:
+            continue
+        radial_distance = _axis_distance(center, location, axis_into_part)
+        if radial_distance > radial_limit:
+            continue
+        if area <= 1e-8:
+            continue
+        cap_faces.append(
+            {
+                "index": idx,
+                "area": round(area, 4),
+                "center": _round(center),
+                "normal": _round(normal),
+                "normal_alignment_to_outward_axis": round(normal_alignment, 4),
+                "plane_distance": round(plane_distance, 4),
+                "axis_distance_from_bore": round(radial_distance, 4),
+            }
+        )
+
+    cap_faces.sort(key=lambda rec: (-rec["area"], rec["axis_distance_from_bore"]))
+    return cap_faces
+
+
+def _find_bored_boss_candidates(shape) -> list[dict]:
+    from build123d_drafting import find_holes as _find_holes
+
+    candidates = []
+    envelope_tol = 0.25
+    holes = list(_find_holes(shape))
+    for hole_idx, hole in enumerate(holes):
+        axis = _unit(_vec3(hole.axis))
+        if axis == (0.0, 0.0, 0.0):
+            continue
+        location = _vec3(hole.location)
+        outward = _neg(axis)
+        diameter = float(hole.diameter)
+        cap_faces = _cap_faces_for_hole(shape, location, axis, diameter)
+        if not cap_faces:
+            continue
+
+        _min_proj, max_proj = _bbox_projection(shape, outward)
+        loc_proj = _dot(location, outward)
+        on_outer_envelope = abs(max_proj - loc_proj) <= max(envelope_tol, diameter * 0.05)
+        split_cap = len(cap_faces) > 1
+        risk_flags = []
+        if split_cap:
+            risk_flags.append("split_cap_front")
+        if not on_outer_envelope:
+            risk_flags.append("opening_not_on_outer_envelope")
+        if getattr(hole, "bottom", "") != "through":
+            risk_flags.append(f"bore_bottom_{hole.bottom}")
+
+        if split_cap:
+            construction_advice = (
+                "The bore opening cap is split across multiple planar faces. Do not "
+                "extrude one face as the boss profile; build a complete extension "
+                "solid/sleeve from the measured axis/profile and re-cut the central "
+                "bore continuously through old plus new material."
+            )
+        else:
+            construction_advice = (
+                "One planar cap face was found at the bore opening. A face-derived "
+                "profile may be usable, but still verify the full outer wire and "
+                "re-cut the bore continuously after any fuse."
+            )
+
+        candidates.append(
+            {
+                "hole_index": hole_idx,
+                "location": _round(location),
+                "axis_into_part": _round(axis),
+                "outward_axis": _round(outward),
+                "bore_diameter": round(diameter, 4),
+                "bore_depth": round(float(hole.depth), 4),
+                "bottom": hole.bottom,
+                "counterbore": _round(getattr(hole, "cbore", None)),
+                "spotface": _round(getattr(hole, "spotface", None)),
+                "cap_face_count": len(cap_faces),
+                "cap_area_total": round(sum(float(face["area"]) for face in cap_faces), 4),
+                "cap_faces": cap_faces[:8],
+                "is_split_cap": split_cap,
+                "opening_on_outer_envelope": on_outer_envelope,
+                "risk_flags": risk_flags,
+                "construction_advice": construction_advice,
+            }
+        )
+
+    candidates.sort(
+        key=lambda rec: (
+            not rec["opening_on_outer_envelope"],
+            -rec["bore_diameter"],
+            rec["hole_index"],
+        )
+    )
+    return candidates
 
 
 def find_holes(session, object_name: str = "") -> str:
@@ -88,3 +259,29 @@ def find_bosses(session, object_name: str = "") -> str:
         return json.dumps({"error": str(exc)})
     bosses = [_record(b) for b in _find_bosses(shape)]
     return json.dumps({"count": len(bosses), "bosses": bosses})
+
+
+def find_bored_bosses(session, object_name: str = "") -> str:
+    """Find bored-boss edit candidates with bore/cap evidence.
+
+    This is a diagnostic, not a proof that the user's target is one of these
+    candidates. It helps agents avoid the common failure mode of extruding one
+    split cap face and leaving an open shell or filled bore.
+    """
+
+    try:
+        shape = _resolve_shape(session, object_name)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+    candidates = _find_bored_boss_candidates(shape)
+    return json.dumps(
+        {
+            "count": len(candidates),
+            "candidates": candidates,
+            "selection_advice": (
+                "Treat this as a candidate table. Match against the request's visual "
+                "and dimensional qualifiers, mark plausible candidates in a render, "
+                "then measure the current boss length/depth before editing."
+            ),
+        }
+    )

--- a/src/build123d_mcp/tools/find_features.py
+++ b/src/build123d_mcp/tools/find_features.py
@@ -50,6 +50,14 @@ def _dot(a, b) -> float:
     return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 
 
+def _cross(a, b) -> tuple[float, float, float]:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
 def _norm(a) -> float:
     return math.sqrt(_dot(a, a))
 
@@ -79,6 +87,32 @@ def _bbox_projection(shape, axis) -> tuple[float, float]:
     zs = (float(bb.min.Z), float(bb.max.Z))
     vals = [_dot((x, y, z), axis) for x in xs for y in ys for z in zs]
     return (min(vals), max(vals))
+
+
+def _perp_basis(axis) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    ref = (1.0, 0.0, 0.0) if abs(axis[0]) < 0.9 else (0.0, 1.0, 0.0)
+    u = _unit(_cross(axis, ref))
+    return u, _unit(_cross(axis, u))
+
+
+def _bbox_corners(shape) -> list[tuple[float, float, float]]:
+    bb = shape.bounding_box()
+    xs = (float(bb.min.X), float(bb.max.X))
+    ys = (float(bb.min.Y), float(bb.max.Y))
+    zs = (float(bb.min.Z), float(bb.max.Z))
+    return [(x, y, z) for x in xs for y in ys for z in zs]
+
+
+def _perp_spans(shape, axis) -> tuple[float, float]:
+    u, v = _perp_basis(axis)
+    corners = _bbox_corners(shape)
+    us = [_dot(c, u) for c in corners]
+    vs = [_dot(c, v) for c in corners]
+    return (max(us) - min(us), max(vs) - min(vs))
+
+
+def _radial_extent(shape, origin, axis) -> float:
+    return max(_axis_distance(corner, origin, axis) for corner in _bbox_corners(shape))
 
 
 def _face_geom_name(face) -> str:
@@ -112,6 +146,7 @@ def _cap_faces_for_hole(shape, location, axis_into_part, bore_diameter: float) -
             continue
         if area <= 1e-8:
             continue
+        span_u, span_v = _perp_spans(face, axis_into_part)
         cap_faces.append(
             {
                 "index": idx,
@@ -121,6 +156,8 @@ def _cap_faces_for_hole(shape, location, axis_into_part, bore_diameter: float) -
                 "normal_alignment_to_outward_axis": round(normal_alignment, 4),
                 "plane_distance": round(plane_distance, 4),
                 "axis_distance_from_bore": round(radial_distance, 4),
+                "radial_extent_from_bore": round(_radial_extent(face, location, axis_into_part), 4),
+                "perpendicular_span": [round(span_u, 4), round(span_v, 4)],
             }
         )
 
@@ -144,6 +181,19 @@ def _find_bored_boss_candidates(shape) -> list[dict]:
         cap_faces = _cap_faces_for_hole(shape, location, axis, diameter)
         if not cap_faces:
             continue
+
+        shape_span_u, shape_span_v = _perp_spans(shape, axis)
+        local_cap_faces = [
+            face
+            for face in cap_faces
+            if (
+                face["perpendicular_span"][0] < shape_span_u * 0.85
+                or face["perpendicular_span"][1] < shape_span_v * 0.85
+            )
+        ]
+        if not local_cap_faces:
+            continue
+        cap_faces = local_cap_faces
 
         _min_proj, max_proj = _bbox_projection(shape, outward)
         loc_proj = _dot(location, outward)

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -864,6 +864,10 @@ class WorkerSession:
     def find_bosses(self, object_name: str = "") -> str:
         raise NotImplementedError
 
+    @_op(_tool(f"{_T}.find_features:find_bored_bosses"), _GEOMETRY_TIMEOUT)
+    def find_bored_bosses(self, object_name: str = "") -> str:
+        raise NotImplementedError
+
     @_op(_tool(f"{_T}.find_features:find_hole_patterns"), _GEOMETRY_TIMEOUT)
     def find_hole_patterns(self, object_name: str = "") -> str:
         raise NotImplementedError

--- a/tests/test_find_features.py
+++ b/tests/test_find_features.py
@@ -10,7 +10,12 @@ import json
 import pytest
 
 from build123d_mcp.session import Session
-from build123d_mcp.tools.find_features import find_bosses, find_hole_patterns, find_holes
+from build123d_mcp.tools.find_features import (
+    find_bored_bosses,
+    find_bosses,
+    find_hole_patterns,
+    find_holes,
+)
 
 
 @pytest.fixture
@@ -59,10 +64,50 @@ def test_find_bosses(session):
     assert boss["location"] == [0.0, 0.0, 13.0]
 
 
+def test_find_bored_bosses_reports_cap_evidence(session):
+    session.execute(
+        "p = Box(40, 40, 8)\n"
+        "boss = Pos(25, 0, 0) * Box(10, 20, 16)\n"
+        "bore = Pos(25, 0, 0) * Rot(0, 90, 0) * Cylinder(3, 24)\n"
+        "p = p + boss - bore\n"
+        "show(p, 'bored')"
+    )
+
+    r = json.loads(find_bored_bosses(session, "bored"))
+    assert r["count"] == 1
+    (candidate,) = r["candidates"]
+    assert candidate["bore_diameter"] == pytest.approx(6.0)
+    assert candidate["axis_into_part"][0] == pytest.approx(-1.0)
+    assert candidate["outward_axis"][0] == pytest.approx(1.0)
+    assert candidate["cap_face_count"] == 1
+    assert candidate["opening_on_outer_envelope"] is True
+    assert "re-cut the bore continuously" in candidate["construction_advice"]
+
+
+def test_find_bored_bosses_flags_split_cap_front(session):
+    session.execute(
+        "p = Box(40, 40, 8)\n"
+        "boss = Pos(25, 0, 0) * Box(10, 20, 16)\n"
+        "bore = Pos(25, 0, 0) * Rot(0, 90, 0) * Cylinder(3, 24)\n"
+        "slot = Pos(30.5, 0, 0) * Box(2, 4, 20)\n"
+        "p = p + boss - bore - slot\n"
+        "show(p, 'split_bored')"
+    )
+
+    r = json.loads(find_bored_bosses(session, "split_bored"))
+    assert r["count"] == 1
+    (candidate,) = r["candidates"]
+    assert candidate["is_split_cap"] is True
+    assert candidate["cap_face_count"] >= 2
+    assert "split_cap_front" in candidate["risk_flags"]
+    assert "Do not extrude one face" in candidate["construction_advice"]
+
+
 def test_plain_box_has_no_features(session):
     session.execute("show(Box(10, 10, 10), 'box')")
     assert json.loads(find_holes(session, "box")) == {"count": 0, "holes": []}
     assert json.loads(find_bosses(session, "box")) == {"count": 0, "bosses": []}
+    assert json.loads(find_bored_bosses(session, "box"))["count"] == 0
 
 
 def test_find_hole_patterns_bolt_circle(session):

--- a/tests/test_find_features.py
+++ b/tests/test_find_features.py
@@ -103,6 +103,31 @@ def test_find_bored_bosses_flags_split_cap_front(session):
     assert "Do not extrude one face" in candidate["construction_advice"]
 
 
+def test_find_bored_bosses_ignores_plain_drilled_plate(session):
+    session.execute("p = Box(40, 40, 8) - Cylinder(3, 12)\nshow(p, 'plate')")
+
+    assert json.loads(find_bored_bosses(session, "plate")) == {
+        "count": 0,
+        "candidates": [],
+        "selection_advice": (
+            "Treat this as a candidate table. Match against the request's visual "
+            "and dimensional qualifiers, mark plausible candidates in a render, "
+            "then measure the current boss length/depth before editing."
+        ),
+    }
+
+
+def test_find_bored_bosses_ignores_shared_plate_face_with_multiple_holes(session):
+    session.execute(
+        "p = Box(80, 40, 8)\n"
+        "p = p - Pos(-20, 0, 0) * Cylinder(3, 12)\n"
+        "p = p - Pos(20, 0, 0) * Cylinder(4, 12)\n"
+        "show(p, 'plate')"
+    )
+
+    assert json.loads(find_bored_bosses(session, "plate"))["count"] == 0
+
+
 def test_plain_box_has_no_features(session):
     session.execute("show(Box(10, 10, 10), 'box')")
     assert json.loads(find_holes(session, "box")) == {"count": 0, "holes": []}

--- a/tests/test_outcomes.py
+++ b/tests/test_outcomes.py
@@ -910,6 +910,7 @@ def test_mcp_lists_all_tools():
         "align_check",
         "find_holes",
         "find_bosses",
+        "find_bored_bosses",
         "find_countersinks",
         "find_hole_patterns",
         "resolve",

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -27,6 +27,7 @@ def test_read_only_query_tools_are_marked_read_only():
         "find_holes",
         "find_hole_patterns",
         "find_bosses",
+        "find_bored_bosses",
         "find_countersinks",
         "align_check",
         "session_state",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2019,6 +2019,7 @@ def test_session_state_variables_exclude_injected_helpers(session):
     execute_code(session, "x = 5")
     variables = json.loads(session_state(session))["variables"]
     assert "x" in variables
+    assert "find_bored_bosses" in _INJECTED
     assert not (_INJECTED & set(variables))
 
 

--- a/tests/test_worker_boundary_coverage.py
+++ b/tests/test_worker_boundary_coverage.py
@@ -169,6 +169,11 @@ def _find_bosses(ws, tmp_path):
     assert "error" not in r and r["bosses"] == []
 
 
+def _find_bored_bosses(ws, tmp_path):
+    r = json.loads(ws.find_bored_bosses("a"))
+    assert "error" not in r and r["candidates"] == []
+
+
 def _find_countersinks(ws, tmp_path):
     # seeded box 'a' has no countersinks; a non-error reply proves the worker's
     # objects were consulted (an empty parent proxy would error on unknown 'a').
@@ -292,6 +297,7 @@ SESSION_STATEFUL_TOOLS = {
     "align_check": _align_check,
     "find_holes": _find_holes,
     "find_bosses": _find_bosses,
+    "find_bored_bosses": _find_bored_bosses,
     "find_countersinks": _find_countersinks,
     "find_hole_patterns": _find_hole_patterns,
     "cross_sections": _cross_sections,


### PR DESCRIPTION
## Summary
- add read-only find_bored_bosses diagnostics for bored-boss edit candidates
- expose the helper through server, worker, and execute() session namespace
- update MCP edit/modeling/repair skills to use the diagnostic before split-cap boss edits
- add synthetic tests for ordinary, split-cap, and negative plain-plate bored-boss cases

## Verification
- uv run ruff check src/build123d_mcp/tools/find_features.py src/build123d_mcp/session.py tests/test_find_features.py tests/test_tools.py
- uv run ruff format --check src/build123d_mcp/tools/find_features.py src/build123d_mcp/session.py tests/test_find_features.py tests/test_tools.py
- uv run mypy src/build123d_mcp/tools/find_features.py
- uv run pytest tests/test_find_features.py tests/test_tools.py::test_session_state_variables_exclude_injected_helpers tests/test_tool_annotations.py tests/test_outcomes.py::test_mcp_lists_all_tools tests/test_repair_advice.py -q
- adversarial probe: plain drilled plate and multi-hole flat plate return 0 bored-boss candidates; synthetic rectangular/split-cap bored bosses still return 1