### PR TITLE
[codex] Add dominant-form modeling guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **MCP comparison calls are now one `compare()` tool.** External prompt authors should replace standalone MCP tool calls to `clearance`, `align_check`, `shape_compare`, and `diff_snapshot` with `compare(kind="fit")`, `compare(kind="align")`, `compare(kind="shape")`, and `compare(kind="snapshot")` respectively. The same computations remain available as composable Python helpers inside `execute()` code, so `clearance(a, b)` and `align_check(a, b)` still work there; the consolidation only changes the advertised standalone MCP surface.
+- **`b123d-modeling` skill: add a dominant-form correction loop for generation fidelity.** The modeling workflow now tells agents to treat the first valid render as a diagnostic checkpoint: classify the dominant body family, name the largest semantic mismatch, and rebuild from the named dimension table when the model is a valid-but-wrong body class rather than patching it with cosmetic cuts. The guidance stays generic CAD workflow advice, with decision rules for axisymmetric shells, repeated radial features, blind pockets versus through voids, sheet-metal bodies, and preserving scored interfaces after fillets/chamfers.
 
 ### Fixed
 

--- a/src/build123d_mcp/server.py
+++ b/src/build123d_mcp/server.py
@@ -969,7 +969,7 @@ def build123d_drawing_skill() -> str:
 @mcp.resource(
     "build123d://skill/modeling",
     mime_type="text/plain",
-    description="The b123d-modeling workflow skill: step-by-step guide for building 3D parts and assemblies with build123d via this server — including extracting a spec from a technical drawing, the incremental build/measure/render loop, snapshots, and export.",
+    description="The b123d-modeling workflow skill: step-by-step guide for building 3D parts and assemblies with build123d via this server — including extracting a spec from a technical drawing, the incremental build/measure/render loop, dominant-form correction after the first render, snapshots, and export.",
 )
 def build123d_modeling_skill() -> str:
     """b123d-modeling workflow skill."""

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -108,6 +108,25 @@ large shapes. The standalone MCP tools remain for one-shot queries.
 - Render only after `measure()` agrees with the spec:
   `render_view(save_to="/tmp/part.png")`, then show /tmp/part.png to the user.
   Use `clip_plane`/`clip_at` to reveal internal features.
+- Assemblies: use the MCP `compare(a="a", b="b", kind="fit")` tool for fit
+  (apart / touching / containing / interpenetrating, with volumes), and
+  `compare(a="a", b="b", kind="align", axis="Z", mode="flush")` for
+  flush/concentric checks. Inside `execute()`, the lower-level Python helpers
+  `clearance(a, b)` and `align_check(a, b)` remain available for branching in
+  code. Connect parts with Joints (RigidJoint / RevoluteJoint / …) rather than
+  raw `.move()` — see `build123d://quickref`.
+- Editing an imported reference: after changing a part loaded with
+  `import_cad_file()`, `compare(a="input", b="edited", kind="shape")` localizes *where* the
+  geometry changed and reports the exact added/removed volume and surface
+  displacement — confirm the changed region and magnitude match the request, and
+  that the rest stayed put. A tangential move (sliding a hole) shows no region;
+  cross-check `find_holes` and the bbox/center deltas for those.
+- Use `find_holes`' bore axis for holes on curved or BSpline faces. Face centers
+  and bounding-box centers can be off-axis; an apparent "already at target"
+  result is a prompt to re-measure against the axis.
+- Avoid large point grids with `is_inside()` on big solids. They are slow and can
+  hit the operation timeout; prefer `cross_sections()` or a targeted clipped
+  render for interiors.
 
 ### Dominant-form correction after the first valid render
 
@@ -149,25 +168,6 @@ Field-proven decision rules:
 - **Interface preservation:** after adding fillets/chamfers, verify hole,
   bore, boss, and fit features again. Cosmetic rounding is not acceptable if it
   silently shortens a through-bore or changes a mating feature.
-- Assemblies: use the MCP `compare(a="a", b="b", kind="fit")` tool for fit
-  (apart / touching / containing / interpenetrating, with volumes), and
-  `compare(a="a", b="b", kind="align", axis="Z", mode="flush")` for
-  flush/concentric checks. Inside `execute()`, the lower-level Python helpers
-  `clearance(a, b)` and `align_check(a, b)` remain available for branching in
-  code. Connect parts with Joints (RigidJoint / RevoluteJoint / …) rather than
-  raw `.move()` — see `build123d://quickref`.
-- Editing an imported reference: after changing a part loaded with
-  `import_cad_file()`, `compare(a="input", b="edited", kind="shape")` localizes *where* the
-  geometry changed and reports the exact added/removed volume and surface
-  displacement — confirm the changed region and magnitude match the request, and
-  that the rest stayed put. A tangential move (sliding a hole) shows no region;
-  cross-check `find_holes` and the bbox/center deltas for those.
-- Use `find_holes`' bore axis for holes on curved or BSpline faces. Face centers
-  and bounding-box centers can be off-axis; an apparent "already at target"
-  result is a prompt to re-measure against the axis.
-- Avoid large point grids with `is_inside()` on big solids. They are slow and can
-  hit the operation timeout; prefer `cross_sections()` or a targeted clipped
-  render for interiors.
 
 ## Step 4 — Experiments and recovery
 

--- a/src/build123d_mcp/skills/b123d-modeling/SKILL.md
+++ b/src/build123d_mcp/skills/b123d-modeling/SKILL.md
@@ -108,6 +108,47 @@ large shapes. The standalone MCP tools remain for one-shot queries.
 - Render only after `measure()` agrees with the spec:
   `render_view(save_to="/tmp/part.png")`, then show /tmp/part.png to the user.
   Use `clip_plane`/`clip_at` to reveal internal features.
