### PR TITLE
[codex] Refactor mesh gate result reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **MCP comparison calls are now one `compare()` tool.** External prompt authors should replace standalone MCP tool calls to `clearance`, `align_check`, `shape_compare`, and `diff_snapshot` with `compare(kind="fit")`, `compare(kind="align")`, `compare(kind="shape")`, and `compare(kind="snapshot")` respectively. The same computations remain available as composable Python helpers inside `execute()` code, so `clearance(a, b)` and `align_check(a, b)` still work there; the consolidation only changes the advertised standalone MCP surface.
+
+### Fixed
+
+- **The exact mesh gate no longer reports a timed-out refined probe as refined-clean.** `_mesh_defects_exact()` now returns a structured `MeshGateResult` instead of a growing positional tuple, so adding a defect class no longer requires mechanical unpacking edits across every caller. The report also gains `refined_untriangulated_faces_verified`; if the refined face-tessellation probe runs out of budget after another definite defect has already been found, the known defect is still reported but the refined count is explicitly marked unverified instead of reading as `0` confirmed defects.
+
 ## v0.3.73
 
 ### Fixed

--- a/src/build123d_mcp/_gate_subprocess.py
+++ b/src/build123d_mcp/_gate_subprocess.py
@@ -42,23 +42,10 @@ def main() -> None:
         # deadline=inf: no in-process time bail — the parent's subprocess timeout
         # bounds us, so the triangle ceiling can be much higher than the in-worker
         # checks' (#381) — it's a memory/sanity backstop here, not a time proxy.
