### PR TITLE
fix: stop build123d INFO logs leaking to server stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.76
+
+### Fixed
+
+- **build123d's per-object INFO logging no longer leaks to the server's stderr, where a hostile host stderr turns it into a logging-error traceback in every tool result.** build123d emits an INFO record on every object construction (`"<ctx> context requested by <op>"`). build123d itself only attaches a `NullHandler`, but FastMCP installs a root stderr handler, so those records propagate to the server's stderr. On a host whose stderr is a pipe where writes fail — the Copilot/Codex CLI on Windows, where each write raises `OSError(EINVAL)` — the standard-library logging machinery prints a `--- Logging error ---` traceback, and it lands in the middle of the tool result the user sees. `_build_session` (the setup path shared by the worker and in-process modes) now sets `logging.getLogger("build123d").propagate = False`, so the per-object chatter stops reaching that handler. build123d keeps its own `NullHandler`, so nothing that wants the log is affected. Thanks @faisal-shah.
+
 ## v0.3.73
 
 ### Fixed

--- a/src/build123d_mcp/worker.py
+++ b/src/build123d_mcp/worker.py
@@ -44,6 +44,21 @@ def _build_session(
     Shared by worker_main (subprocess mode) and InProcessSession so a future
     setup step cannot be added to one mode and forgotten in the other.
     """
+    # build123d logs at INFO on every object construction ("<ctx> context requested
+    # by <op>"). build123d itself only attaches a NullHandler, but FastMCP installs a
+    # root stderr handler, so those records propagate to the server's stderr. On a
+    # host whose stderr is hostile (the Copilot/Codex CLI on Windows pipes it to a
+    # handle where each write raises OSError), the standard-library logging machinery
+    # then prints a "--- Logging error ---" traceback into the middle of every tool
+    # result. Cut propagation so build123d's per-object chatter stops reaching that
+    # handler; build123d keeps its own NullHandler, so nothing that wants the log is
+    # affected. Set here, the one setup path shared by the worker and in-process
+    # modes, so both are covered. (Getting the logger by name works before build123d
+    # is imported; the flag persists to when it first logs.)
+    import logging as _logging
+
+    _logging.getLogger("build123d").propagate = False
+
     if allow_all_imports or extra_allowed_imports or no_sandbox:
         import build123d_mcp.security as _sec
 

--- a/tests/test_build123d_log_propagation.py
+++ b/tests/test_build123d_log_propagation.py
@@ -1,0 +1,43 @@
+"""build123d's per-object INFO logging must not propagate to the server's stderr.
+
+build123d logs on every object construction. With FastMCP's root stderr handler
+installed, those records reach stderr; on a host whose stderr is hostile (the
+Copilot/Codex CLI on Windows, where a write raises OSError) the logging machinery
+then prints a "--- Logging error ---" traceback into every tool result.
+_build_session cuts propagation so that cannot happen.
+"""
+
+import io
+import logging
+
+from build123d_mcp.worker import _build_session
+
+
+def test_build_session_disables_build123d_log_propagation():
+    logging.getLogger("build123d").propagate = True  # undo any prior state
+    _build_session("", 30, False, ())
+    assert logging.getLogger("build123d").propagate is False
+
+
+def test_build123d_logs_do_not_reach_a_root_stderr_handler():
+    """With a root stderr handler installed (as FastMCP does), a build123d INFO
+    record must not surface on stderr once _build_session has run."""
+    root = logging.getLogger()
+    captured = io.StringIO()
+    handler = logging.StreamHandler(captured)
+    root.addHandler(handler)
+    prior_level = root.level
+    root.setLevel(logging.INFO)
+    try:
+        logging.getLogger("build123d").propagate = True  # simulate the unpatched state
+        logging.getLogger("build123d").info("context requested by Box")
+        assert "context requested by Box" in captured.getvalue()  # leaks without the fix
+
+        captured.truncate(0)
+        captured.seek(0)
+        _build_session("", 30, False, ())  # applies propagate = False
+        logging.getLogger("build123d").info("context requested by Box")
+        assert captured.getvalue() == ""  # no longer reaches the stderr handler
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(prior_level)


### PR DESCRIPTION
build123d logs at INFO on every object construction (`"<ctx> context requested by <op>"`). build123d itself attaches only a `NullHandler`, but FastMCP installs a root stderr handler, so those records propagate to the server's stderr.

On a host whose stderr is a pipe where writes fail, that turns into noise in the user's output. Concretely, under the Copilot/Codex CLI on Windows each stderr write raises `OSError(EINVAL)`, and the standard-library logging machinery responds by printing a `--- Logging error ---` traceback — which lands in the middle of the tool result the user reads. A one-line `execute` that builds a `Box` comes back with a logging stack trace wrapped around it.

## Fix

`_build_session` — the setup path shared by the worker and in-process modes — sets `logging.getLogger("build123d").propagate = False`. build123d's per-object records stop reaching the root stderr handler. build123d keeps its own `NullHandler`, so anything that actually wants the log is unaffected, and setting the flag by logger name works before build123d is imported (it persists to when it first logs).

Placing it in `_build_session` covers both modes from one point, matching that function's existing "a setup step can't be added to one mode and forgotten in the other" contract.

## Scope

This is the stderr-noise half of the #143 experience on Windows, and it stands on its own: it also cleans up the output under `--in-process`, which is the practical way to run on a host where the worker subprocess can't start. It does not attempt to make the worker subprocess itself run under such a host — that's a separate problem.

## Tests

- `tests/test_build123d_log_propagation.py`: `_build_session` sets `propagate = False`, and a build123d INFO record no longer reaches an installed root stderr handler afterward.
- Green with `test_in_process_session`. `ruff` clean.