+
+### Dominant-form correction after the first valid render
+
+A valid, watertight model can still be the wrong *kind* of body. Before final
+export on a model built from a drawing, use the first valid render as a
+diagnostic checkpoint:
+
+1. Render the primary orthographic/isometric views.
+2. Classify the dominant body family, not just the holes and bosses:
+   axisymmetric shell / lathe profile, curved impeller or spoked radial
+   pattern, bent sheet-metal body, cast web with blind pockets, thin-walled
+   cover/housing, drafted casting.
+3. Name the single largest semantic mismatch: block/slab where the drawing
+   shows a casting or shell; through-open gaps where section hatching shows
+   blind pockets and a central web; merged repeated vanes/lobes/spokes; wrong
+   axis/profile interpretation in a revolved part; holes placed on the wrong
+   body surface.
+4. If the mismatch is body-class level, rebuild from the named dimension
+   table. Do not keep patching the wrong representation with cosmetic cuts,
+   fillets, or shallow relief.
+5. After any cosmetic radius pass, re-run `find_holes` / `find_bosses` /
+   relevant recognizers. Reject a fillet/chamfer that changes a through-bore
+   diameter/depth, feature count, or scored interface.
+
+Field-proven decision rules:
+
+- **Axisymmetric shell:** if a revolve is valid but the bbox or section profile
+  is wrong, switch to coaxial cylinders/cones/frustums from the dimension table
+  instead of continuing with the wrong revolve-axis convention.
+- **Repeated radial features:** verify instance count after booleans using a
+  face inventory, recognizer, or render. If vanes/spokes/lobes merge, rebuild
+  with explicit numeric rotations of the analytic feature geometry.
+- **Blind pocket vs through void:** if section views show material remaining,
+  build the full web/body first and subtract shallow pockets from one or both
+  sides. Do not model through truss-like gaps where the section shows solid web.
+- **Sheet metal:** classify constant-thickness folded bodies early. Prefer
+  panels/flanges/bends over solid blocks; boss recognizers should be empty
+  unless the drawing actually has raised bosses.
+- **Interface preservation:** after adding fillets/chamfers, verify hole,
+  bore, boss, and fit features again. Cosmetic rounding is not acceptable if it
+  silently shortens a through-bore or changes a mating feature.
 - Assemblies: use the MCP `compare(a="a", b="b", kind="fit")` tool for fit
   (apart / touching / containing / interpenetrating, with volumes), and
   `compare(a="a", b="b", kind="align", axis="Z", mode="flush")` for

--- a/src/build123d_mcp/tools/install_skill.py
+++ b/src/build123d_mcp/tools/install_skill.py
@@ -33,7 +33,8 @@ SKILLS = {
         "dir": "b123d-modeling",
         "cursor_description": (
             "3D CAD modeling workflow: build parts and assemblies with build123d "
-            "via the build123d-mcp MCP server"
+            "via the build123d-mcp MCP server, including dominant-form correction "
+            "after the first valid render"
         ),
         # No path affinity — the rule is routed by description (agent-requested).
         "cursor_globs": "",

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -39,6 +39,27 @@ def test_load_raw_modeling_returns_skill_content():
     assert len(content) > 1000
 
 
+def test_modeling_skill_contains_dominant_form_correction_loop():
+    content = _load_raw("modeling")
+    start = content.index("### Dominant-form correction")
+    end = content.index("- Assemblies:", start)
+    section = content[start:end]
+
+    assert "first valid render" in section
+    assert "diagnostic checkpoint" in section
+    assert "dominant body family" in section
+    assert "body-class level" in section
+    for phrase in (
+        "Axisymmetric shell",
+        "Repeated radial features",
+        "Blind pocket vs through void",
+        "Sheet metal",
+        "Interface preservation",
+    ):
+        assert phrase in section
+    assert "fixture" not in section.lower()
+
+
 def test_load_raw_edit_returns_skill_content():
     content = _load_raw("edit")
     assert "Edit Existing build123d Geometry" in content

--- a/tests/test_install_skill.py
+++ b/tests/test_install_skill.py
@@ -42,7 +42,7 @@ def test_load_raw_modeling_returns_skill_content():
 def test_modeling_skill_contains_dominant_form_correction_loop():
     content = _load_raw("modeling")
     start = content.index("### Dominant-form correction")
-    end = content.index("- Assemblies:", start)
+    end = content.index("## Step 4", start)
     section = content[start:end]
 
     assert "first valid render" in section


### PR DESCRIPTION
## Summary

- Add a dominant-form correction loop to `build123d://skill/modeling`.
- Tell agents to use the first valid render as a diagnostic checkpoint, classify the dominant body family, and rebuild from named dimensions when the model is valid but the wrong body class.
- Add generic decision rules for axisymmetric shells, repeated radial features, blind pockets vs through voids, sheet-metal bodies, and interface preservation after cosmetic radii.
- Update resource/install descriptions so the new guidance is discoverable, and add a regression test that pins the section without fixture-specific wording.

## Why

Issue #412 came from the v0376 generation analysis: high-scoring runs did not just use more tools. They recognized when a valid model was semantically the wrong representation and rebuilt the dominant form before final export. Low-scoring runs often stopped at a valid envelope with correct holes/features but an obviously simplified or blocky body class.

This keeps the lesson in the reusable MCP modeling skill rather than encoding benchmark-specific prompt tricks.

Closes #412.

## Validation

- `uv run ruff check src/build123d_mcp/server.py src/build123d_mcp/tools/install_skill.py tests/test_install_skill.py`
- `uv run pytest tests/test_install_skill.py tests/test_repair_advice.py tests/test_tool_groups.py tests/test_sync_server_json.py tests/test_server_json_version.py` (`49 passed`)
- `uv run mypy`
- `git diff --check`