-        nm, open_edges, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(
+        result = _mesh_defects_exact(
             shape, max_triangles=_EXACT_ISOLATED_MAX_TRIS, deadline=float("inf")
         )
-        print(
-            _MARKER
-            + json.dumps(
-                {
-                    "nm": nm,
-                    "open": open_edges,
-                    "untri": untri,
-                    "refined_untri": refined_untri,
-                    "nmv": nmv,
-                    "vdefl": vdefl,
-                    "ok": ok,
-                }
-            )
-        )
+        print(_MARKER + json.dumps(result.to_json()))
     except Exception as exc:  # noqa: BLE001 — report and exit cleanly
         print(_MARKER + json.dumps({"error": f"{type(exc).__name__}: {exc}"}))
 

--- a/src/build123d_mcp/tools/export.py
+++ b/src/build123d_mcp/tools/export.py
@@ -319,7 +319,7 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
             # and B-rep checks already spent some), so the subprocess is always
             # killed before the parent kills the worker. B-rep checks run in-process
             # (cheap). On timeout the mesh check is skipped (B-rep only) + a warning.
-            from build123d_mcp.tools.validate import _run_mesh_gate_subprocess
+            from build123d_mcp.tools.validate import MeshGateResult, _run_mesh_gate_subprocess
 
             # Margin covers the B-rep checks that still run in-process after this
             # (fast — BRepCheck, not meshing) + subprocess teardown + parent poll
@@ -333,7 +333,7 @@ def export_file(session, filename: str, format: str = "step", object_name: str =
             report = _gate_report(
                 gate_shape,
                 exact=True,
-                mesh_override=_mesh if _mesh is not None else (0, 0, 0, 0, 0, 0, False),
+                mesh_override=_mesh if _mesh is not None else MeshGateResult.unchecked(),
             )
             if not report["passes_gate"]:
                 suffix += (

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -14,6 +14,7 @@ real solid body, and non-degenerate volume.
 
 import json
 import time
+from dataclasses import dataclass
 
 _EPS = 1e-9
 
@@ -85,6 +86,90 @@ _MESH_GATE_MIN_S = 10.0
 # Such a part is deferred to the fast check (UNDETERMINED), never failed. A genuine
 # small/moderate open part still ladders and is caught; only large parts degrade.
 _LADDER_BASE_MAX_TRIS = 40000
+
+
+@dataclass(frozen=True)
+class MeshGateResult:
+    """Structured result from the exact mesh validity gate."""
+
+    nonmanifold_edges: int = 0
+    open_edges: int = 0
+    untriangulated_faces: int = 0
+    refined_untriangulated_faces: int = 0
+    nonmanifold_vertices: int = 0
+    vertex_deflection_defects: int = 0
+    ok: bool = False
+    refined_verified: bool = False
+
+    @classmethod
+    def unchecked(cls) -> "MeshGateResult":
+        return cls(ok=False, refined_verified=False)
+
+    @classmethod
+    def from_legacy(cls, value) -> "MeshGateResult":
+        if isinstance(value, cls):
+            return value
+        if len(value) == 6:
+            nm, open_edges, untri, nmv, vdefl, ok = value
+            return cls(
+                nonmanifold_edges=int(nm),
+                open_edges=int(open_edges),
+                untriangulated_faces=int(untri),
+                nonmanifold_vertices=int(nmv),
+                vertex_deflection_defects=int(vdefl),
+                ok=bool(ok),
+                refined_verified=False,
+            )
+        if len(value) == 7:
+            nm, open_edges, untri, refined_untri, nmv, vdefl, ok = value
+            return cls(
+                nonmanifold_edges=int(nm),
+                open_edges=int(open_edges),
+                untriangulated_faces=int(untri),
+                refined_untriangulated_faces=int(refined_untri),
+                nonmanifold_vertices=int(nmv),
+                vertex_deflection_defects=int(vdefl),
+                ok=bool(ok),
+                refined_verified=True,
+            )
+        if len(value) == 8:
+            nm, open_edges, untri, refined_untri, nmv, vdefl, ok, refined_verified = value
+            return cls(
+                nonmanifold_edges=int(nm),
+                open_edges=int(open_edges),
+                untriangulated_faces=int(untri),
+                refined_untriangulated_faces=int(refined_untri),
+                nonmanifold_vertices=int(nmv),
+                vertex_deflection_defects=int(vdefl),
+                ok=bool(ok),
+                refined_verified=bool(refined_verified),
+            )
+        raise ValueError("mesh gate result must have 6, 7, or 8 fields")
+
+    @classmethod
+    def from_json(cls, data: dict) -> "MeshGateResult":
+        return cls(
+            nonmanifold_edges=int(data["nm"]),
+            open_edges=int(data["open"]),
+            untriangulated_faces=int(data["untri"]),
+            refined_untriangulated_faces=int(data.get("refined_untri", 0)),
+            nonmanifold_vertices=int(data.get("nmv", 0)),
+            vertex_deflection_defects=int(data.get("vdefl", 0)),
+            ok=bool(data["ok"]),
+            refined_verified=bool(data.get("refined_verified", True)),
+        )
+
+    def to_json(self) -> dict:
+        return {
+            "nm": self.nonmanifold_edges,
+            "open": self.open_edges,
+            "untri": self.untriangulated_faces,
+            "refined_untri": self.refined_untriangulated_faces,
+            "nmv": self.nonmanifold_vertices,
+            "vdefl": self.vertex_deflection_defects,
+            "ok": self.ok,
+            "refined_verified": self.refined_verified,
+        }
 
 
 def _edge_incidence_counts(mf, n_nodes: int):
@@ -177,14 +262,13 @@ def _edge_face_adjacency(occ, fmap, emap):
     return adj
 
 
-def _run_mesh_gate_subprocess(step_path: str, timeout: float):
+def _run_mesh_gate_subprocess(step_path: str, timeout: float) -> MeshGateResult | None:
     """Run the exact mesh check on a written STEP in a separate process, hard-
     bounded by ``timeout`` seconds (the only way to bound the un-interruptible OCC
-    tessellation without risking the worker). Returns
-    ``(nm, open, untri, refined_untri, nmv, vdefl, ok)`` or ``None`` if the subprocess timed out
-    (was killed), errored, or its result could not be parsed — ``None`` means
-    UNDETERMINED, so the caller keeps its safe in-process verdict rather than
-    inventing one.
+    tessellation without risking the worker). Returns ``MeshGateResult`` or
+    ``None`` if the subprocess timed out (was killed), errored, or its result could
+    not be parsed — ``None`` means UNDETERMINED, so the caller keeps its safe
+    in-process verdict rather than inventing one.
     """
     import json
     import subprocess
@@ -207,19 +291,13 @@ def _run_mesh_gate_subprocess(step_path: str, timeout: float):
                 return None
             if "error" in d:
                 return None
-            return (
-                int(d["nm"]),
-                int(d["open"]),
-                int(d["untri"]),
-                int(d.get("refined_untri", 0)),
-                int(d.get("nmv", 0)),
-                int(d.get("vdefl", 0)),
-                bool(d["ok"]),
-            )
+            return MeshGateResult.from_json(d)
     return None
 
 
-def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None) -> dict:
+def _gate_report(
+    shape, exact: bool = False, mesh_override: MeshGateResult | tuple | None = None
+) -> dict:
     """Return the validity-gate verdict for a shape as a plain dict.
 
     Reused by the export tool so a 3D export can warn when the written solid
@@ -276,53 +354,37 @@ def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None)
         # Mesh results computed out-of-process (export's subprocess retry for a
         # part too large to mesh within the in-process budget). Bounded by a hard
         # subprocess timeout there, so it can run the full check without skipping.
-        if len(mesh_override) == 6:
-            # Backwards-compatible parsing for older private callers/tests that still
-            # provide the pre-#401 tuple.
-            mesh_nm_edges, mesh_open_edges, mesh_untri_faces, mesh_nmv, mesh_vdefl, mesh_ok = (
-                mesh_override
-            )
-            mesh_refined_untri_faces = 0
-        else:
-            (
-                mesh_nm_edges,
-                mesh_open_edges,
-                mesh_untri_faces,
-                mesh_refined_untri_faces,
-                mesh_nmv,
-                mesh_vdefl,
-                mesh_ok,
-            ) = mesh_override
+        mesh = MeshGateResult.from_legacy(mesh_override)
         # ok=False means the out-of-process check timed out / couldn't determine —
         # mark it "skipped" so the "mesh validity not verified" warning fires and the
         # caller doesn't report false confidence on an unchecked part.
-        mesh_check = "exact-subprocess" if mesh_ok else "skipped"
+        mesh_check = "exact-subprocess" if mesh.ok else "skipped"
     else:
         _cap = _EXACT_EXPORT_MAX_TRIS if exact else _EXACT_INLINE_MAX_TRIS
         _mesh_deadline = time.monotonic() + _GATE_MESH_BUDGET_S
-        (
-            mesh_nm_edges,
-            mesh_open_edges,
-            mesh_untri_faces,
-            mesh_refined_untri_faces,
-            mesh_nmv,
-            mesh_vdefl,
-            mesh_ok,
-        ) = _mesh_defects_exact(shape, max_triangles=_cap, deadline=_mesh_deadline)
+        mesh = _mesh_defects_exact(shape, max_triangles=_cap, deadline=_mesh_deadline)
         mesh_check = "exact"
-        if not mesh_ok:
+        if not mesh.ok:
             # Exact check over budget / unbuildable — fall back to the fast
             # non-manifold-only check (no open-edge / face-tessellation analysis),
             # under the SAME deadline. This in-worker fallback is structurally blind to
             # open edges (mesh_open_edges stays 0), so the report warns (#381); a large
             # shape avoids it entirely by running the exact check out-of-process.
-            mesh_nm_edges, mesh_ok = _mesh_defects(shape, deadline=_mesh_deadline)
-            mesh_open_edges = mesh_untri_faces = mesh_refined_untri_faces = mesh_nmv = (
-                mesh_vdefl
-            ) = 0
-            mesh_check = "fast" if mesh_ok else "skipped"
-            if not mesh_ok:
-                mesh_nm_edges = 0  # neither check could run in budget — defer to B-rep
+            mesh_nm_edges, mesh_fast_ok = _mesh_defects(shape, deadline=_mesh_deadline)
+            mesh = MeshGateResult(
+                nonmanifold_edges=mesh_nm_edges if mesh_fast_ok else 0,
+                ok=mesh_fast_ok,
+                refined_verified=False,
+            )
+            mesh_check = "fast" if mesh.ok else "skipped"
+    mesh_nm_edges = mesh.nonmanifold_edges
+    mesh_open_edges = mesh.open_edges
+    mesh_untri_faces = mesh.untriangulated_faces
+    mesh_refined_untri_faces = mesh.refined_untriangulated_faces
+    mesh_nmv = mesh.nonmanifold_vertices
+    mesh_vdefl = mesh.vertex_deflection_defects
+    mesh_ok = mesh.ok
+    mesh_refined_verified = mesh.refined_verified
     mesh_nonmanifold = mesh_ok and mesh_nm_edges > 0
     mesh_open = mesh_ok and mesh_open_edges > 0
     mesh_incomplete = mesh_ok and mesh_untri_faces > 0
@@ -413,6 +475,12 @@ def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None)
             "that only fail at a finer mesh. export() runs the authoritative check — "
             "test-export before trusting this PASS"
         )
+    elif mesh_ok and not mesh_refined_verified:
+        warnings.append(
+            "refined face-tessellation not verified — the exact mesh gate found other "
+            "defects, then the finer face-tessellation probe ran out of budget before "
+            "proving whether additional tolerance-sensitive faces exist"
+        )
 
     passes = (
         brep_valid
@@ -439,6 +507,7 @@ def _gate_report(shape, exact: bool = False, mesh_override: tuple | None = None)
         "mesh_vertex_deflection_defects": mesh_vdefl,
         "untriangulated_faces": mesh_untri_faces,
         "refined_untriangulated_faces": mesh_refined_untri_faces,
+        "refined_untriangulated_faces_verified": mesh_refined_verified,
         "mesh_check": mesh_check,
         "brep_valid": brep_valid,
         "warnings": warnings,
@@ -554,7 +623,7 @@ def _mesh_defects(shape, deadline: float | None = None) -> tuple[int, bool]:
 
 def _mesh_defects_exact(
     shape, max_triangles: int | None = None, deadline: float | None = None
-) -> tuple[int, int, int, int, int, int, bool]:
+) -> MeshGateResult:
     """Accurate mesh non-manifold count via a topology-stitched tessellation.
 
     Builds one conformal boundary mesh from the per-face OCC triangulations by
@@ -573,16 +642,15 @@ def _mesh_defects_exact(
     B-reps), so callers use it where correctness matters most (export) rather
     than on every interactive validate(). ``max_triangles`` bounds that cost: if
     the tessellation exceeds it, return ok=False *before* the slow stitch so the
-    caller can fall back to the fast check. Returns
-    (nonmanifold_edges, open_edges, untriangulated_faces,
-    refined_untriangulated_faces, nonmanifold_vertices, vertex_deflection_defects,
-    ok); ok=False if the mesh could not be built or was over budget (caller then
-    falls back to the fast check). open_edges>0 means the tessellated boundary is
-    not closed (edges incident to a single triangle); untriangulated_faces>0 means
-    a face failed to mesh at the base deflection, leaving the boundary incomplete.
-    refined_untriangulated_faces>0 means the base mesh succeeded but a lightweight
-    finer pass (base/4) exposed faces that downstream consumers using tighter
-    tolerances may reject.
+    caller can fall back to the fast check. Returns ``MeshGateResult``; ``ok=False``
+    if the mesh could not be built or was over budget (caller then falls back to the
+    fast check). ``refined_verified=False`` means the base mesh findings may be
+    usable but the finer face-tessellation probe did not complete. ``open_edges>0``
+    means the tessellated boundary is not closed (edges incident to a single
+    triangle); ``untriangulated_faces>0`` means a face failed to mesh at the base
+    deflection, leaving the boundary incomplete. ``refined_untriangulated_faces>0``
+    means the base mesh succeeded but a lightweight finer pass (base/4) exposed
+    faces that downstream consumers using tighter tolerances may reject.
 
     ``vertex_deflection_defects`` guards the BREP-vertex merge below: a node
     claiming to sit at a given BREP vertex (an edge polygon's own first/last
@@ -633,7 +701,7 @@ def _mesh_defects_exact(
         bb = shape.bounding_box()
         diag = math.dist((bb.min.X, bb.min.Y, bb.min.Z), (bb.max.X, bb.max.Y, bb.max.Z))
         if diag <= 0:
-            return 0, 0, 0, 0, 0, 0, False
+            return MeshGateResult.unchecked()
         # Deflection relative to part scale, clamped — matches the scorer.
         deflection = min(0.5, max(0.005, diag * 1e-3))
         _open_deadline = (
@@ -885,9 +953,8 @@ def _mesh_defects_exact(
             This intentionally does not stitch or allocate the full triangle soup; it
             only asks OCC to refine and then verifies every face owns a triangulation.
             Return ``(count, verified)``. If the refined pass cannot be checked within
-            the budget and did not find a definite missing face, ``verified`` is False
-            so the caller can degrade to an "unverified" mesh verdict instead of a
-            false PASS.
+            the budget, ``verified`` is False so the caller can report any definite
+            missing faces found so far without implying the count is complete.
             """
             if time.monotonic() > _open_deadline:
                 return 0, False
@@ -901,7 +968,7 @@ def _mesh_defects_exact(
             n_tris = 0
             for fi in range(1, fmap.Size() + 1):
                 if time.monotonic() > _open_deadline:
-                    return (missing, True) if missing else (0, False)
+                    return missing, False
                 face = TopoDS.Face_s(fmap.FindKey(fi))
                 loc = TopLoc_Location()
                 tri = BRep_Tool.Triangulation_s(face, loc)
@@ -910,7 +977,7 @@ def _mesh_defects_exact(
                     continue
                 n_tris += tri.NbTriangles()
             if n_tris > _REFINED_UNTRIANGULATED_MAX_TRIS and _open_deadline != float("inf"):
-                return (missing, True) if missing else (0, False)
+                return missing, False
             return missing, True
 
         def _finish(
@@ -919,20 +986,26 @@ def _mesh_defects_exact(
             base_untriangulated: int,
             nmv: int,
             vdefl: int,
-        ) -> tuple[int, int, int, int, int, int, bool]:
+        ) -> MeshGateResult:
             refined_untriangulated, refined_ok = _refined_untriangulated_faces()
             if not refined_ok and not (
-                nm_edges or open_edges or base_untriangulated or nmv or vdefl
+                nm_edges
+                or open_edges
+                or base_untriangulated
+                or refined_untriangulated
+                or nmv
+                or vdefl
             ):
-                return 0, 0, 0, 0, 0, 0, False
-            return (
-                nm_edges,
-                open_edges,
-                base_untriangulated,
-                refined_untriangulated,
-                nmv,
-                vdefl,
-                True,
+                return MeshGateResult.unchecked()
+            return MeshGateResult(
+                nonmanifold_edges=nm_edges,
+                open_edges=open_edges,
+                untriangulated_faces=base_untriangulated,
+                refined_untriangulated_faces=refined_untriangulated,
+                nonmanifold_vertices=nmv,
+                vertex_deflection_defects=vdefl,
+                ok=True,
+                refined_verified=refined_ok,
             )
 
         # Build the base-deflection mesh for the non-manifold / untriangulated
@@ -944,7 +1017,7 @@ def _mesh_defects_exact(
         faces = TopTools_IndexedMapOfShape()
         TopExp.MapShapes_s(occ, TopAbs_FACE, faces)
         if faces.Size() == 0:
-            return 0, 0, 0, 0, 0, 0, False
+            return MeshGateResult.unchecked()
 
         # 1. Lay every face's triangulation into one global node/triangle list,
         #    flipping winding for REVERSED faces so orientation is consistent.
@@ -980,14 +1053,18 @@ def _mesh_defects_exact(
         if not triangles:
             # Nothing meshed: a defect if some faces failed, else un-analysable.
             return (
-                (0, 0, untriangulated, 0, 0, 0, True)
+                MeshGateResult(
+                    untriangulated_faces=untriangulated,
+                    ok=True,
+                    refined_verified=False,
+                )
                 if untriangulated
-                else (0, 0, 0, 0, 0, 0, False)
+                else MeshGateResult.unchecked()
             )
         if max_triangles is not None and len(triangles) > max_triangles:
             # Over the perf budget; bail before the slow stitch so the caller
             # falls back to the fast check rather than hanging.
-            return 0, 0, 0, 0, 0, 0, False
+            return MeshGateResult.unchecked()
 
         parent = list(range(len(vertices)))
 
@@ -1041,7 +1118,7 @@ def _mesh_defects_exact(
                 # part — few edges but expensive OCC calls each); defer to the fast
                 # check rather than approach the worker op-timeout. Bounds total
                 # gate wall-clock to ~the budget.
-                return 0, 0, 0, 0, 0, 0, False
+                return MeshGateResult.unchecked()
             edge = TopoDS.Edge_s(emap.FindKey(ei))
             node_lists = []
             for fi in edge_adj.get(ei, ()):
@@ -1114,7 +1191,7 @@ def _mesh_defects_exact(
             return (
                 _finish(0, 0, untriangulated, nmv, _vd)
                 if (untriangulated or nmv or _vd)
-                else (0, 0, 0, 0, 0, 0, False)
+                else MeshGateResult.unchecked()
             )
 
         # 4. Cancel opposite-winding flap pairs (a degenerate fold meshes to a
@@ -1158,7 +1235,7 @@ def _mesh_defects_exact(
             return (
                 _finish(0, 0, untriangulated, nmv, _vd)
                 if (untriangulated or nmv or _vd)
-                else (0, 0, 0, 0, 0, 0, False)
+                else MeshGateResult.unchecked()
             )
 
         # 5. Non-manifold count from the index-stitched mesh: undirected edges
@@ -1178,9 +1255,9 @@ def _mesh_defects_exact(
         # open-edge ladder
         if nm_edges or untriangulated or nmv or _vd:
             return _finish(nm_edges, 0, untriangulated, nmv, _vd)
-        return 0, 0, 0, 0, 0, 0, False
+        return MeshGateResult.unchecked()
     except Exception:
-        return 0, 0, 0, 0, 0, 0, False
+        return MeshGateResult.unchecked()
 
 
 def _resolve_shape(session, object_name: str):
@@ -1244,17 +1321,16 @@ def _validate_gate(session, shape) -> dict:
     return _gate_report(
         shape,
         exact=True,
-        mesh_override=mesh if mesh is not None else (0, 0, 0, 0, 0, 0, False),
+        mesh_override=mesh if mesh is not None else MeshGateResult.unchecked(),
     )
 
 
-def _mesh_gate_out_of_process(session, shape):
+def _mesh_gate_out_of_process(session, shape) -> MeshGateResult | None:
     """Serialise the shape to a temp STEP and run the exact mesh gate in the same
-    hard-bounded subprocess ``export()`` uses. Returns the mesh tuple
-    ``(nm, open, untri, refined_untri, nmv, vdefl, ok)``, or ``None`` (→
-    ``"skipped"``) if it timed out, the host blocks child processes, or the shape
-    couldn't be serialised — in every case the caller keeps the in-worker B-rep
-    verdict rather than inventing a mesh result."""
+    hard-bounded subprocess ``export()`` uses. Returns ``MeshGateResult`` or
+    ``None`` (→ ``"skipped"``) if it timed out, the host blocks child processes, or
+    the shape couldn't be serialised — in every case the caller keeps the in-worker
+    B-rep verdict rather than inventing a mesh result."""
     import os
     import tempfile
 

--- a/src/build123d_mcp/tools/validate.py
+++ b/src/build123d_mcp/tools/validate.py
@@ -106,47 +106,6 @@ class MeshGateResult:
         return cls(ok=False, refined_verified=False)
 
     @classmethod
-    def from_legacy(cls, value) -> "MeshGateResult":
-        if isinstance(value, cls):
-            return value
-        if len(value) == 6:
-            nm, open_edges, untri, nmv, vdefl, ok = value
-            return cls(
-                nonmanifold_edges=int(nm),
-                open_edges=int(open_edges),
-                untriangulated_faces=int(untri),
-                nonmanifold_vertices=int(nmv),
-                vertex_deflection_defects=int(vdefl),
-                ok=bool(ok),
-                refined_verified=False,
-            )
-        if len(value) == 7:
-            nm, open_edges, untri, refined_untri, nmv, vdefl, ok = value
-            return cls(
-                nonmanifold_edges=int(nm),
-                open_edges=int(open_edges),
-                untriangulated_faces=int(untri),
-                refined_untriangulated_faces=int(refined_untri),
-                nonmanifold_vertices=int(nmv),
-                vertex_deflection_defects=int(vdefl),
-                ok=bool(ok),
-                refined_verified=True,
-            )
-        if len(value) == 8:
-            nm, open_edges, untri, refined_untri, nmv, vdefl, ok, refined_verified = value
-            return cls(
-                nonmanifold_edges=int(nm),
-                open_edges=int(open_edges),
-                untriangulated_faces=int(untri),
-                refined_untriangulated_faces=int(refined_untri),
-                nonmanifold_vertices=int(nmv),
-                vertex_deflection_defects=int(vdefl),
-                ok=bool(ok),
-                refined_verified=bool(refined_verified),
-            )
-        raise ValueError("mesh gate result must have 6, 7, or 8 fields")
-
-    @classmethod
     def from_json(cls, data: dict) -> "MeshGateResult":
         return cls(
             nonmanifold_edges=int(data["nm"]),
@@ -295,9 +254,7 @@ def _run_mesh_gate_subprocess(step_path: str, timeout: float) -> MeshGateResult 
     return None
 
 
-def _gate_report(
-    shape, exact: bool = False, mesh_override: MeshGateResult | tuple | None = None
-) -> dict:
+def _gate_report(shape, exact: bool = False, mesh_override: MeshGateResult | None = None) -> dict:
     """Return the validity-gate verdict for a shape as a plain dict.
 
     Reused by the export tool so a 3D export can warn when the written solid
@@ -354,7 +311,7 @@ def _gate_report(
         # Mesh results computed out-of-process (export's subprocess retry for a
         # part too large to mesh within the in-process budget). Bounded by a hard
         # subprocess timeout there, so it can run the full check without skipping.
-        mesh = MeshGateResult.from_legacy(mesh_override)
+        mesh = mesh_override
         # ok=False means the out-of-process check timed out / couldn't determine —
         # mark it "skipped" so the "mesh validity not verified" warning fires and the
         # caller doesn't report false confidence on an unchecked part.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -143,7 +143,7 @@ def test_mesh_exact_passes_disjoint_touching_bodies():
 
     two = Compound([Box(10, 10, 10), Pos(0, 0, 10) * Box(10, 10, 10)])
     assert _mesh_defects(two)[0] > 0  # fast weld over-flags two touching bodies
-    assert _mesh_defects_exact(two)[0] == 0  # exact (topology) is correct
+    assert _mesh_defects_exact(two).nonmanifold_edges == 0  # exact topology is correct
 
 
 def test_validate_small_part_uses_exact_check(session):
@@ -381,8 +381,11 @@ def test_mesh_defects_exact_no_false_nm_vertex_on_clean_solids():
     # The vertex check runs on a coordinate-welded mesh, so poles/seams of a
     # sphere must not register as pinches (#298 regression guard).
     for shape in (Box(10, 10, 10), Sphere(8)):
-        nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(shape)
-        assert ok and refined_untri == 0 and nmv == 0 and vdefl == 0
+        result = _mesh_defects_exact(shape)
+        assert result.ok
+        assert result.refined_untriangulated_faces == 0
+        assert result.nonmanifold_vertices == 0
+        assert result.vertex_deflection_defects == 0
 
 
 def test_mesh_defects_exact_detects_refined_untriangulated_face(monkeypatch):
@@ -414,10 +417,15 @@ def test_mesh_defects_exact_detects_refined_untriangulated_face(monkeypatch):
     monkeypatch.setattr(brep_mesh, "BRepMesh_IncrementalMesh", _tracking_mesh)
     monkeypatch.setattr(BRep_Tool, "Triangulation_s", staticmethod(_refined_only_missing_tri))
 
-    nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(box)
-    assert ok
-    assert (nm_e, open_e, untri, nmv, vdefl) == (0, 0, 0, 0, 0)
-    assert refined_untri == 1
+    result = _mesh_defects_exact(box)
+    assert result.ok
+    assert result.refined_verified is True
+    assert result.nonmanifold_edges == 0
+    assert result.open_edges == 0
+    assert result.untriangulated_faces == 0
+    assert result.nonmanifold_vertices == 0
+    assert result.vertex_deflection_defects == 0
+    assert result.refined_untriangulated_faces == 1
 
 
 def test_gate_report_fails_on_refined_untriangulated_face(monkeypatch):
@@ -449,7 +457,30 @@ def test_gate_report_fails_on_refined_untriangulated_face(monkeypatch):
     assert report["passes_gate"] is False
     assert report["untriangulated_faces"] == 0
     assert report["refined_untriangulated_faces"] == 1
+    assert report["refined_untriangulated_faces_verified"] is True
     assert any("finer mesh deflection" in r for r in report["reasons"])
+
+
+def test_refined_probe_budget_gap_is_reported_explicitly(monkeypatch):
+    """A known defect plus an over-budget refined probe must not read as refined-clean."""
+    from build123d import Box, Shell
+
+    import build123d_mcp.tools.validate as v
+
+    monkeypatch.setattr(v, "_REFINED_UNTRIANGULATED_MAX_TRIS", 1)
+    shell = Shell(Box(10, 10, 10).faces()[:5])
+
+    result = v._mesh_defects_exact(shell)
+    assert result.ok
+    assert result.open_edges > 0
+    assert result.refined_untriangulated_faces == 0
+    assert result.refined_verified is False
+
+    report = v._gate_report(shell, exact=True, mesh_override=result)
+    assert report["passes_gate"] is False
+    assert report["refined_untriangulated_faces"] == 0
+    assert report["refined_untriangulated_faces_verified"] is False
+    assert any("refined face-tessellation not verified" in w for w in report["warnings"])
 
 
 def test_mesh_defects_exact_detects_vertex_deflection(monkeypatch):
@@ -485,10 +516,13 @@ def test_mesh_defects_exact_detects_vertex_deflection(monkeypatch):
         return p
 
     monkeypatch.setattr(BRep_Tool, "Pnt_s", staticmethod(_lying_pnt_s))
-    nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(box)
-    assert ok
-    assert vdefl == 1
-    assert nm_e == 0 and untri == 0 and refined_untri == 0 and nmv == 0
+    result = _mesh_defects_exact(box)
+    assert result.ok
+    assert result.vertex_deflection_defects == 1
+    assert result.nonmanifold_edges == 0
+    assert result.untriangulated_faces == 0
+    assert result.refined_untriangulated_faces == 0
+    assert result.nonmanifold_vertices == 0
 
 
 def test_mesh_defects_exact_open_ladder_catches_vertex_deflection_too(monkeypatch):
@@ -522,11 +556,11 @@ def test_mesh_defects_exact_open_ladder_catches_vertex_deflection_too(monkeypatc
         return p
 
     monkeypatch.setattr(BRep_Tool, "Pnt_s", staticmethod(_lying_pnt_s))
-    nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(shell)
-    assert ok
-    assert open_e == 4  # the missing face's 4 rim edges — unaffected by the guard
-    assert refined_untri == 0
-    assert vdefl == 1  # only reachable via the ladder's own guard at this magnitude
+    result = _mesh_defects_exact(shell)
+    assert result.ok
+    assert result.open_edges == 4  # the missing face's 4 rim edges — unaffected by the guard
+    assert result.refined_untriangulated_faces == 0
+    assert result.vertex_deflection_defects == 1  # only reachable via the ladder guard
 
 
 def test_mesh_defects_exact_counts_multiple_ladder_only_vertices(monkeypatch):
@@ -558,11 +592,11 @@ def test_mesh_defects_exact_counts_multiple_ladder_only_vertices(monkeypatch):
         return p
 
     monkeypatch.setattr(BRep_Tool, "Pnt_s", staticmethod(_lying_pnt_s))
-    nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(shell)
-    assert ok
-    assert open_e == 4
-    assert refined_untri == 0
-    assert vdefl == 2  # both distinct vertices counted, not capped at 1
+    result = _mesh_defects_exact(shell)
+    assert result.ok
+    assert result.open_edges == 4
+    assert result.refined_untriangulated_faces == 0
+    assert result.vertex_deflection_defects == 2  # both distinct vertices counted
 
 
 def test_mesh_defects_exact_no_double_count_when_base_and_ladder_agree(monkeypatch):
@@ -586,11 +620,11 @@ def test_mesh_defects_exact_no_double_count_when_base_and_ladder_agree(monkeypat
         return p
 
     monkeypatch.setattr(BRep_Tool, "Pnt_s", staticmethod(_lying_pnt_s))
-    nm_e, open_e, untri, refined_untri, nmv, vdefl, ok = _mesh_defects_exact(shell)
-    assert ok
-    assert open_e == 4
-    assert refined_untri == 0
-    assert vdefl == 1  # same vertex found twice (base + ladder), deduped to 1
+    result = _mesh_defects_exact(shell)
+    assert result.ok
+    assert result.open_edges == 4
+    assert result.refined_untriangulated_faces == 0
+    assert result.vertex_deflection_defects == 1  # same vertex found twice, deduped
 
 
 # --- out-of-process mesh gate (export retry for parts too large to mesh in-budget) ---
@@ -605,7 +639,16 @@ def test_mesh_gate_subprocess_valid_step(tmp_path):
     export_step(Box(10, 10, 10), str(p))
     # A clean solid: 0 nm-edge, 0 open, 0 base/refined untriangulated, 0
     # nm-vertex, 0 vertex-deflection defects, ok=True.
-    assert _run_mesh_gate_subprocess(str(p), timeout=120) == (0, 0, 0, 0, 0, 0, True)
+    result = _run_mesh_gate_subprocess(str(p), timeout=120)
+    assert result is not None
+    assert result.ok
+    assert result.refined_verified
+    assert result.nonmanifold_edges == 0
+    assert result.open_edges == 0
+    assert result.untriangulated_faces == 0
+    assert result.refined_untriangulated_faces == 0
+    assert result.nonmanifold_vertices == 0
+    assert result.vertex_deflection_defects == 0
 
 
 def test_mesh_gate_subprocess_timeout_returns_none(tmp_path):

--- a/tests/test_validate_open_edge_381.py
+++ b/tests/test_validate_open_edge_381.py
@@ -78,7 +78,7 @@ def test_large_shape_runs_mesh_check_out_of_process(monkeypatch):
 
     def _fake_subproc(step_path, timeout):
         calls["n"] += 1
-        return (0, 0, 0, 0, 0, 0, True)  # clean mesh, determined
+        return v.MeshGateResult(ok=True, refined_verified=True)  # clean mesh, determined
 
     monkeypatch.setattr(v, "_run_mesh_gate_subprocess", _fake_subproc)
     out = validate(_StubSession(current=Box(10, 10, 10)))


### PR DESCRIPTION
## Summary

- Replace the growing positional mesh-defect tuple with a structured `MeshGateResult`.
- Surface `refined_untriangulated_faces_verified` so an over-budget refined probe is not reported as a verified zero.
- Thread the structured result through the gate subprocess, export warning path, validation report, and tests.
- Add the missing changelog note for the `compare()` tool consolidation and the new mesh gate reporting behavior.

## Why

The exact mesh gate had accumulated seven positional return fields and multiple positional unpacking call sites. That made each new defect class a shotgun edit and hid a subtle reporting gap: if the refined face-tessellation probe ran out of budget after another definite defect was found, the report could still show `refined_untriangulated_faces: 0` with no indication that the refined probe was incomplete.

## Validation

- `uv run ruff check src/build123d_mcp/tools/validate.py src/build123d_mcp/_gate_subprocess.py src/build123d_mcp/tools/export.py tests/test_validate.py tests/test_validate_open_edge_381.py`
- `uv run mypy`
- `uv run pytest tests/test_validate.py tests/test_validate_open_edge_381.py`
- `uv run pytest tests/test_validate.py tests/test_validate_open_edge_381.py tests/test_worker_session_tools.py tests/test_tool_annotations.py tests/test_tool_groups.py tests/test_sync_server_json.py tests/test_namespace_primitives.py`
- `uv run pytest` passed once before the final refined-verification semantic tightening; after that final tweak, the focused validation suite and mypy were rerun and passed.

Follow-up guidance consolidation is tracked in #413.
